### PR TITLE
fix: use correct paths during migration

### DIFF
--- a/renku/cli/migrate.py
+++ b/renku/cli/migrate.py
@@ -64,8 +64,7 @@ def datasets(ctx, client):
         new_path.parent.mkdir(parents=True, exist_ok=True)
 
         dataset = dataset.rename_files(
-            lambda key: os.path.
-            relpath(str(old_path.parent / key), start=str(new_path.parent))
+            lambda key: old_path.parent / key
         )
 
         with new_path.open('w') as fp:

--- a/renku/models/datasets.py
+++ b/renku/models/datasets.py
@@ -434,7 +434,20 @@ class Dataset(Entity, CreatorsMixin):
 
         for file_ in self.files:
             new_path = rename(file_.path)
-            new_file = attr.evolve(file_, path=new_path)
+            client, commit, path = self.client.resolve_in_submodules(
+                self.client.find_previous_commit(new_path, revision='HEAD'),
+                new_path,
+            )
+            new_file = attr.evolve(
+                file_,
+                path=new_path.relative_to(self.client.path),
+                dataset=self.name,
+                client=client,
+                commit=commit
+            )
+            new_file._id = new_file.default_id()
+            new_file._label = new_file.default_label()
+
             if not self.find_file(new_file.path):
                 files.append(new_file)
             else:


### PR DESCRIPTION

Ensure that the paths in migrated `DatasetFile`s are relative to the project root

Fixes #636 

## Checklist

**Do not create pull request unless you checked all points.**

- [x] I have performed a self-review of my own code.
- [ ] I have added tests to cover my changes.
- [x] I have **NOT** removed any existing tests.
- [ ] I have run ``./run-tests.sh`` locally.
