### PR TITLE
docker: build from git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,9 +5,6 @@ __pycache__
 build
 dist
 
-.git
-*.gitignore
-
 *.mo
 *.pyc
 *.swp


### PR DESCRIPTION
Fixes Docker builds since Git repo is required to correctly detect the package version.