### PR TITLE
models: allow for '.' and '-' in repo path

### DIFF
--- a/renku/models/_git.py
+++ b/renku/models/_git.py
@@ -41,12 +41,12 @@ _RE_PORT = r':(?P<port>\d+)'
 
 _RE_PATHNAME = (
     r'/(?P<pathname>'
-    r'(((?P<owner>[\w-]+)/)?(?P<name>[\w\-]+)(\.git)?)?)'
+    r'(((?P<owner>[\w\-\.]+)/)?(?P<name>[\w\-\.]+)(\.git)?)?)'
 )
 
 _RE_PREFIXED_PATHNAME = (
-    r'/(?P<pathname>(([\w\-\~]+)/)+'
-    r'(?P<owner>[\w-]+)/(?P<name>[\w\-]+)(\.git)?)'
+    r'/(?P<pathname>(([\w\-\~\.]+)/)+'
+    r'(?P<owner>[\w\-\.]+)/(?P<name>[\w\-\.]+)(\.git)?)'
 )
 
 _RE_UNIXPATH = (
@@ -81,6 +81,13 @@ _REPOSITORY_URLS = (
 )
 
 
+def filter_repo_name(repo_name):
+    """Remove the .git extension from the repo name."""
+    if repo_name is not None and repo_name.endswith('.git'):
+        return repo_name[:-len('.git')]
+    return repo_name
+
+
 @attr.s()
 class GitURL(object):
     """Parser for common Git URLs."""
@@ -96,7 +103,7 @@ class GitURL(object):
     password = attr.ib(default=None)
     port = attr.ib(default=None)
     owner = attr.ib(default=None)
-    name = attr.ib(default=None)
+    name = attr.ib(default=None, converter=filter_repo_name)
     _regex = attr.ib(default=None, cmp=False)
 
     def __attrs_post_init__(self):

--- a/tests/models/test_git.py
+++ b/tests/models/test_git.py
@@ -74,6 +74,14 @@ from renku.models._git import GitURL
             'port': '1234',
         },
         {
+            'href': 'https://example.com/pre.fix/owner.name/repo.name.git',
+            'protocol': 'https',
+            'hostname': 'example.com',
+            'pathname': 'pre.fix/owner.name/repo.name.git',
+            'owner': 'owner.name',
+            'name': 'repo.name',
+        },
+        {
             'href': 'git+https://example.com:1234/owner/repo.git',
             'protocol': 'git+https',
             'hostname': 'example.com',


### PR DESCRIPTION
closes #371 

- Bug fix (non-breaking change which fixes an issue)
- I have added tests to cover my changes.
- I have run ``./run-tests.sh`` locally.
