### PR TITLE
cli: verify exit-code of run command

### DIFF
--- a/renku/errors.py
+++ b/renku/errors.py
@@ -181,5 +181,24 @@ class OutputsNotFound(RenkuException, click.ClickException):
         super(OutputsNotFound, self).__init__(msg)
 
 
+class InvalidSuccessCode(RenkuException, click.ClickException):
+    """Raise when the exit-code is not 0 or redefined."""
+
+    def __init__(self, returncode, success_codes=None):
+        """Build a custom message."""
+        if not success_codes:
+            msg = 'Command returned non-zero exit status {0}.'.format(
+                returncode
+            )
+        else:
+            msg = (
+                'Command returned {0} exit status, but it expects {1}'.format(
+                    returncode,
+                    ', '.join((str(code) for code in success_codes))
+                )
+            )
+        super(InvalidSuccessCode, self).__init__(msg)
+
+
 class NotFound(APIError):
     """Raise when an API object is not found."""

--- a/renku/models/cwl/command_line_tool.py
+++ b/renku/models/cwl/command_line_tool.py
@@ -171,6 +171,8 @@ class CommandLineToolFactory(object):
     inputs = attr.ib(init=False)
     outputs = attr.ib(init=False)
 
+    successCodes = attr.ib(default=attr.Factory(list))  # list(int)
+
     def __attrs_post_init__(self):
         """Derive basic informations."""
         self.baseCommand, detect = self.split_command_and_args()
@@ -215,6 +217,7 @@ class CommandLineToolFactory(object):
             arguments=self.arguments,
             inputs=self.inputs,
             outputs=self.outputs,
+            successCodes=self.successCodes,
         )
 
     @contextmanager

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,6 +152,23 @@ def test_run_simple(runner, project):
     assert '.renku/workflow/' in result.output
 
 
+_CMD_EXIT_2 = ['bash', '-c', 'exit 2']
+
+
+@pytest.mark.parametrize(
+    'cmd, exit_code', (
+        (_CMD_EXIT_2, 1),
+        (['--success-code', '1', '--no-output'] + _CMD_EXIT_2, 1),
+        (['--success-code', '2', '--no-output'] + _CMD_EXIT_2, 0),
+        (['--success-code', '0', '--no-output', 'echo', 'hola'], 0),
+    )
+)
+def test_exit_code(cmd, exit_code, runner, project):
+    """Test exit-code of run command."""
+    result = runner.invoke(cli.cli, ['run'] + cmd)
+    assert result.exit_code == exit_code
+
+
 def test_git_pre_commit_hook(runner, project, capsys):
     """Test detection of output edits."""
     result = runner.invoke(cli.cli, ['githooks', 'install'])


### PR DESCRIPTION
# Description

Adds `--success-code` option for `renku run` command.

(closes #288)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have read and understood the **CONTRIBUTING** document.
- [x] I have performed a self-review of my own code.
- [x] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [x] I have added tests to cover my changes.
- [x] I have **NOT** removed any existing tests.
- [x] I have updated the documentation accordingly.
- [ ] I have described *all* changes in the **CHANGELOG.rst**.
- [x] I have run ``./run-tests.sh`` locally.
