### PR TITLE
api: move metadata to .renku/datasets

### DIFF
--- a/renku/api/datasets.py
+++ b/renku/api/datasets.py
@@ -79,12 +79,7 @@ class DatasetsApiMixin(object):
 
             yield dataset
 
-            source.update(
-                **asjsonld(
-                    dataset,
-                    filter=lambda attr, _: attr.name != 'datadir',
-                )
-            )
+            source.update(**asjsonld(dataset))
 
             # TODO
             # if path is None:

--- a/renku/api/datasets.py
+++ b/renku/api/datasets.py
@@ -42,6 +42,14 @@ class DatasetsApiMixin(object):
     datadir = attr.ib(default='data', converter=str)
     """Define a name of the folder for storing datasets."""
 
+    DATASETS = 'datasets'
+    """Directory for storing dataset metadata in Renku."""
+
+    @property
+    def renku_datasets_path(self):
+        """Return a ``Path`` instance of Renku dataset metadata folder."""
+        return self.renku_path.joinpath(self.DATASETS)
+
     @contextmanager
     def with_dataset(self, name=None):
         """Yield an editable metadata object for a dataset."""
@@ -54,7 +62,7 @@ class DatasetsApiMixin(object):
             dataset_path = self.path / self.datadir / name
 
             if name:
-                path = dataset_path / self.METADATA
+                path = self.renku_datasets_path / name / self.METADATA
                 if path.exists():
                     with path.open('r') as f:
                         source = yaml.load(f) or {}
@@ -63,10 +71,11 @@ class DatasetsApiMixin(object):
             if dataset is None:
                 source = {}
                 dataset = Dataset(name=name)
-                try:
-                    dataset_path.mkdir(parents=True, exist_ok=True)
-                except FileExistsError:
-                    raise FileExistsError('This dataset already exists.')
+
+            (self.renku_datasets_path / name).mkdir(
+                parents=True, exist_ok=True
+            )
+            dataset_path.mkdir(parents=True, exist_ok=True)
 
             yield dataset
 
@@ -112,7 +121,12 @@ class DatasetsApiMixin(object):
             files = self._add_from_url(dataset, dataset_path, url, **kwargs)
 
         ignored = self.find_ignored_paths(
-            *[str(dataset_path / key) for key in files.keys()]
+            *[
+                os.path.relpath(
+                    str(self.renku_datasets_path / dataset.name / key),
+                    start=str(self.path),
+                ) for key in files.keys()
+            ]
         )
 
         if ignored:
