### PR TITLE
setup: add pydot dependency to fix gitlab runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ extras_require = {
         'Sphinx>=1.6.3',
         'renku-sphinx-theme>=0.1.0',
     ],
-    'runner': ['cwlref-runner>=1.0', ],
+    'runner': [
+        'cwlref-runner>=1.0',
+        'pydot>=1.2.4',
+    ],
     'notebook': [
         'jupyter>=1.0.0',
         'openid-connect>=0.3.0',


### PR DESCRIPTION
Currently the runner fails when trying to build the dot files for the graph due to a missing library (pydot). Couldn't test if this actually fixes it, but it's my best guess...