### PR TITLE
build: update and cleanup build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,10 @@ stages:
     if: branch = master AND (type != pull_request)
   - name: test OSX
     if: branch = master AND (type != pull_request)
-  - name: publish 🐍  🐳
+  - name: publish 🐍
     if: type = push AND (branch = master OR tag IS present)
   - name: brew 🍺
-    if: type = push AND tag IS present
+    if: type = push AND tag IS present AND tag =~ /^\d\.\d\.\d$/
 
 before_install:
   - git fetch --tags
@@ -145,9 +145,14 @@ jobs:
       os: osx
       osx_image: xcode9.2
 
-    - stage: publish 🐍  🐳
+    - stage: publish 🐍
       python: 3.6
       script: echo "Publishing on PyPI.io ..."
+      before_deploy:
+        if [[ -z $TRAVIS_TAG ]]; then
+          export TRAVIS_TAG=$(renku --version) &&
+          git tag $TRAVIS_TAG;
+        fi
       deploy:
         - provider: pypi
           user:
@@ -157,19 +162,14 @@ jobs:
           distributions: "sdist bdist_wheel"
           on:
             all_branches: true
+        # push the dev tag to github
+        - provider: releases
+          api_key: ${GITHUB_TOKEN}
+          on:
+            all_branches: true
+            tags: false
 
-    - # stage: publish
-      sudo: required
-      services:
-        - docker
-      install:
-        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-        - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-        - sudo apt-get update
-        - sudo apt-get -y install docker-ce
-      script: make docker-login docker-push
-
-    - # stage: brew 🍺
+    - stage: brew 🍺
       language: generic
       sudo: true
       os: osx
@@ -189,7 +189,6 @@ jobs:
             all_branches: true
         - provider: pages
           skip-cleanup: true
-          # Set in the settings page of your repository, as a secure variable
           github-token: ${GITHUB_TOKEN}
           repo: swissdatasciencecenter/homebrew-renku
           target-branch: master

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,52 +18,164 @@
 Changes
 =======
 
-``v0.5.0``
-----------
+`0.5.2 <https://github.com/SwissDataScienceCenter/renku-python/compare/v0.5.1...v0.5.2>`__ (2019-07-26)
+-------------------------------------------------------------------------------------------------------
 