@@ -189,8 +203,8 @@ class DatasetsApiMixin(object):
         dst.chmod(mode & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
 
         self.track_paths_in_storage(str(dst.relative_to(self.path)))
-        dataset_path = self.path / self.datadir / dataset.name
-        result = dst.relative_to(dataset_path).as_posix()
+        dataset_path = self.renku_datasets_path / dataset.name
+        result = os.path.relpath(str(dst), start=str(dataset_path))
         return {
             result:
                 DatasetFile(
@@ -310,8 +324,8 @@ class DatasetsApiMixin(object):
             if author not in authors:
                 authors.append(author)
 
-        dataset_path = self.path / self.datadir / dataset.name
-        result = dst.relative_to(dataset_path).as_posix()
+        dataset_path = self.renku_datasets_path / dataset.name
+        result = os.path.relpath(str(dst), start=str(dataset_path))
 
         if u.scheme in ('', 'file'):
             url = None

--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -94,6 +94,7 @@ from .githooks import githooks
 from .image import image
 from .init import init
 from .log import log
+from .migrate import migrate
 from .pull import pull
 from .rerun import rerun
 from .run import run
@@ -207,6 +208,7 @@ cli.add_command(githooks)
 cli.add_command(image)
 cli.add_command(init)
 cli.add_command(log)
+cli.add_command(migrate)
 cli.add_command(pull)
 cli.add_command(rerun)
 cli.add_command(run)

--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -89,6 +89,7 @@ from ._options import install_completion, option_use_external_storage
 from ._version import check_version, print_version
 from .config import config
 from .dataset import dataset
+from .doctor import doctor
 from .githooks import githooks
 from .image import image
 from .init import init
@@ -201,6 +202,7 @@ def help(ctx):
 cli.add_command(config)
 cli.add_command(dataset)
 cli.add_command(deactivate)
+cli.add_command(doctor)
 cli.add_command(githooks)
 cli.add_command(image)
 cli.add_command(init)

--- a/renku/cli/_checks/__init__.py
+++ b/renku/cli/_checks/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Define repository checks for :program:`renku doctor`."""
+
+from .location_datasets import check_dataset_metadata
+
+# Checks will be executed in the order as they are listed in __all__
+__all__ = ('check_dataset_metadata', )

--- a/renku/cli/_checks/location_datasets.py
+++ b/renku/cli/_checks/location_datasets.py
@@ -15,16 +15,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Check location of dataset metedata files."""
 
 import click
 
 from .._echo import WARNING
 
 
+def _dataset_metadata_pre_0_3_4(client):
+    """Return paths of dataset metadata for pre 0.3.4."""
+    return (client.path / 'data').rglob('metadata.yml')
+
+
 def check_dataset_metadata(client):
     """Check location of dataset metadata."""
     # Find pre 0.3.4 metadata files.
-    old_metadata = list((client.path / 'data').rglob('metadata.yml'))
+    old_metadata = list(_dataset_metadata_pre_0_3_4(client))
 
     if not old_metadata:
         return True

--- a/renku/cli/doctor.py
+++ b/renku/cli/doctor.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Check your system and repository for potential problems."""
+
+import textwrap
+
+import click
+
+from ._client import pass_local_client
+
+DOCTOR_INFO = """\
+Please note that the diagnosis report is used to help Renku maintainers with
+debugging if you file an issue. Use all proposed solutions with maximal care
+and if in doubt ask an expert around or file an issue. Thanks!
+"""
+
+
+@click.command()
+@pass_local_client
+@click.pass_context
+def doctor(ctx, client):
+    """Check your system and repository for potential problems."""
+    click.secho('\n'.join(textwrap.wrap(DOCTOR_INFO)) + '\n', bold=True)
+
+    from . import _checks
+
+    is_ok = True
+    for attr in _checks.__all__:
+        is_ok &= getattr(_checks, attr)(client)
+
+    ctx.exit(0 if is_ok else 1)

--- a/renku/cli/migrate.py
+++ b/renku/cli/migrate.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Migrate files and metadata to latest Renku version."""
+
+import os
+
+import attr
+import click
+import yaml
+
+from ._client import pass_local_client
+
+
+@click.group()
+def migrate():
+    """Migrate to latest Renku version."""
+
+
+@migrate.command()
+@pass_local_client(clean=True, commit=True)
+@click.pass_context
+def datasets(ctx, client):
+    """Migrate dataset metadata."""
+    from renku.models._jsonld import asjsonld
+    from renku.models.datasets import Dataset
+
+    from ._checks.location_datasets import _dataset_metadata_pre_0_3_4
+
+    with client.lock:
+        for old_path in _dataset_metadata_pre_0_3_4(client):
+            with old_path.open('r') as fp:
+                dataset = Dataset.from_jsonld(yaml.load(fp))
+
+            name = str(old_path.parent.relative_to(client.path / 'data'))
+            new_path = client.renku_datasets_path / name / client.METADATA
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+
+            files = {}
+            for key, file in dataset.files.items():
+                key = os.path.relpath(
+                    str(old_path.parent / key), start=str(new_path.parent)
+                )
+                files[key] = attr.evolve(file, path=key)
+
+            dataset = attr.evolve(dataset, files=files)
+
+            with new_path.open('w') as fp:
+                yaml.dump(asjsonld(dataset), fp, default_flow_style=False)
+
+            old_path.unlink()

--- a/renku/models/datasets.py
+++ b/renku/models/datasets.py
@@ -37,7 +37,6 @@ NoneType = type(None)
 _path_attr = partial(
     jsonld.ib,
     converter=Path,
-    validator=lambda i, arg, val: Path(val).absolute().is_file()
 )
 
 

--- a/renku/models/refs.py
+++ b/renku/models/refs.py
@@ -45,7 +45,7 @@ class LinkReference:
         - any path component of it begins with ".", or
         - it has double dots "..", or
         - it has ASCII control characters, or
-        - it has ":", "?", "[", "\", "^", "~", SP, or TAB anywhere, or
+        - it has ":", "?", "\[", "\\", "^", "~", SP, or TAB anywhere, or
         - it has "*" anywhere, or
         - it ends with a "/", or
         - it ends with ".lock", or

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,12 +307,12 @@ def test_streams_and_args_names(runner, project, capsys):
     assert result.exit_code == 0
 
 
-def test_datasets(data_file, data_repository, runner, project):
+def test_datasets(data_file, data_repository, runner, project, client):
     """Test importing data into a dataset."""
     # create a dataset
     result = runner.invoke(cli.cli, ['dataset', 'create', 'dataset'])
     assert result.exit_code == 0
-    assert os.stat('data/dataset/metadata.yml')
+    assert (client.renku_datasets_path / 'dataset' / client.METADATA).exists()
 
     # add data
     result = runner.invoke(
@@ -349,12 +349,14 @@ def test_datasets(data_file, data_repository, runner, project):
     assert result.exit_code == 0
 
 
-def test_multiple_file_to_dataset(tmpdir, data_repository, runner, project):
+def test_multiple_file_to_dataset(
+    tmpdir, data_repository, runner, project, client
+):
     """Test importing multiple data into a dataset at once."""
     # create a dataset
     result = runner.invoke(cli.cli, ['dataset', 'create', 'dataset'])
     assert result.exit_code == 0
-    assert os.stat('data/dataset/metadata.yml')
+    assert (client.renku_datasets_path / 'dataset' / client.METADATA).exists()
 
     paths = []
     for i in range(3):
@@ -371,12 +373,14 @@ def test_multiple_file_to_dataset(tmpdir, data_repository, runner, project):
     assert result.exit_code == 0
 
 
-def test_relative_import_to_dataset(tmpdir, data_repository, runner, project):
+def test_relative_import_to_dataset(
+    tmpdir, data_repository, runner, project, client
+):
     """Test importing data from a directory structure."""
     # create a dataset
     result = runner.invoke(cli.cli, ['dataset', 'create', 'dataset'])
     assert result.exit_code == 0
-    assert os.stat('data/dataset/metadata.yml')
+    assert (client.renku_datasets_path / 'dataset' / client.METADATA).exists()
 
     zero_data = tmpdir.join('data.txt')
     zero_data.write('zero')
@@ -408,13 +412,13 @@ def test_relative_import_to_dataset(tmpdir, data_repository, runner, project):
     )
 
 
-def test_relative_git_import_to_dataset(tmpdir, runner, project):
+def test_relative_git_import_to_dataset(tmpdir, runner, project, client):
     """Test importing data from a directory structure."""
 
     # create a dataset
     result = runner.invoke(cli.cli, ['dataset', 'create', 'dataset'])
     assert result.exit_code == 0
-    assert os.stat('data/dataset/metadata.yml')
+    assert (client.renku_datasets_path / 'dataset' / client.METADATA).exists()
 
     data_repo = git.Repo.init(str(tmpdir))
 


### PR DESCRIPTION
Moves location of dataset metadata file from `data/<name>/metadata.yml`  to `.renku/datasets/<name>/metadata.yml`

(closes #396)

## TODO

- [x] `renku doctor`
- [x] `renku migrate datasets`