### PR TITLE
cwl: support pre-existing output directory

### DIFF
--- a/renku/models/cwl/process_requirements.py
+++ b/renku/models/cwl/process_requirements.py
@@ -76,6 +76,7 @@ class InitialWorkDirRequirement(ProcessRequirement, CWLClass):
                     input_ = inputs.get(input_id)
                     if input_ is not None:
                         directories.add(convert(input_.default))
+                        # TODO parametrize directory name directories.add(glob)
                 elif glob:
                     directories.add(convert(glob))
 

--- a/tests/test_cwl.py
+++ b/tests/test_cwl.py
@@ -282,7 +282,7 @@ def test_input_directory(instance_path):
 
 
 def test_exitings_output_directory(client):
-    """Test input directory."""
+    """Test creation of InitialWorkDirRequirement for output directory."""
     instance_path = client.path
     output = client.path / 'output'
 
@@ -314,3 +314,6 @@ def test_exitings_output_directory(client):
     ]
     assert 1 == len(initial_work_dir_requirement)
     assert initial_work_dir_requirement[0].listing[0].entryname == output.name
+
+    assert 1 == len(tool.inputs)
+    assert 1 == len(tool.outputs)


### PR DESCRIPTION
# Description

Makes sure that only the defined output directory is listed in tool outputs and not the files it contains.
The pre-existing output directory MUST be empty before running the command.

(closes #309)

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read and understood the **CONTRIBUTING** document.
- [x] I have performed a self-review of my own code.
- [x] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [x] I have added tests to cover my changes.
- [x] I have **NOT** removed any existing tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have described *all* changes in the **CHANGELOG.rst**.
- [x] I have run ``./run-tests.sh`` locally.
