### PR TITLE
build(ci): skip integration tests on prs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ python:
 stages:
   - name: test
   - name: integration
-    if: branch = master
+    if: branch = master AND (type != pull_request)
   - name: test OSX
-    if: branch = master
+    if: branch = master AND (type != pull_request)
   - name: publish 🐍  🐳
     if: type = push AND (branch = master OR tag IS present)
   - name: brew 🍺


### PR DESCRIPTION
Change the travis-ci setup to skip integration tests on PRs. They will run once the PR is merged and on cron jobs. 