### PR TITLE
Fixes pip install flag for installing pre-releases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ repository:
 
 ::
 
-    $ pip install --dev renku
+    $ pip install --pre renku
     # - OR -
     $ pip install -e git+https://github.com/SwissDataScienceCenter/renku-python.git#egg=renku
 


### PR DESCRIPTION
Fixes a wrong flag in the docs related to installing dev versions of renku via pip