### PR TITLE
gitlab-ci: use docker:stable for image build

### DIFF
--- a/renku/cli/.gitlab-ci.yml
+++ b/renku/cli/.gitlab-ci.yml
@@ -11,9 +11,8 @@ stages:
 
 image_build:
   stage: build
-  image: python:3.6
+  image: docker:stable
   before_script:
-    - curl -sSL https://get.docker.com/ | sh
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN http://$CI_REGISTRY
   script:
     - CI_COMMIT_SHA_7=$(echo $CI_COMMIT_SHA | cut -c1-7)


### PR DESCRIPTION
reduces the build time to just a few seconds on trivial image builds

closes https://github.com/SwissDataScienceCenter/renku/issues/326