### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2018 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2019 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 
@@ -17,6 +17,48 @@
 
 Changes
 =======
+
+``v0.4.0``
+----------
+
+*(released 2019-03-05)*
+
+- Adds ``renku mv`` command which updates dataset metadata, ``.gitattributes``
+  and symlinks.
+- Pulls LFS objects from submodules correctly.
+- Adds listing of datasets.
+- Adds reduced dot format for ``renku log``.
+- Adds ``doctor`` command to check missing files in datasets.
+- Moves dataset metadata to ``.renku/datasets`` and adds ``migrate datasets``
+  command and uses UUID for metadata path.
+- Gets git attrs for files to prevent duplicates in ``.gitattributes``.
+- Fixes ``renku show outputs`` for directories.
+- Runs Git LFS checkout in a worktrees and lazily pulls necessary LFS files
+  before running commands.
+- Asks user before overriding an existing file using ``renku init``
+  or ``renku runner template``.
+- Fixes ``renku init --force`` in an empty dir.
+- Renames ``CommitMixin._location`` to ``_project``.
+- Addresses issue with commits editing multiple CWL files.
+- Exports merge commits for full lineage.
+- Exports path and parent directories.
+- Adds an automatic check for the latest version.
+- Simplifies issue submission from traceback to GitHub or Sentry.
+  Requires ``SENTRY_DSN`` variable to be set and `sentry-sdk` package to be
+  installed before sending any data.
+- Removes outputs before run.
+- Allows update of directories.
+- Improves readability of the status message.
+- Checks ignored path when added to a dataset.
+- Adds API method for finding ignored paths.
+- Uses branches for ``init --force``.
+- Fixes CVE-2017-18342.
+- Fixes regex for parsing Git remote URLs.
+- Handles ``--isolation`` option using ``git worktree``.
+- Renames ``client.git`` to ``client.repo``.
+- Supports ``python -m renku``.
+- Allows '.' and '-' in repo path.
+
 
 ``v0.3.3``
 ----------

--- a/README.rst
+++ b/README.rst
@@ -97,19 +97,32 @@ The recommended way of installing Renku on MacOS is via `Homebrew <brew.sh>`_.
       $ open https://launchpad.net/~swissdatasciencecenter/+snap/renku/
       $ snap install renku
 
-Pip Script Installer (``pipsi``)
---------------------------------
+Isolated environments using ``pipx``
+------------------------------------
 
-You can use `pipsi <https://github.com/mitsuhiko/pipsi>`_ to isolate
-dependencies and to guarantee that there are no version conflicts. Make sure
-you have the ``pipsi`` command correctly installed and ``~/.local/bin`` is in
-your ``$PATH``.
+Install and execute Renku in an isolated environment using ``pipx``.
+It will guarantee that there are no version conflicts with dependencies
+you are using for your work and research.
+
+`Install pipx <https://github.com/pipxproject/pipx#install-pipx>`_
+and make sure that the ``$PATH`` is correctly configured.
 
 ::
 
-    $ pipsi install renku
+    $ python3 -m pip install --user pipx
+    $ pipx ensurepath
+
+Once ``pipx`` is installed use following command to install ``renku``.
+
+::
+
+    $ pipx install renku
     $ which renku
     ~/.local/bin/renku
+
+Prevously we have recommended to use ``pipsi``. You can still use it or
+`migrate to **pipx**
+<https://github.com/pipxproject/pipx#migrating-to-pipx-from-pipsi>`_.
 
 Docker
 ------


### PR DESCRIPTION
## `v0.4.0`

*(released 2019-03-05)*

- Adds ``renku mv`` command which updates dataset metadata, ``.gitattributes``
  and symlinks.
- Pulls LFS objects from submodules correctly.
- Adds listing of datasets.
- Adds reduced dot format for ``renku log``.
- Adds ``doctor`` command to check missing files in datasets.
- Moves dataset metadata to ``.renku/datasets`` and adds ``migrate datasets``
  command and uses UUID for metadata path.
- Gets git attrs for files to prevent duplicates in ``.gitattributes``.
- Fixes ``renku show outputs`` for directories.
- Runs Git LFS checkout in a worktrees and lazily pulls necessary LFS files
  before running commands.
- Asks user before overriding an existing file using ``renku init``
  or ``renku runner template``.
- Fixes ``renku init --force`` in an empty dir.
- Renames ``CommitMixin._location`` to ``_project``.
- Addresses issue with commits editing multiple CWL files.
- Exports merge commits for full lineage.
- Exports path and parent directories.
- Adds an automatic check for the latest version.
- Simplifies issue submission from traceback to GitHub or Sentry.
  Requires ``SENTRY_DSN`` variable to be set and `sentry-sdk` package to be
  installed before sending any data.
- Removes outputs before run.
- Allows update of directories.
- Improves readability of the status message.
- Checks ignored path when added to a dataset.
- Adds API method for finding ignored paths.
- Uses branches for ``init --force``.
- Fixes CVE-2017-18342.
- Fixes regex for parsing Git remote URLs.
- Handles ``--isolation`` option using ``git worktree``.
- Renames ``client.git`` to ``client.repo``.
- Supports ``python -m renku``.
- Allows '.' and '-' in repo path.