### PR TITLE
fix: always add commit to dataset if possible

### DIFF
--- a/renku/api/datasets.py
+++ b/renku/api/datasets.py
@@ -50,7 +50,7 @@ class DatasetsApiMixin(object):
     @property
     def renku_datasets_path(self):
         """Return a ``Path`` instance of Renku dataset metadata folder."""
-        return self.renku_path.joinpath(self.DATASETS)
+        return Path(self.renku_home).joinpath(self.DATASETS)
 
     def datasets_from_commit(self, commit=None):
         """Return datasets defined in a commit."""
@@ -80,11 +80,11 @@ class DatasetsApiMixin(object):
             result[path] = self.get_dataset(path)
         return result
 
-    def get_dataset(self, path):
+    def get_dataset(self, path, commit=None):
         """Return a dataset from a given path."""
         if not path.is_absolute():
             path = self.path / path
-        return Dataset.from_yaml(path, client=self)
+        return Dataset.from_yaml(path, client=self, commit=commit)
 
     def dataset_path(self, name):
         """Get dataset path from name."""

--- a/renku/models/_jsonld.py
+++ b/renku/models/_jsonld.py
@@ -315,7 +315,7 @@ class JSONLDMixin(ReferenceMixin):
         data,
         __reference__=None,
         __source__=None,
-        **kwargs,
+        **kwargs
     ):
         """Instantiate a JSON-LD class from data."""
         if isinstance(data, cls):

--- a/renku/models/_jsonld.py
+++ b/renku/models/_jsonld.py
@@ -313,9 +313,9 @@ class JSONLDMixin(ReferenceMixin):
     def from_jsonld(
         cls,
         data,
-        client=None,
         __reference__=None,
         __source__=None,
+        **kwargs,
     ):
         """Instantiate a JSON-LD class from data."""
         if isinstance(data, cls):
@@ -331,7 +331,7 @@ class JSONLDMixin(ReferenceMixin):
             ) != type_:
                 new_cls = cls.__type_registry__[type_]
                 if cls != new_cls:
-                    return new_cls.from_jsonld(data, client=client)
+                    return new_cls.from_jsonld(data, **kwargs)
 
         if cls._jsonld_translate:
             data = ld.compact(data, {'@context': cls._jsonld_translate})
@@ -352,9 +352,7 @@ class JSONLDMixin(ReferenceMixin):
 
         fields = cls._jsonld_fields
 
-        data_ = {}
-        if client:
-            data_['client'] = client
+        data_ = kwargs
 
         for k, v in compacted.items():
             if k in fields:
@@ -372,7 +370,7 @@ class JSONLDMixin(ReferenceMixin):
         return self
 
     @classmethod
-    def from_yaml(cls, path, client=None):
+    def from_yaml(cls, path, **kwargs):
         """Return an instance from a YAML file."""
         import yaml
 
@@ -380,9 +378,9 @@ class JSONLDMixin(ReferenceMixin):
             source = yaml.safe_load(fp) or {}
             self = cls.from_jsonld(
                 source,
-                client=client,
                 __reference__=path,
                 __source__=deepcopy(source),
+                **kwargs
             )
 
         return self

--- a/renku/models/_jsonld.py
+++ b/renku/models/_jsonld.py
@@ -313,9 +313,10 @@ class JSONLDMixin(ReferenceMixin):
     def from_jsonld(
         cls,
         data,
+        client=None,
+        commit=None,
         __reference__=None,
         __source__=None,
-        **kwargs
     ):
         """Instantiate a JSON-LD class from data."""
         if isinstance(data, cls):
@@ -331,7 +332,9 @@ class JSONLDMixin(ReferenceMixin):
             ) != type_:
                 new_cls = cls.__type_registry__[type_]
                 if cls != new_cls:
-                    return new_cls.from_jsonld(data, **kwargs)
+                    return new_cls.from_jsonld(
+                        data, client=client, commit=commit
+                    )
 
         if cls._jsonld_translate:
             data = ld.compact(data, {'@context': cls._jsonld_translate})
@@ -352,7 +355,10 @@ class JSONLDMixin(ReferenceMixin):
 
         fields = cls._jsonld_fields
 
-        data_ = kwargs
+        data_ = {}
+        if client:
+            data_['client'] = client
+            data_['commit'] = commit
 
         for k, v in compacted.items():
             if k in fields:
@@ -370,7 +376,7 @@ class JSONLDMixin(ReferenceMixin):
         return self
 
     @classmethod
-    def from_yaml(cls, path, **kwargs):
+    def from_yaml(cls, path, client=None, commit=None):
         """Return an instance from a YAML file."""
         import yaml
 
@@ -378,11 +384,11 @@ class JSONLDMixin(ReferenceMixin):
             source = yaml.safe_load(fp) or {}
             self = cls.from_jsonld(
                 source,
+                client=client,
+                commit=commit,
                 __reference__=path,
-                __source__=deepcopy(source),
-                **kwargs
+                __source__=deepcopy(source)
             )
-
         return self
 
     def asjsonld(self):

--- a/renku/models/datasets.py
+++ b/renku/models/datasets.py
@@ -467,7 +467,7 @@ class Dataset(Entity, CreatorsMixin):
         return self.files.pop(index)
 
     def __attrs_post_init__(self):
-        """Post-Init hook to set _id field."""
+        """Post-Init hook."""
         self._id = self.identifier
 
         if not self._label:
@@ -487,3 +487,11 @@ class Dataset(Entity, CreatorsMixin):
                     )
 
                     datasetfile.client = client
+
+        try:
+            self.commit = self.client.find_previous_commit(
+                self.path, revision=self.commit or 'HEAD'
+            )
+        except KeyError:
+            # if with_dataset is used, the dataset is not committed yet
+            pass

--- a/renku/models/provenance/entities.py
+++ b/renku/models/provenance/entities.py
@@ -18,6 +18,7 @@
 """Represent provenance entities."""
 
 import weakref
+from pathlib import Path
 
 import attr
 
@@ -76,6 +77,13 @@ class CommitMixin:
         """Generate a default location."""
         if self.client:
             return self.client.project
+
+    def __attrs_post_init__(self):
+        """Post-init hook."""
+        if self.path:
+            path = Path(self.path)
+            if path.is_absolute():
+                self.path = str(path.relative_to(self.client.path))
 
 
 @jsonld.s(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -88,7 +88,6 @@ def test_data_add(
         assert not os.access(
             'data/dataset/file', stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         )
-        # assert os.stat('data/dataset/file/metadata.yml')
 
         # check the linking
         if scheme in ('', 'file://'):


### PR DESCRIPTION
Always add a `commit` to `Dataset` if possible - in the case where a dataset is first being created with `with_dataset`, it won't have been committed yet.

This addresses #646 but needs the resolution of #639 for a full solution. 

- [x] I have run ``./run-tests.sh`` locally.
