### PR TITLE
add human commiter to KG and clean up dataset creator ids

### DIFF
--- a/renku/models/datasets.py
+++ b/renku/models/datasets.py
@@ -69,7 +69,7 @@ class Creator(object):
         context='schema:name'
     )
 
-    _id = jsonld.ib(default=None, kw_only=True, context='@id')
+    _id = jsonld.ib(kw_only=True, context='@id')
 
     @property
     def short_name(self):
@@ -123,10 +123,18 @@ class Creator(object):
         """Create an instance from a Git commit."""
         return cls(name=commit.author.name, email=commit.author.email)
 
+    @_id.default
+    def default_id(self):
+        """Set the default id."""
+        if self.email:
+            return 'mailto:{email}'.format(email=self.email)
+        return '_' + str(uuid.uuid4())
+
     def __attrs_post_init__(self):
-        """Post-Init hook to set _id field."""
-        if not self._id:
-            self._id = 'mailto:{self.email}'.format(self=self)
+        """Finish object initialization."""
+        # handle the case where ids were improperly set
+        if self._id == 'mailto:None':
+            self._id = '_' + str(uuid.uuid4())
 
 
 @attr.s

--- a/renku/models/provenance/activities.py
+++ b/renku/models/provenance/activities.py
@@ -29,7 +29,7 @@ from renku.models.cwl import WORKFLOW_STEP_RUN_TYPES
 from renku.models.cwl._ascwl import CWLClass
 from renku.models.cwl.types import PATH_OBJECTS
 
-from .agents import renku_agent
+from .agents import Person, renku_agent
 from .entities import Collection, CommitMixin, Entity, Process, Workflow
 from .qualified import Association, Generation, Usage
 
@@ -102,6 +102,7 @@ class Activity(CommitMixin):
     )
 
     agent = jsonld.ib(context='prov:agent', kw_only=True, default=renku_agent)
+    person_agent = jsonld.ib(context='prov:agent', kw_only=True)
 
     @generated.default
     def default_generated(self):
@@ -219,6 +220,13 @@ class Activity(CommitMixin):
     def default_ended_at_time(self):
         """Configure calculated properties."""
         return self.commit.committed_datetime.isoformat()
+
+    @person_agent.default
+    def default_person_agent(self):
+        """Set person agent to be the author of the commit."""
+        if self.commit:
+            return Person.from_commit(self.commit)
+        return None
 
     @property
     def nodes(self):


### PR DESCRIPTION
This PR:

* prevents the creation of nodes with `mailto:None` ids - instead, if we don't have obvious identifying information like an email or an orcid-id we simply generate a blank node
* adds the `Person` `prov:agent` to the commit activity - this is the human agent that created the commit

This is a sample graph:

![noname gv](https://user-images.githubusercontent.com/3353586/63513676-280de700-c4e7-11e9-99d2-1be4492b6f39.png)


Fixes #634 
Fixes #632
