### PR TITLE
fix: only check local repo for lfs filter

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -397,16 +397,23 @@ def test_configuration_of_external_storage(isolated_runner, monkeypatch):
         m.setattr(StorageApiMixin, 'external_storage_installed', False)
 
         result = runner.invoke(cli.cli, ['run', 'touch', 'output'])
-        assert 1 == result.exit_code
-        subprocess.call(['git', 'clean', '-df'])
+        assert 0 == result.exit_code
 
-    result = runner.invoke(cli.cli, ['-S', 'run', 'touch', 'output'])
+    result = runner.invoke(cli.cli, ['-S', 'run', 'touch', 'output2'])
     assert 0 == result.exit_code
 
     result = runner.invoke(cli.cli, ['init', '--force'])
     assert 0 == result.exit_code
 
-    result = runner.invoke(cli.cli, ['run', 'touch', 'output2'])
+    with monkeypatch.context() as m:
+        from renku.api.storage import StorageApiMixin
+        m.setattr(StorageApiMixin, 'external_storage_installed', False)
+
+        result = runner.invoke(cli.cli, ['run', 'touch', 'output3'])
+        assert 1 == result.exit_code
+        subprocess.call(['git', 'clean', '-df'])
+
+    result = runner.invoke(cli.cli, ['run', 'touch', 'output4'])
     assert 0 == result.exit_code
 
 
@@ -489,7 +496,7 @@ def test_status_with_submodules(isolated_runner, monkeypatch):
             cli.cli, ['dataset', 'add', 'f', '../woop'],
             catch_exceptions=False
         )
-        assert 1 == result.exit_code
+        assert 0 == result.exit_code
         subprocess.call(['git', 'clean', '-dff'])
 
     result = runner.invoke(


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

# Description

Checking for LFS usage in Renku project was looking into current repo git config file and all the higher level files (i.e. user and system). If LFS filter was enabled in any of these config file, Renku would try to use it even if it was told not to when initialising the project.

This fix only looks in repository's git config.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/562.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

**Do not create pull request unless you checked all points.**

- [ ] I have read and understood the **CONTRIBUTING** document.
- [ ] I have performed a self-review of my own code.
- [ ] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [x] I have added tests to cover my changes.
- [ ] I have **NOT** removed any existing tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have described *all* changes in the **CHANGELOG.rst**.
- [x] I have run ``./run-tests.sh`` locally.
