### PR TITLE
Improve import

### DIFF
--- a/renku/api/datasets.py
+++ b/renku/api/datasets.py
@@ -220,7 +220,7 @@ class DatasetsApiMixin(object):
                 else:
                     target = top_target
                 url = src_repo_path.as_posix()
-        elif u.scheme in ('http', 'https'):
+        elif u.scheme in {'http', 'https', 'git+https', 'git+ssh'}:
             submodule_name = os.path.splitext(os.path.basename(u.path))[0]
             submodule_path = submodule_path.joinpath(
                 os.path.dirname(u.path).lstrip('/'), submodule_name
@@ -233,6 +233,10 @@ class DatasetsApiMixin(object):
         # FIXME: do a proper check that the repos are not the same
         if submodule_name not in (s.name for s in self.git.submodules):
             # new submodule to add
+            if u.scheme == 'git+ssh':
+                url = 'git@{netloc}:{path}'.format(
+                    netloc=u.netloc, path=u.path[1:]
+                )
             self.git.create_submodule(
                 name=submodule_name, path=submodule_path.as_posix(), url=url
             )

--- a/renku/api/datasets.py
+++ b/renku/api/datasets.py
@@ -253,7 +253,7 @@ class DatasetsApiMixin(object):
                 target = src.relative_to(submodule_path / relative_to)
 
         # link the target into the data directory
-        dst = self.path / path / submodule_name / (target or '')
+        dst = self.path / path / (target or '')
 
         # if we have a directory, recurse
         if src.is_dir():

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -34,6 +34,48 @@ Adding data to the dataset:
 
 This will copy the contents of ``data-url`` to the dataset and add it
 to the dataset metadata.
+
+To add data from a git repository, you can specify it via https or git+ssh
+URL schemes. For example,
+
+.. code-block:: console
+
+    $ renku dataset add my-dataset git+ssh://host.io/namespace/project.git
+
+Sometimes you want to import just a specific path within the parent project.
+In this case, use the ``--target`` flag:
+
+.. code-block:: console
+
+    $ renku dataset add my-dataset --target relative-path/datafile \
+        git+ssh://host.io/namespace/project.git
+
+To trim part of the path from the parent directory, use the ``--relative-to``
+option. For example, the command above will result in a structure like
+
+.. code-block:: console
+
+    data/
+      my-dataset/
+        relative-path/
+          datafile
+
+Using instead
+
+.. code-block:: console
+
+    $ renku dataset add my-dataset \
+        --target relative-path/datafile \
+        --relative-to relative-path \
+        git+ssh://host.io/namespace/project.git
+
+will yield:
+
+.. code-block:: console
+
+    data/
+      my-dataset/
+        datafile
 """
 
 import click

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Work with datasets in the current repository.
+r"""Work with datasets in the current repository.
 
 Manipulating datasets
 ~~~~~~~~~~~~~~~~~~~~~

--- a/renku/models/datasets.py
+++ b/renku/models/datasets.py
@@ -162,7 +162,7 @@ def _parse_date(value):
 class Dataset(object):
     """Repesent a dataset."""
 
-    SUPPORTED_SCHEMES = ('', 'file', 'http', 'https')
+    SUPPORTED_SCHEMES = ('', 'file', 'http', 'https', 'git+https', 'git+ssh')
 
     name = jsonld.ib(type=str, context='dcterms:name')
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -472,12 +472,12 @@ def test_datasets(data_file, data_repository, runner, project):
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert os.stat('data/dataset/renku-python/README.rst')
+    assert os.stat('data/dataset/README.rst')
 
     # add data from local git repo
     result = runner.invoke(
         cli.cli, [
-            'dataset', 'add', 'dataset', '-t', 'file', '-t', 'file2',
+            'dataset', 'add', 'dataset', '-t', 'file2', '-t', 'file3',
             os.path.dirname(data_repository.git_dir)
         ]
     )
@@ -541,7 +541,6 @@ def test_relative_import_to_dataset(tmpdir, data_repository, runner, project):
 
 def test_relative_git_import_to_dataset(tmpdir, runner, project):
     """Test importing data from a directory structure."""
-    submodule_name = os.path.basename(str(tmpdir))
 
     # create a dataset
     result = runner.invoke(cli.cli, ['dataset', 'create', 'dataset'])
@@ -578,10 +577,8 @@ def test_relative_git_import_to_dataset(tmpdir, runner, project):
     )
     assert result.exit_code == 0
 
-    assert os.stat(os.path.join('data', 'dataset', submodule_name, 'data.txt'))
-    assert os.stat(
-        os.path.join('data', 'dataset', submodule_name, 'second', 'data.txt')
-    )
+    assert os.stat(os.path.join('data', 'dataset', 'data.txt'))
+    assert os.stat(os.path.join('data', 'dataset', 'second', 'data.txt'))
 
     # add data in subdirectory
     result = runner.invoke(
@@ -592,12 +589,8 @@ def test_relative_git_import_to_dataset(tmpdir, runner, project):
     )
     assert result.exit_code == 0
 
-    assert os.stat(
-        os.path.join('data', 'relative', submodule_name, 'data.txt')
-    )
-    assert os.stat(
-        os.path.join('data', 'relative', submodule_name, 'second', 'data.txt')
-    )
+    assert os.stat(os.path.join('data', 'relative', 'data.txt'))
+    assert os.stat(os.path.join('data', 'relative', 'second', 'data.txt'))
 
 
 def test_file_tracking(isolated_runner):
@@ -653,7 +646,7 @@ def test_status_with_submodules(isolated_runner):
         with contextlib.redirect_stdout(stdout):
             try:
                 cli.cli.main(
-                    args=('run', 'wc', 'data/b/foo/data/f/woop'),
+                    args=('run', 'wc', 'data/b/data/f/woop'),
                     prog_name=runner.get_default_prog_name(cli.cli),
                 )
             except SystemExit as e:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -129,19 +129,16 @@ def test_git_repo_import(client, dataset, tmpdir, data_repository):
         dataset,
         os.path.join(os.path.dirname(data_repository.git_dir), 'dir2')
     )
-    assert os.stat('data/dataset/directory_tree/dir2/file2')
-    assert 'directory_tree/dir2/file2' in dataset.files
+    assert os.stat('data/dataset/dir2/file2')
+    assert 'dir2/file2' in dataset.files
     assert os.stat('.renku/vendors/local')
 
     # check that the authors are properly parsed from commits
     client.add_data_to_dataset(
         dataset, os.path.dirname(data_repository.git_dir), target='file'
     )
-    assert len(dataset.files['directory_tree/file'].authors) == 2
-    assert all(
-        x.name in ('me', 'me2')
-        for x in dataset.files['directory_tree/file'].authors
-    )
+    assert len(dataset.files['file'].authors) == 2
+    assert all(x.name in ('me', 'me2') for x in dataset.files['file'].authors)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

This PR addresses two problems:

* using `--relative-to` was resulting in unexpected directory trees since it also injected the name of the parent project -- this is now removed
* it adds support for importing via `git+ssh` e.g. `renku dataset add mydata git+ssh://myhost.io/namespace/project.git`

addresses #214 

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

**Do not create pull request unless you checked all points.**

- [x] I have read and understood the **CONTRIBUTING** document.
- [x] I have performed a self-review of my own code.
- [x] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [x] I have added tests to cover my changes.
- [ ] I have **NOT** removed any existing tests.
- [x] I have updated the documentation accordingly.
- [ ] I have described *all* changes in the **CHANGELOG.rst**.
- [x] I have run ``./run-tests.sh`` locally.
