### PR TITLE
cli: init --force on empty dir

### DIFF
--- a/renku/cli/init.py
+++ b/renku/cli/init.py
@@ -119,7 +119,7 @@ def init(ctx, client, directory, name, force, use_external_storage):
 
     stack = contextlib.ExitStack()
 
-    if force:
+    if force and client.repo:
         msg = 'Initialized project in {path} (branch {branch_name})'
         merge_args = ['--no-ff', '-s', 'recursive', '-X', 'ours']
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -91,3 +91,13 @@ def test_init_on_cloned_repo(isolated_runner, data_repository):
 
     result = runner.invoke(cli.cli, ['init', '--force'])
     assert 0 == result.exit_code
+
+
+def test_init_force_in_empty_dir(isolated_runner):
+    """Run init --force in empty directory."""
+    runner = isolated_runner
+
+    new_project = Path('test-new-project')
+    assert not new_project.exists()
+    result = runner.invoke(cli.cli, ['init', '--force', 'test-new-project'])
+    assert 0 == result.exit_code


### PR DESCRIPTION
# Description

Handles case when when running `renku init --force` fails badly on empty directory.

(closes #404)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update