### PR TITLE
cli: preserve environment variables during update

### DIFF
--- a/renku/cli/update.py
+++ b/renku/cli/update.py
@@ -165,7 +165,12 @@ def update(ctx, client, revision, paths):
     argv = sys.argv
     sys.argv = ['cwltool']
 
-    factory = cwltool.factory.Factory(makeTool=makeTool)
+    # Keep all environment variables.
+    execkwargs = {
+        'preserve_entire_environment': True,
+    }
+
+    factory = cwltool.factory.Factory(makeTool=makeTool, **execkwargs)
     process = factory.make(os.path.relpath(output_file))
     outputs = process()
 

--- a/renku/version.py
+++ b/renku/version.py
@@ -23,4 +23,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '0.1.0.dev20180518'
+__version__ = '0.1.0.dev201806060'


### PR DESCRIPTION
Solves problem with `click` running on Python 3 discovered by @mitch-volpi 