### PR TITLE
fix(datasets): link flag on dataset add

### DIFF
--- a/renku/api/datasets.py
+++ b/renku/api/datasets.py
@@ -157,7 +157,7 @@ class DatasetsApiMixin(object):
 
         dataset.files.update(files)
 
-    def _add_from_url(self, dataset, path, url, nocopy=False, **kwargs):
+    def _add_from_url(self, dataset, path, url, link=False, **kwargs):
         """Process an add from url and return the location on disk."""
         u = parse.urlparse(url)
 
@@ -190,7 +190,7 @@ class DatasetsApiMixin(object):
                             dataset,
                             dst,
                             f.absolute().as_posix(),
-                            nocopy=nocopy
+                            link=link,
                         )
                     )
                 return files
@@ -198,13 +198,13 @@ class DatasetsApiMixin(object):
             # Make sure the parent directory exists.
             dst.parent.mkdir(parents=True, exist_ok=True)
 
-            if nocopy:
+            if link:
                 try:
                     os.link(str(src), str(dst))
                 except Exception as e:
                     raise Exception(
                         'Could not create hard link '
-                        '- retry without nocopy.'
+                        '- retry without --link.'
                     ) from e
             else:
                 shutil.copy(str(src), str(dst))

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -125,7 +125,7 @@ def create(client, name):
 @dataset.command()
 @click.argument('name')
 @click.argument('urls', nargs=-1)
-@click.option('nocopy', '--copy/--no-copy', default=False, is_flag=True)
+@click.option('--link', is_flag=True, help='Creates a hard link.')
 @click.option('--relative-to', default=None)
 @click.option(
     '-t',
@@ -138,7 +138,7 @@ def create(client, name):
     '--force', is_flag=True, help='Allow adding otherwise ignored files.'
 )
 @pass_local_client(clean=True, commit=True)
-def add(client, name, urls, nocopy, relative_to, target, force):
+def add(client, name, urls, link, relative_to, target, force):
     """Add data to a dataset."""
     try:
         with client.with_dataset(name=name) as dataset:
@@ -148,7 +148,7 @@ def add(client, name, urls, nocopy, relative_to, target, force):
                     client.add_data_to_dataset(
                         dataset,
                         url,
-                        nocopy=nocopy,
+                        link=link,
                         target=target,
                         relative_to=relative_to,
                         force=force,


### PR DESCRIPTION
This PR removes --copy/--no-copy flags on add command and introduces --link flag which will create a hardlink of the file into dataset.

Fixes #448 