-*(released 2019-03-28)*
+Bug Fixes
+~~~~~~~~~
+
+-  safe_path check always operates on str
+   (`#603 <https://github.com/SwissDataScienceCenter/renku-python/issues/603>`__)
+   (`7c1c34e <https://github.com/SwissDataScienceCenter/renku-python/commit/7c1c34e>`__)
+
+Features
+~~~~~~~~
+
+-  add SoftwareAgent to Activity
+   (`#590 <https://github.com/SwissDataScienceCenter/renku-python/issues/590>`__)
+   (`a60c20c <https://github.com/SwissDataScienceCenter/renku-python/commit/a60c20c>`__),
+   closes
+   `#508 <https://github.com/SwissDataScienceCenter/renku-python/issues/508>`__
+
+.. _section-2:
+
+`0.5.1 <https://github.com/SwissDataScienceCenter/renku-python/compare/v0.5.0...v0.5.1>`__ (2019-07-12)
+-------------------------------------------------------------------------------------------------------
+
+.. _bug-fixes-1:
+
+Bug Fixes
+~~~~~~~~~
+
+-  ensure external storage is handled correctly
+   (`#592 <https://github.com/SwissDataScienceCenter/renku-python/issues/592>`__)
+   (`7938ac4 <https://github.com/SwissDataScienceCenter/renku-python/commit/7938ac4>`__)
+-  only check local repo for lfs filter
+   (`#575 <https://github.com/SwissDataScienceCenter/renku-python/issues/575>`__)
+   (`a64dc79 <https://github.com/SwissDataScienceCenter/renku-python/commit/a64dc79>`__)
+-  **cli:** allow renku run with many inputs
+   (`f60783e <https://github.com/SwissDataScienceCenter/renku-python/commit/f60783e>`__),
+   closes
+   `#552 <https://github.com/SwissDataScienceCenter/renku-python/issues/552>`__
+-  added check for overwriting datasets
+   (`#541 <https://github.com/SwissDataScienceCenter/renku-python/issues/541>`__)
+   (`8c697fb <https://github.com/SwissDataScienceCenter/renku-python/commit/8c697fb>`__)
+-  escape whitespaces in notebook name
+   (`#584 <https://github.com/SwissDataScienceCenter/renku-python/issues/584>`__)
+   (`0542fcc <https://github.com/SwissDataScienceCenter/renku-python/commit/0542fcc>`__)
+-  modify json-ld for datasets
+   (`#534 <https://github.com/SwissDataScienceCenter/renku-python/issues/534>`__)
+   (`ab6a719 <https://github.com/SwissDataScienceCenter/renku-python/commit/ab6a719>`__),
+   closes
+   `#525 <https://github.com/SwissDataScienceCenter/renku-python/issues/525>`__
+   `#526 <https://github.com/SwissDataScienceCenter/renku-python/issues/526>`__
+-  refactored tests and docs to align with updated pydoctstyle
+   (`#586 <https://github.com/SwissDataScienceCenter/renku-python/issues/586>`__)
+   (`6f981c8 <https://github.com/SwissDataScienceCenter/renku-python/commit/6f981c8>`__)
+-  **cli:** add check of missing references
+   (`9a373da <https://github.com/SwissDataScienceCenter/renku-python/commit/9a373da>`__)
+-  **cli:** fail when removing non existing dataset
+   (`dd728db <https://github.com/SwissDataScienceCenter/renku-python/commit/dd728db>`__)
+-  **status:** fix renku status output when not in root folder
+   (`#564 <https://github.com/SwissDataScienceCenter/renku-python/issues/564>`__)
+   (`873270d <https://github.com/SwissDataScienceCenter/renku-python/commit/873270d>`__),
+   closes
+   `#551 <https://github.com/SwissDataScienceCenter/renku-python/issues/551>`__
+-  added dependencies for SSL support
+   (`#565 <https://github.com/SwissDataScienceCenter/renku-python/issues/565>`__)
+   (`4fa0fed <https://github.com/SwissDataScienceCenter/renku-python/commit/4fa0fed>`__)
+-  **datasets:** strip query string from data filenames
+   (`450898b <https://github.com/SwissDataScienceCenter/renku-python/commit/450898b>`__)
+-  fixed serialization of creators
+   (`#550 <https://github.com/SwissDataScienceCenter/renku-python/issues/550>`__)
+   (`6a9173c <https://github.com/SwissDataScienceCenter/renku-python/commit/6a9173c>`__)
+-  updated docs
+   (`#539 <https://github.com/SwissDataScienceCenter/renku-python/issues/539>`__)
+   (`ff9a67c <https://github.com/SwissDataScienceCenter/renku-python/commit/ff9a67c>`__)
+-  **cli:** remove dataset aliases
+   (`6206e62 <https://github.com/SwissDataScienceCenter/renku-python/commit/6206e62>`__)
+-  **cwl:** detect script as input parameter
+   (`e23b75a <https://github.com/SwissDataScienceCenter/renku-python/commit/e23b75a>`__),
+   closes
+   `#495 <https://github.com/SwissDataScienceCenter/renku-python/issues/495>`__
+-  **deps:** updated dependencies
+   (`691644d <https://github.com/SwissDataScienceCenter/renku-python/commit/691644d>`__)
+
+.. _features-1:
+
+Features
+~~~~~~~~
+
+-  add dataset metadata to the KG
+   (`#558 <https://github.com/SwissDataScienceCenter/renku-python/issues/558>`__)
+   (`fb443d7 <https://github.com/SwissDataScienceCenter/renku-python/commit/fb443d7>`__)
+-  **datasets:** export dataset to zenodo
+   (`#529 <https://github.com/SwissDataScienceCenter/renku-python/issues/529>`__)
+   (`fc6fd4f <https://github.com/SwissDataScienceCenter/renku-python/commit/fc6fd4f>`__)
+-  added support for working on dirty repo
+   (`ae67be7 <https://github.com/SwissDataScienceCenter/renku-python/commit/ae67be7>`__)
+-  **datasets:** edit dataset metadata
+   (`#549 <https://github.com/SwissDataScienceCenter/renku-python/issues/549>`__)
+   (`db39083 <https://github.com/SwissDataScienceCenter/renku-python/commit/db39083>`__)
+-  integrate metadata from zenodo
+   (`#545 <https://github.com/SwissDataScienceCenter/renku-python/issues/545>`__)
+   (`4273d2a <https://github.com/SwissDataScienceCenter/renku-python/commit/4273d2a>`__)
+-  **config:** added global config manager
+   (`#533 <https://github.com/SwissDataScienceCenter/renku-python/issues/533>`__)
+   (`938f820 <https://github.com/SwissDataScienceCenter/renku-python/commit/938f820>`__)
+-  **datasets:** import data from zenodo
+   (`#509 <https://github.com/SwissDataScienceCenter/renku-python/issues/509>`__)
+   (`52b2769 <https://github.com/SwissDataScienceCenter/renku-python/commit/52b2769>`__)
+
+
+`0.5.0 <https://github.com/SwissDataScienceCenter/renku-python/compare/v0.4.0...v0.5.0>`__ (2019-03-28)
+-------------------------------------------------------------------------------------------------------
+
+.. _bug-fixes-2:
 
 Bug Fixes
 ~~~~~~~~~
 
 -  **api:** make methods lock free
