### PR TITLE
build: use correct tag regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ stages:
   - name: publish 🐍
     if: type = push AND (branch = master OR tag IS present)
   - name: brew 🍺
-    if: type = push AND tag IS present AND tag =~ /^\d\.\d\.\d$/
+    if: type = push AND tag IS present AND tag =~ /^v\d\.\d\.\d$/
 
 before_install:
   - git fetch --tags


### PR DESCRIPTION
mac os x build regex was missing a `v`.