### PR TITLE
use reentry to workaround pkg_resources slowness

### DIFF
--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -74,7 +74,7 @@ import uuid
 import click
 import yaml
 from click_plugins import with_plugins
-from reentry.manager import iter_entry_points
+import reentry.manager
 
 from ._config import RENKU_HOME, default_config_dir, print_app_config_path
 from ._version import print_version
@@ -88,7 +88,7 @@ def _uuid_representer(dumper, data):
 yaml.add_representer(uuid.UUID, _uuid_representer)
 
 
-@with_plugins(iter_entry_points('renku.cli'))
+@with_plugins(reentry.manager.iter_entry_points('renku.cli'))
 @click.group(
     context_settings={
         'auto_envvar_prefix': 'RENKU',

--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -74,7 +74,7 @@ import uuid
 import click
 import yaml
 from click_plugins import with_plugins
-from pkg_resources import iter_entry_points
+from reentry.manager import iter_entry_points
 
 from ._config import RENKU_HOME, default_config_dir, print_app_config_path
 from ._version import print_version

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ for name, reqs in extras_require.items():
 setup_requires = [
     'Babel>=1.3',
     'pytest-runner>=2.6.2',
+    'reentry>=1.2.0',
 ]
 
 install_requires = [
@@ -80,6 +81,7 @@ install_requires = [
     'networkx>=2.1',
     'pyld>=0.8.2',
     'python-dateutil>=2.6.1',
+    'reentry>=1.2.0',
     'requests-oauthlib>=0.8.0',
     'requests>=2.18.4',
     'tabulate>=0.7.7',
@@ -108,6 +110,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
+    reentry_register=True,
     entry_points={
         'console_scripts': ['renku=renku.cli:cli'],
         'renku.cli': [


### PR DESCRIPTION
Use https://github.com/DropD/reentry to speed up the cli.

I noticed this short lag during a renku demo and thought that looks familiar. We also use click and click-plugins in some projects so decided to have a look.

### before
```
(renku-orig) [22:30:31] crius:~% timeit renku               
Usage: renku [OPTIONS] COMMAND [ARGS]...

  Check common Renku commands used in various situations.

Options:
  --version            Print version number.
  --config PATH        Location of client config files.
  --config-path        Print application config path.
  --path <path>        Location of a Renku repository.  [default: .]
  --renku-home <path>  Location of Renku directory.  [default: .renku]
  -h, --help           Show this message and exit.

Commands:
  dataset     Handle datasets.
  deactivate  Deactivate environment for tracking work on a...
  help        Show help message and exit.
  init        Initialize a project.
  log         Show logs for a file.
  run         Tracking work on a specific problem.
  runner      Simplify running of CI scripts.
  status      Show a status of the repository.
  update      Update existing files by rerunning their...
  workflow    Workflow operations.
  workon      Activate environment for tracking work on a...
0.81
(renku-orig) [22:30:34] crius:~% 
```

### after
```
(renku) [22:31:16] crius:~% timeit renku
Usage: renku [OPTIONS] COMMAND [ARGS]...

  Check common Renku commands used in various situations.

Options:
  --version            Print version number.
  --config PATH        Location of client config files.
  --config-path        Print application config path.
  --path <path>        Location of a Renku repository.  [default: .]
  --renku-home <path>  Location of Renku directory.  [default: .renku]
  -h, --help           Show this message and exit.

Commands:
  dataset     Handle datasets.
  deactivate  Deactivate environment for tracking work on a...
  help        Show help message and exit.
  init        Initialize a project.
  log         Show logs for a file.
  run         Tracking work on a specific problem.
  runner      Simplify running of CI scripts.
  status      Show a status of the repository.
  update      Update existing files by rerunning their...
  workflow    Workflow operations.
  workon      Activate environment for tracking work on a...
0.59
(renku) [22:31:17] crius:~% 
```

This is not a huge but still noticable speedup.
Then again maybe it's just premature optimization ;-)

Note that when installing using pip in editable mode ('pip install -e') instead of installing from a wheel you may also want to look at
https://github.com/pypa/setuptools/issues/510
and
https://pypi.org/project/fastentrypoints/