-   (`1f63964 <https://github.com/swissdatasciencecenter/renku-python/commit/1f63964>`__),
+   (`1f63964 <https://github.com/SwissDataScienceCenter/renku-python/commit/1f63964>`__),
    closes
-   `#486 <https://github.com/swissdatasciencecenter/renku-python/issues/486>`__
+   `#486 <https://github.com/SwissDataScienceCenter/renku-python/issues/486>`__
 -  use safe_load for parsing yaml
-   (`5383d1e <https://github.com/swissdatasciencecenter/renku-python/commit/5383d1e>`__),
+   (`5383d1e <https://github.com/SwissDataScienceCenter/renku-python/commit/5383d1e>`__),
    closes
-   `#464 <https://github.com/swissdatasciencecenter/renku-python/issues/464>`__
+   `#464 <https://github.com/SwissDataScienceCenter/renku-python/issues/464>`__
 -  **datasets:** link flag on dataset add
-   (`eae30f4 <https://github.com/swissdatasciencecenter/renku-python/commit/eae30f4>`__)
+   (`eae30f4 <https://github.com/SwissDataScienceCenter/renku-python/commit/eae30f4>`__)
+
+.. _features-2:
 
 Features
 ~~~~~~~~
 
 -  **api:** list datasets from a commit
-   (`04a9fe9 <https://github.com/swissdatasciencecenter/renku-python/commit/04a9fe9>`__)
+   (`04a9fe9 <https://github.com/SwissDataScienceCenter/renku-python/commit/04a9fe9>`__)
 -  **cli:** add dataset rm command
-   (`a70c7ce <https://github.com/swissdatasciencecenter/renku-python/commit/a70c7ce>`__)
+   (`a70c7ce <https://github.com/SwissDataScienceCenter/renku-python/commit/a70c7ce>`__)
 -  **cli:** add rm command
-   (`cf0f502 <https://github.com/swissdatasciencecenter/renku-python/commit/cf0f502>`__)
+   (`cf0f502 <https://github.com/SwissDataScienceCenter/renku-python/commit/cf0f502>`__)
 -  **cli:** configurable format of dataset output
-   (`d37abf3 <https://github.com/swissdatasciencecenter/renku-python/commit/d37abf3>`__)
+   (`d37abf3 <https://github.com/SwissDataScienceCenter/renku-python/commit/d37abf3>`__)
 -  **dataset:** add existing file from current repo
-   (`575686b <https://github.com/swissdatasciencecenter/renku-python/commit/575686b>`__),
-   closes `#99 <https://github.com/swissdatasciencecenter/renku-python/issues/99>`__
+   (`575686b <https://github.com/SwissDataScienceCenter/renku-python/commit/575686b>`__),
+   closes
+   `#99 <https://github.com/SwissDataScienceCenter/renku-python/issues/99>`__
 -  **datasets:** added ls-files command
-   (`ccc4f59 <https://github.com/swissdatasciencecenter/renku-python/commit/ccc4f59>`__)
+   (`ccc4f59 <https://github.com/SwissDataScienceCenter/renku-python/commit/ccc4f59>`__)
 -  **models:** reference context for relative paths
-   (`5d1e8e7 <https://github.com/swissdatasciencecenter/renku-python/commit/5d1e8e7>`__),
+   (`5d1e8e7 <https://github.com/SwissDataScienceCenter/renku-python/commit/5d1e8e7>`__),
    closes
-   `#452 <https://github.com/swissdatasciencecenter/renku-python/issues/452>`__
+   `#452 <https://github.com/SwissDataScienceCenter/renku-python/issues/452>`__
 -  add JSON-LD output format for datasets
-   (`c755d7b <https://github.com/swissdatasciencecenter/renku-python/commit/c755d7b>`__),
+   (`c755d7b <https://github.com/SwissDataScienceCenter/renku-python/commit/c755d7b>`__),
    closes
-   `#426 <https://github.com/swissdatasciencecenter/renku-python/issues/426>`__
+   `#426 <https://github.com/SwissDataScienceCenter/renku-python/issues/426>`__
 -  generate Makefile with log –format Makefile
-   (`1e440ce <https://github.com/swissdatasciencecenter/renku-python/commit/1e440ce>`__)
-
+   (`1e440ce <https://github.com/SwissDataScienceCenter/renku-python/commit/1e440ce>`__)
 
 ``v0.4.0``
 ----------


### PR DESCRIPTION
This PR:

* removes the docker build (not needed anymore since the KG is hosted and dot files are not generated in CI)
* push dev tags to have consistency between pypi releases and repo tags
* updates changelog