### PR TITLE
installation: unpin flake8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,13 @@ history = open('CHANGES.rst').read()
 tests_require = [
     'check-manifest>=0.37',
     'coverage>=4.0',
-    'flake8>=3.5,<3.7',  # remove with pytest-flake8>=1.0.4
+    'flake8>=3.5',
     'freezegun>=0.3.9',
     'isort>=4.3.4',
     'pydocstyle>=3.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=2.5.1',
-    'pytest-flake8>=0.9.1',
+    'pytest-flake8>=1.0.4',
     'pytest-pep8>=1.0.6',
     'pytest-yapf>=0.1.1',
     'pytest>=4.0.0',


### PR DESCRIPTION
The latest release of `pytest-flake8==1.0.4` removes the incompatibility with `flake8==3.7`. 