### PR TITLE
models: export path and parent directories

### DIFF
--- a/renku/models/provenance/activities.py
+++ b/renku/models/provenance/activities.py
@@ -51,6 +51,7 @@ def _nodes(output, parent=None):
 @jsonld.s(
     type='prov:Activity',
     context={
+        'schema': 'http://schema.org/',
         'prov': 'http://www.w3.org/ns/prov#',
         'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
     },
@@ -78,6 +79,10 @@ class Activity(CommitMixin):
         context={
             '@reverse': 'prov:activity',
         }, kw_only=True, hash=False
+    )
+    influenced = jsonld.ib(
+        context='prov:influenced',
+        kw_only=True,
     )
 
     started_at_time = jsonld.ib(
@@ -149,6 +154,11 @@ class Activity(CommitMixin):
                 )
             )
         return results
+
+    @influenced.default
+    def default_influenced(self):
+        """Calculate default values."""
+        return list(self._collections.values())
 
     @property
     def parents(self):

--- a/renku/models/provenance/entities.py
+++ b/renku/models/provenance/entities.py
@@ -35,7 +35,12 @@ class CommitMixin:
 
     commit = attr.ib(default=None, kw_only=True)
     client = attr.ib(default=None, kw_only=True)
-    path = attr.ib(default=None, kw_only=True, converter=_str_or_none)
+    path = jsonld.ib(
+        context='prov:atLocation',
+        default=None,
+        kw_only=True,
+        converter=_str_or_none
+    )
 
     _id = jsonld.ib(context='@id', kw_only=True)
     _label = jsonld.ib(context='rdfs:label', kw_only=True)
@@ -68,6 +73,7 @@ class CommitMixin:
         'wfprov:Artifact',
     ],
     context={
+        'schema': 'http://schema.org/',
         'prov': 'http://www.w3.org/ns/prov#',
         'wfprov': 'http://purl.org/wf4ever/wfprov#',
     },


### PR DESCRIPTION
# Description

Exports missing triples and adds `path` as `schema.org/name` for `Entities`.

Addresses #370