### PR TITLE
api: get git attrs for files to prevent duplicates

### DIFF
--- a/renku/api/storage.py
+++ b/renku/api/storage.py
@@ -63,7 +63,13 @@ class StorageApiMixin(RepositoryApiMixin):
         """Track paths in the external storage."""
         if self.use_external_storage and self.external_storage_installed:
             track_paths = []
+            attrs = self.find_attr(*paths)
+
             for path in paths:
+                # Do not add files with filter=lfs in .gitattributes
+                if attrs.get(path, {}).get('filter') == 'lfs':
+                    continue
+
                 path = Path(path)
                 if path.is_dir():
                     track_paths.append(str(path / '**'))


### PR DESCRIPTION
Prevents creation of duplicates in `.gitattributes` when a general rules exists.

(closes #410)

cc @lusamino 