### PR TITLE
Fix zenodo export relative path

### DIFF
--- a/renku/api/datasets.py
+++ b/renku/api/datasets.py
@@ -187,7 +187,12 @@ class DatasetsApiMixin(object):
         # Generate the DatasetFiles
         dataset_files = []
         for data in files:
-            dataset_files.append(DatasetFile.from_revision(self, **data))
+            datasetfile = DatasetFile.from_revision(self, **data)
+
+            # Set dataset file path relative to projects root for submodules
+            if datasetfile.client != self:
+                datasetfile.path = str(data['path'])
+            dataset_files.append(datasetfile)
         dataset.update_files(dataset_files)
 
     def _add_from_url(self, dataset, path, url, link=False, **kwargs):

--- a/renku/cli/_format/graph.py
+++ b/renku/cli/_format/graph.py
@@ -271,7 +271,7 @@ def _rdf2dot_reduced(g, stream):
             fields[sn].add((qname(p, g), formatliteral(o, g)))
 
     for u, n in nodes.items():
-        stream.write(u"# %s %s\n" % (u, n))
+        stream.write(u'# %s %s\n' % (u, n))
         f = [
             '<tr><td align="left"><b>%s</b></td><td align="left">'
             '<b>%s</b></td></tr>' % x for x in sorted(types[n])

--- a/renku/models/datasets.py
+++ b/renku/models/datasets.py
@@ -469,14 +469,11 @@ class Dataset(Entity, CreatorsMixin):
         if self.files:
             for datasetfile in self.files:
                 if datasetfile.client is None:
-                    try:
-                        client, _, _ = self.client.resolve_in_submodules(
-                            self.client.find_previous_commit(
-                                datasetfile.path, revision='HEAD'
-                            ),
-                            datasetfile.path,
-                        )
-                    except KeyError:
-                        client = self.client
+                    client, _, _ = self.client.resolve_in_submodules(
+                        self.client.find_previous_commit(
+                            datasetfile.path, revision='HEAD'
+                        ),
+                        datasetfile.path,
+                    )
 
                     datasetfile.client = client

--- a/renku/models/datasets.py
+++ b/renku/models/datasets.py
@@ -465,3 +465,18 @@ class Dataset(Entity, CreatorsMixin):
 
         if not self.path:
             self.path = str(self.client.renku_datasets_path / str(self.uid))
+
+        if self.files:
+            for datasetfile in self.files:
+                if datasetfile.client is None:
+                    try:
+                        client, _, _ = self.client.resolve_in_submodules(
+                            self.client.find_previous_commit(
+                                datasetfile.path,
+                                revision='HEAD'),
+                            datasetfile.path,
+                        )
+                    except KeyError:
+                        client = self.client
+
+                    datasetfile.client = client

--- a/renku/models/datasets.py
+++ b/renku/models/datasets.py
@@ -88,7 +88,7 @@ class Creator(object):
     def check_email(self, attribute, value):
         """Check that the email is valid."""
         if self.email and not (
-            isinstance(value, str) and re.match(r"[^@]+@[^@]+\.[^@]+", value)
+            isinstance(value, str) and re.match(r'[^@]+@[^@]+\.[^@]+', value)
         ):
             raise ValueError('Email address is invalid.')
 
@@ -472,8 +472,8 @@ class Dataset(Entity, CreatorsMixin):
                     try:
                         client, _, _ = self.client.resolve_in_submodules(
                             self.client.find_previous_commit(
-                                datasetfile.path,
-                                revision='HEAD'),
+                                datasetfile.path, revision='HEAD'
+                            ),
                             datasetfile.path,
                         )
                     except KeyError:

--- a/renku/models/provenance/agents.py
+++ b/renku/models/provenance/agents.py
@@ -54,7 +54,7 @@ class Person:
     @email.validator
     def check_email(self, attribute, value):
         """Check that the email is valid."""
-        if not (isinstance(value, str) and re.match(r"[^@]+@[^@]+", value)):
+        if not (isinstance(value, str) and re.match(r'[^@]+@[^@]+', value)):
             raise ValueError('Email address "{0}" is invalid.'.format(value))
 
     @classmethod


### PR DESCRIPTION

# Description

Sets the `client` property of files in a dataset after the dataset has been loaded. This is needed to ensure the `full_path` property of files returns the correct path to a file irrespective of the current working directory.

Also adds a new unit test to check for this case

Fixes #617

## Type of change

Please select relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

**Do not create pull request unless you checked all points.**

- [X] I have read and understood the **CONTRIBUTING** document.
- [X] I have performed a self-review of my own code.
- [X] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [X] I have added tests to cover my changes.
- [X] I have **NOT** removed any existing tests.
- [X] I have updated the documentation accordingly.
- [X] I have described *all* changes in the **CHANGELOG.rst**.
- [X] I have run ``./run-tests.sh`` locally.
