### PR TITLE
Make dot output simpler by default

### DIFF
--- a/renku/cli/_format.py
+++ b/renku/cli/_format.py
@@ -17,6 +17,8 @@
 # limitations under the License.
 """Serializers for graph data."""
 
+import functools
+
 import click
 
 
@@ -62,12 +64,17 @@ def dot(graph, simple=False, landscape=True):
     g.bind('wfprov', 'http://purl.org/wf4ever/wfprov#')
 
     if simple:
-        rdf2dot_simple(g, sys.stdout, landscape)
+        _rdf2dot_simple(g, sys.stdout, landscape)
         return
     rdf2dot(g, sys.stdout)
 
 
-def rdf2dot_simple(g, stream, landscape=True):
+dot_landscape = functools.partial(dot, landscape=True)
+
+dot_portrait = functools.partial(dot, landscape=False)
+
+
+def _rdf2dot_simple(g, stream, landscape=True):
     """Create a simple graph of processes and artifacts."""
     from itertools import chain
 
@@ -145,8 +152,8 @@ def rdf2dot_simple(g, stream, landscape=True):
         node_path = path_re.match(node).groupdict()
         stream.write(
             '\t"{commit}:{path}" '
-            '[shape=box label=<{comment}<br/>'
-            '#{commit}<br/>{path}>] \n'.format(
+            '[shape=box label="{comment}<br/>'
+            '#{commit}<br/>{path}"] \n'.format(
                 comment=content['comment'],
                 commit=node_path['commit'][:5],
                 path=node_path.get('path') or ''
@@ -156,7 +163,7 @@ def rdf2dot_simple(g, stream, landscape=True):
         node_path = path_re.match(node).groupdict()
         stream.write(
             '\t"{commit}:{path}" '
-            '[label=<{path}<br/>#{commit}>] \n'.format(
+            '[label="{path}<br/>#{commit}"] \n'.format(
                 commit=node_path['commit'][:5],
                 path=node_path.get('path') or ''
             )
@@ -207,6 +214,8 @@ def rdf(graph, **kwargs):
 FORMATS = {
     'ascii': ascii,
     'dot': dot,
+    'dot-landscape': dot_landscape,
+    'dot-portrait': dot_portrait,
     'json-ld': jsonld,
     'json-ld-graph': jsonld_graph,
     'nt': nt,

--- a/renku/cli/_format.py
+++ b/renku/cli/_format.py
@@ -22,7 +22,7 @@ import functools
 import click
 
 
-def ascii(graph, **kwargs):
+def ascii(graph):
     """Format graph as an ASCII art."""
     from ._ascii import DAG
     from ._echo import echo_via_pager
@@ -43,7 +43,7 @@ def _jsonld(graph, format, *args, **kwargs):
     return json.dumps(output, indent=2)
 
 
-def dot(graph, simple=False, landscape=True):
+def dot(graph, simple=True, landscape=False):
     """Format graph as a dot file."""
     import sys
 
@@ -65,13 +65,14 @@ def dot(graph, simple=False, landscape=True):
 
     if simple:
         _rdf2dot_simple(g, sys.stdout, landscape)
-        return
-    rdf2dot(g, sys.stdout)
+    else:
+        rdf2dot(g, sys.stdout)
 
 
-dot_landscape = functools.partial(dot, landscape=True)
-
-dot_portrait = functools.partial(dot, landscape=False)
+# define the various dot options
+dot_full = functools.partial(dot, simple=False, landscape=False)
+dot_landscape = functools.partial(dot, simple=True, landscape=True)
+dot_full_landscape = functools.partial(dot, simple=False, landscape=True)
 
 
 def _rdf2dot_simple(g, stream, landscape=True):
@@ -170,17 +171,17 @@ def _rdf2dot_simple(g, stream, landscape=True):
     stream.write('}\n')
 
 
-def jsonld(graph, **kwargs):
+def jsonld(graph):
     """Format graph as JSON-LD file."""
     click.echo(_jsonld(graph, 'expand'))
 
 
-def jsonld_graph(graph, **kwargs):
+def jsonld_graph(graph):
     """Format graph as JSON-LD graph file."""
     click.echo(_jsonld(graph, 'flatten'))
 
 
-def nt(graph, **kwargs):
+def nt(graph):
     """Format graph as n-tuples."""
     from rdflib import ConjunctiveGraph
     from rdflib.plugin import register, Parser
@@ -195,7 +196,7 @@ def nt(graph, **kwargs):
     )
 
 
-def rdf(graph, **kwargs):
+def rdf(graph):
     """Output the graph as RDF."""
     from rdflib import ConjunctiveGraph
     from rdflib.plugin import register, Parser
@@ -213,8 +214,9 @@ def rdf(graph, **kwargs):
 FORMATS = {
     'ascii': ascii,
     'dot': dot,
+    'dot-full': dot_full,
     'dot-landscape': dot_landscape,
-    'dot-portrait': dot_portrait,
+    'dot-full-landscape': dot_full_landscape,
     'json-ld': jsonld,
     'json-ld-graph': jsonld_graph,
     'nt': nt,

--- a/renku/cli/_format.py
+++ b/renku/cli/_format.py
@@ -41,7 +41,7 @@ def _jsonld(graph, format, *args, **kwargs):
     return json.dumps(output, indent=2)
 
 
-def dot(graph, simple=False):
+def dot(graph, simple=False, landscape=True):
     """Format graph as a dot file."""
     import sys
 
@@ -62,17 +62,16 @@ def dot(graph, simple=False):
     g.bind('wfprov', 'http://purl.org/wf4ever/wfprov#')
 
     if simple:
-        rdf2dot_simple(g, sys.stdout)
+        rdf2dot_simple(g, sys.stdout, landscape)
         return
     rdf2dot(g, sys.stdout)
 
 
-def rdf2dot_simple(g, stream):
+def rdf2dot_simple(g, stream, landscape=True):
     """Create a simple graph of processes and artifacts."""
-    stream.write(
-        'digraph { \n node [ fontname="DejaVu Sans" ] ; \n '
-        'rankdir="LR" \n'
-    )
+    stream.write('digraph { \n node [ fontname="DejaVu Sans" ] ; \n ')
+    if landscape:
+        stream.write('rankdir="LR" \n')
 
     import re
 

--- a/renku/cli/_format.py
+++ b/renku/cli/_format.py
@@ -152,8 +152,7 @@ def _rdf2dot_simple(g, stream, landscape=True):
         node_path = path_re.match(node).groupdict()
         stream.write(
             '\t"{commit}:{path}" '
-            '[shape=box label="{comment}<br/>'
-            '#{commit}<br/>{path}"] \n'.format(
+            '[shape=box label="#{commit}:{path}:{comment}"] \n'.format(
                 comment=content['comment'],
                 commit=node_path['commit'][:5],
                 path=node_path.get('path') or ''
@@ -163,7 +162,7 @@ def _rdf2dot_simple(g, stream, landscape=True):
         node_path = path_re.match(node).groupdict()
         stream.write(
             '\t"{commit}:{path}" '
-            '[label="{path}<br/>#{commit}"] \n'.format(
+            '[label="#{commit}:{path}"] \n'.format(
                 commit=node_path['commit'][:5],
                 path=node_path.get('path') or ''
             )

--- a/renku/cli/log.py
+++ b/renku/cli/log.py
@@ -92,9 +92,15 @@ from ._graph import Graph
     default=False,
     help='Generate a simplified graph.'
 )
+@click.option(
+    '--landscape/--portrait',
+    is_flag=True,
+    default=True,
+    help='Generate a landscape-oriented graph'
+)
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @pass_local_client
-def log(client, revision, format, no_output, simple, paths):
+def log(client, revision, format, no_output, simple, landscape, paths):
     """Show logs for a file."""
     graph = Graph(client)
     if not paths:
@@ -107,4 +113,4 @@ def log(client, revision, format, no_output, simple, paths):
     # NOTE shall we warn when "not no_output and not paths"?
     graph.build(paths=paths, revision=revision, can_be_cwl=no_output)
 
-    FORMATS[format](graph, simple)
+    FORMATS[format](graph, simple=simple, landscape=landscape)

--- a/renku/cli/log.py
+++ b/renku/cli/log.py
@@ -92,15 +92,9 @@ from ._graph import Graph
     default=False,
     help='Generate a simplified graph.'
 )
-@click.option(
-    '--landscape/--portrait',
-    is_flag=True,
-    default=True,
-    help='Generate a landscape-oriented graph'
-)
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @pass_local_client
-def log(client, revision, format, no_output, simple, landscape, paths):
+def log(client, revision, format, no_output, simple, paths):
     """Show logs for a file."""
     graph = Graph(client)
     if not paths:
@@ -113,4 +107,4 @@ def log(client, revision, format, no_output, simple, landscape, paths):
     # NOTE shall we warn when "not no_output and not paths"?
     graph.build(paths=paths, revision=revision, can_be_cwl=no_output)
 
-    FORMATS[format](graph, simple=simple, landscape=landscape)
+    FORMATS[format](graph, simple=simple)

--- a/renku/cli/log.py
+++ b/renku/cli/log.py
@@ -86,9 +86,15 @@ from ._graph import Graph
     default=False,
     help='Display commands without output files.'
 )
+@click.option(
+    '--simple',
+    is_flag=True,
+    default=False,
+    help='Generate a simplified graph.'
+)
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @pass_local_client
-def log(client, revision, format, no_output, paths):
+def log(client, revision, format, no_output, simple, paths):
     """Show logs for a file."""
     graph = Graph(client)
     if not paths:
@@ -101,4 +107,4 @@ def log(client, revision, format, no_output, paths):
     # NOTE shall we warn when "not no_output and not paths"?
     graph.build(paths=paths, revision=revision, can_be_cwl=no_output)
 
-    FORMATS[format](graph)
+    FORMATS[format](graph, simple)

--- a/renku/cli/log.py
+++ b/renku/cli/log.py
@@ -86,15 +86,9 @@ from ._graph import Graph
     default=False,
     help='Display commands without output files.'
 )
-@click.option(
-    '--simple',
-    is_flag=True,
-    default=False,
-    help='Generate a simplified graph.'
-)
 @click.argument('paths', type=click.Path(exists=True), nargs=-1)
 @pass_local_client
-def log(client, revision, format, no_output, simple, paths):
+def log(client, revision, format, no_output, paths):
     """Show logs for a file."""
     graph = Graph(client)
     if not paths:
@@ -107,4 +101,4 @@ def log(client, revision, format, no_output, simple, paths):
     # NOTE shall we warn when "not no_output and not paths"?
     graph.build(paths=paths, revision=revision, can_be_cwl=no_output)
 
-    FORMATS[format](graph, simple=simple)
+    FORMATS[format](graph)


### PR DESCRIPTION
# Description

Provides an option for a simplified dot graph generation showing only inputs, outputs, and processes.

Fixes #339 

## Type of change

Please select relevant options.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run ``./run-tests.sh`` locally.

## Example output

![simple](https://user-images.githubusercontent.com/3353586/47825306-8065d380-dd71-11e8-8b2b-aabe687dcf07.png)

![simple](https://user-images.githubusercontent.com/3353586/47825335-9f646580-dd71-11e8-8cee-3a2268ef1733.png)


