### PR TITLE
feat: add SoftwareAgent to Activity

### DIFF
--- a/renku/api/_git.py
+++ b/renku/api/_git.py
@@ -228,7 +228,7 @@ class GitCore:
     def commit(self, author_date=None, commit_only=None):
         """Automatic commit."""
         from git import Actor
-        from renku.version import __version__
+        from renku.version import __version__, version_url
 
         author_date = author_date or formatdate(localtime=True)
 
@@ -243,10 +243,7 @@ class GitCore:
 
         yield
 
-        committer = Actor(
-            'renku {0}'.format(__version__),
-            'renku+{0}@datascience.ch'.format(__version__),
-        )
+        committer = Actor('renku {0}'.format(__version__), version_url)
 
         if isinstance(commit_only, list):
             for path_ in commit_only:

--- a/renku/models/provenance/activities.py
+++ b/renku/models/provenance/activities.py
@@ -29,6 +29,7 @@ from renku.models.cwl import WORKFLOW_STEP_RUN_TYPES
 from renku.models.cwl._ascwl import CWLClass
 from renku.models.cwl.types import PATH_OBJECTS
 
+from .agents import renku_agent
 from .entities import Collection, CommitMixin, Entity, Process, Workflow
 from .qualified import Association, Generation, Usage
 
@@ -99,6 +100,8 @@ class Activity(CommitMixin):
         },
         kw_only=True,
     )
+
+    agent = jsonld.ib(context='prov:agent', kw_only=True, default=renku_agent)
 
     @generated.default
     def default_generated(self):

--- a/renku/models/provenance/agents.py
+++ b/renku/models/provenance/agents.py
@@ -20,6 +20,7 @@
 import re
 
 from renku.models import _jsonld as jsonld
+from renku.version import __version__, version_url
 
 
 @jsonld.s(
@@ -96,7 +97,14 @@ class SoftwareAgent:
         if commit.author != commit.committer:
             return cls(
                 label=commit.committer.name,
-                id='mailto:{0}'.format(commit.committer.email),
+                id=commit.committer.email,
                 was_started_by=author,
             )
         return author
+
+
+# set up the default agent
+
+renku_agent = SoftwareAgent(
+    label='renku {0}'.format(__version__), id=version_url
+)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 """Python SDK and CLI for the Renku platform."""
 
-import datetime
 import os
 
 from setuptools import find_packages, setup
@@ -114,14 +113,27 @@ version_template = """\
 # See the License for the specific language governing permissions and
 # limitations under the License.
 \"\"\"Version information for Renku.\"\"\"
+import re
 
 __version__ = {version!r}
-""" % (datetime.date.today().year, )
+
+
+def _get_disribution_url():
+    import pkg_resources
+    d = pkg_resources.get_distribution('renku')
+    metadata = d._get_metadata(d.PKG_INFO)
+    home_page = [m for m in metadata if m.startswith('Home-page:')]
+    return home_page[0].split(':', 1)[1].strip()
+
+
+_components = re.findall(r'(\d\.\d\.\d)(?:.+g(\w+))?', __version__)[0]
+_version = _components[1] or 'v' + _components[0]
+version_url = '{{}}/tree/{{}}'.format(_get_disribution_url(), _version)
+"""
 
 setup(
     name='renku',
     use_scm_version={
-        'local_scheme': 'dirty-tag',
         'write_to': os.path.join('renku', 'version.py'),
         'write_to_template': version_template,
     },


### PR DESCRIPTION
This PR links every activity to the version of `renku` used to generate the triples. This way we can check in the future which parts of the graph may need to be regenerated. 

---

closes #508

