### PR TITLE
cli: remove outputs before run

### DIFF
--- a/renku/cli/_cwl.py
+++ b/renku/cli/_cwl.py
@@ -102,23 +102,8 @@ def execute(client, output_file, output_paths=None):
                     shutil.move(location, str(destination))
                     continue
 
-    # Keep only unchanged files in the output paths.
-    tracked_paths = {
-        diff.b_path
-        for diff in client.repo.index.diff(None)
-        if diff.change_type in {'A', 'R', 'M', 'T'} and
-        diff.b_path in output_paths
-    }
-    unchanged_paths = output_paths - tracked_paths
-
-    # Fix tracking of unchanged files by removing them first.
+    unchanged_paths = client.remove_unmodified(output_paths)
     if unchanged_paths:
-        client.repo.index.remove(
-            unchanged_paths, cached=True, r=True, ignore_unmatch=True
-        )
-        client.repo.index.commit('renku: automatic removal of unchanged files')
-        client.repo.index.add(unchanged_paths)
-
         click.echo(
             'Unchanged files:\n\n\t{0}'.format(
                 '\n\t'.join(

--- a/renku/cli/run.py
+++ b/renku/cli/run.py
@@ -137,7 +137,7 @@ from ._options import option_isolation
     'outputs',
     '--output',
     multiple=True,
-    help='Force a path to be an output.',
+    help='Force a path to be considered an output.',
 )
 @click.option(
     '--no-output',

--- a/renku/cli/run.py
+++ b/renku/cli/run.py
@@ -134,6 +134,12 @@ from ._options import option_isolation
 
 @click.command(context_settings=dict(ignore_unknown_options=True, ))
 @click.option(
+    'outputs',
+    '--output',
+    multiple=True,
+    help='Force a path to be an output.',
+)
+@click.option(
     '--no-output',
     is_flag=True,
     default=False,
@@ -152,7 +158,7 @@ from ._options import option_isolation
 @pass_local_client(
     clean=True, up_to_date=True, commit=True, ignore_std_streams=True
 )
-def run(client, no_output, success_codes, isolation, command_line):
+def run(client, outputs, no_output, success_codes, isolation, command_line):
     """Tracking work on a specific problem."""
     working_dir = client.repo.working_dir
     mapped_std = _mapped_std_streams(client.candidate_paths)
@@ -168,7 +174,9 @@ def run(client, no_output, success_codes, isolation, command_line):
     )
 
     with client.with_workflow_storage() as wf:
-        with factory.watch(client, no_output=no_output) as tool:
+        with factory.watch(
+            client, no_output=no_output, outputs=outputs
+        ) as tool:
             returncode = call(
                 factory.command_line,
                 cwd=os.getcwd(),

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ history = open('CHANGES.rst').read()
 tests_require = [
     'check-manifest>=0.37',
     'coverage>=4.0',
-    'flake8>=3.5',
+    'flake8>=3.5,<3.7',  # remove with pytest-flake8>=1.0.4
     'freezegun>=0.3.9',
     'isort>=4.3.4',
     'pydocstyle>=3.0.0',

--- a/tests/cli/test_output_option.py
+++ b/tests/cli/test_output_option.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test behavior of ``--output`` option."""
+
+import yaml
+
+from renku.models.cwl import CWLClass
+
+
+def test_without_an_output_option(runner, client, run):
+    """Test detection of an output file without an output option."""
+    assert 0 == run(args=('run', 'touch', 'hello.txt'))
+    assert 1 == run(args=('run', 'touch', 'hello.txt'))
+    assert 0 == run(args=('run', '--no-output', 'touch', 'hello.txt'))
+
+    # There should be two command line tool.
+    tools = list(client.workflow_path.glob('*_touch.cwl'))
+    assert 2 == len(tools)
+
+    cwls = []
+    for tool_path in tools:
+        with tool_path.open('r') as f:
+            cwls.append(CWLClass.from_cwl(yaml.load(f)))
+
+    assert cwls[0].inputs != cwls[1].inputs
+    assert cwls[0].outputs != cwls[1].outputs
+
+
+def test_with_an_output_option(runner, client, run):
+    """Test detection of an output file with an output option."""
+    assert 0 == run(args=('run', 'touch', 'hello.txt'))
+    assert 0 == run(
+        args=('run', '--output', 'hello.txt', 'touch', 'hello.txt')
+    )
+
+    # There should be two command line tool.
+    tools = list(client.workflow_path.glob('*_touch.cwl'))
+    assert 2 == len(tools)
+
+    cwls = []
+    for tool_path in tools:
+        with tool_path.open('r') as f:
+            cwls.append(CWLClass.from_cwl(yaml.load(f)))
+
+    assert cwls[0].inputs == cwls[1].inputs
+    assert cwls[0].outputs == cwls[1].outputs
+
+
+def test_output_directory_with_output_option(runner, client, run):
+    """Test directory cleanup with the output option."""
+    base_sh = ['sh', '-c', 'mkdir -p "$0"; touch "$0/$1"']
+
+    assert 0 == run(args=['run'] + base_sh + ['output', 'foo'])
+    assert (client.path / 'output' / 'foo').exists()
+
+    # The output directory is wronly detected.
+    assert 1 == run(args=['run'] + base_sh + ['output', 'foo'])
+    assert 0 == run(args=['run', '--no-output'] + base_sh + ['output', 'foo'])
+
+    # There should be two command line tool.
+    tools = list(client.workflow_path.glob('*_sh.cwl'))
+    assert 2 == len(tools)
+
+    cwls = []
+    for tool_path in tools:
+        with tool_path.open('r') as f:
+            cwls.append(CWLClass.from_cwl(yaml.load(f)))
+
+    assert cwls[0].inputs != cwls[1].inputs
+    assert cwls[0].outputs != cwls[1].outputs
+
+    # The output directory is cleaned.
+    assert 0 == run(
+        args=['run', '--output', 'output'] + base_sh + ['output', 'bar']
+    )
+    assert not (client.path / 'output' / 'foo').exists()
+    assert (client.path / 'output' / 'bar').exists()
+
+
+def test_output_directory_without_separate_outputs(runner, client, run):
+    """Output files in directory are not listed as separate outputs.
+
+    See https://github.com/SwissDataScienceCenter/renku-python/issues/387
+    """
+    base_sh = ['sh', '-c', 'mkdir -p "$0"; touch "$0/$1"']
+
+    assert 0 == run(args=['run'] + base_sh + ['output', 'foo'])
+    assert (client.path / 'output' / 'foo').exists()
+
+    # There should be two command line tool.
+    tools = list(client.workflow_path.glob('*_sh.cwl'))
+    assert 1 == len(tools)
+
+    with tools[0].open('r') as f:
+        cwl = CWLClass.from_cwl(yaml.load(f))
+
+    assert 1 == len(cwl.outputs)
+    assert 'Directory' == cwl.outputs[0].type


### PR DESCRIPTION
# Description

Automatically removes specified outputs before executing a `renku run` command.

Addresses #387 

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TODO

- [x] write tests
