### PR TITLE
FIX: Add better error message when metadata is missing in zenodo export

### DIFF
--- a/renku/cli/_providers/zenodo.py
+++ b/renku/cli/_providers/zenodo.py
@@ -68,7 +68,11 @@ def check_or_raise(response):
                 for err in err_response['errors']
             ]
 
-            raise HTTPError('\n' + '\n'.join(errors))
+            raise HTTPError(
+                '\n' + '\n'.join(errors) +
+                '\nSee `renku dataset edit -h` for details on how to edit'
+                ' metadata'
+            )
 
         else:
             raise HTTPError(response.content)


### PR DESCRIPTION


# Description

Adds a small hint about `renku dataset edit` to the Zenodo export command error message if metadata is missing. 

Not a huge improvement but since metadata will be overhauled anyways it should at least help (power-)users to figure things out until that is done.

Fixes #618 

## Type of change

Please select relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
