### PR TITLE
fix: use latest_html for version check

### DIFF
--- a/renku/cli/_providers/zenodo.py
+++ b/renku/cli/_providers/zenodo.py
@@ -31,7 +31,6 @@ from renku._compat import Path
 from renku.cli._providers.api import ExporterApi, ProviderApi
 from renku.cli._providers.doi import DOIProvider
 from renku.models.datasets import Dataset, DatasetFile
-from renku.utils.doi import is_doi
 
 ZENODO_BASE_URL = 'https://zenodo.org'
 ZENODO_SANDBOX_URL = 'https://sandbox.zenodo.org/'
@@ -190,7 +189,7 @@ class ZenodoRecordSerializer:
 
     owner = attr.ib(default=None, kw_only=True)
 
-    record_id = attr.ib(default=None, kw_only=True)
+    record_id = attr.ib(default=None, kw_only=True, converter=str)
 
     state = attr.ib(default=None, kw_only=True)
 
@@ -212,12 +211,10 @@ class ZenodoRecordSerializer:
         return self.metadata.version
 
     def is_last_version(self, uri):
-        """Check if record is at last possible version."""
-        if is_doi(uri):
-            return uri == self.metadata.prereserve_doi['doi']
-
-        record_id = self.metadata.prereserve_doi['recid']
-        return ZenodoProvider.record_id(uri) == record_id
+        """Check if this record is the latest version."""
+        return ZenodoProvider.record_id(
+            self.links.get('latest_html')
+        ) == self.record_id
 
     def get_jsonld(self):
         """Get record metadata as jsonld."""

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -559,7 +559,9 @@ def import_(ctx, client, uri, name, extract):
 
         text_prompt = 'Do you wish to download this version?'
         if record.is_last_version(uri) is False:
-            text_prompt = WARNING + 'Newer version found.\n' + text_prompt
+            text_prompt = WARNING + 'Newer version found at {}\n'.format(
+                record.links.get('latest_html')
+            ) + text_prompt
 
     except KeyError as e:
         raise BadParameter((

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -87,17 +87,17 @@ def test_dataset_import_real_param(doi, runner, project):
 def test_dataset_import_real_doi_warnings(runner, project):
     """Test dataset import for existing DOI and dataset"""
     result = runner.invoke(
-        cli.cli, ['dataset', 'import', '10.5281/zenodo.597964'], input='y'
+        cli.cli, ['dataset', 'import', '10.5281/zenodo.1438326'], input='y'
     )
     assert 0 == result.exit_code
-    assert 'Warning: Newer version found.' in result.output
+    assert 'Warning: Newer version found' in result.output
     assert 'OK'
 
     result = runner.invoke(
-        cli.cli, ['dataset', 'import', '10.5281/zenodo.597964'], input='y\ny'
+        cli.cli, ['dataset', 'import', '10.5281/zenodo.1438326'], input='y\ny'
     )
     assert 0 == result.exit_code
-    assert 'Warning: Newer version found.' in result.output
+    assert 'Warning: Newer version found' in result.output
     assert 'Warning: This dataset already exists.' in result.output
     assert 'OK' in result.output
 
@@ -105,8 +105,8 @@ def test_dataset_import_real_doi_warnings(runner, project):
         cli.cli, ['dataset', 'import', '10.5281/zenodo.597964'], input='y\nn'
     )
     assert 0 == result.exit_code
-    assert 'Warning: Newer version found.' in result.output
-    assert 'Warning: This dataset already exists.' in result.output
+    assert 'Warning: Newer version found' not in result.output
+    assert 'Warning: This dataset already exists.' not in result.output
     assert 'OK' not in result.output
 
     result = runner.invoke(cli.cli, ['dataset'])


### PR DESCRIPTION
Also changes the integration test, which was previously
passing for the wrong reasons - it was always using the
"concept" doi so it should have never shown the
"newer version exists" message.

closes #641

- [x] I have run ``./run-tests.sh`` locally.
