### PR TITLE
feat: support for indirect inputs and outputs

### DIFF
--- a/renku/cli/run.py
+++ b/renku/cli/run.py
@@ -118,6 +118,25 @@ done when invoking a command:
 
 .. warning:: Detecting inputs and outputs from pipes ``|`` is not supported.
 
+Specifying inputs and outputs programmatically
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes the list of inputs and outputs are not known before execution of the
+program. For example, a program might accept a date range as input and access
+all files within that range during its execution.
+
+To address this issue, the program can dump a list of input and output files
+that it is accessing in ``inputs.txt`` and ``outputs.txt``. Each line in these
+files is expected to be the path to an input or output file within the
+project's directory. When the program is finished, Renku will look for
+existence of these two files and adds their content to the list of explicit
+inputs and outputs. Renku will then delete these two files.
+
+By default, Renku looks for these two files in ``.renku/tmp`` directory. One
+can change this default location by setting ``RENKU_FILELIST_PATH``
+environment variable. When set, it points to the directory within the
+project's directory where ``inputs.txt`` and ``outputs.txt`` reside.
+
 Exit codes
 ~~~~~~~~~~
 
@@ -126,8 +145,8 @@ All Unix commands return a number between 0 and 255 which is called
 (-10 is equivalent to 246, 257 is equivalent to 1). The exit-code 0 represents
 a *success* and non-zero exit-code indicates a *failure*.
 
-Therefore the command speficied after ``renku run`` is expected to return
-exit-code 0. If the command returns different exit code, you can speficy them
+Therefore the command specified after ``renku run`` is expected to return
+exit-code 0. If the command returns different exit code, you can specify them
 with ``--success-code=<INT>`` parameter.
 
 .. code-block:: console

--- a/tests/cli/test_indirect.py
+++ b/tests/cli/test_indirect.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test behavior of indirect inputs/outputs files list."""
+
+
+def test_indirect_inputs(cli, client):
+    """Test indirect inputs that are programmatically created."""
+    # Set up a script that creates indirect inputs
+    cli('run', '--no-output', 'mkdir', 'foo')
+    cli('run', '--no-output', 'mkdir', '.renku/tmp')
+    cli('run', 'touch', 'foo/bar')
+    cli('run', 'touch', 'baz')
+    cli('run', 'touch', 'qux')
+    cli(
+        'run', 'sh', '-c',
+        'echo "echo foo > .renku/tmp/inputs.txt" > script.sh'
+    )
+    cli(
+        'run', 'sh', '-c',
+        'echo "echo baz >> .renku/tmp/inputs.txt" >> script.sh'
+    )
+    cli(
+        'run', 'sh', '-c',
+        'echo "echo qux > .renku/tmp/outputs.txt" >> script.sh'
+    )
+
+    exit_code, cwl = cli('run', 'sh', '-c', 'sh script.sh')
+    assert exit_code == 0
+
+    assert len(cwl.inputs) == 3
+    cwl.inputs.sort(key=lambda e: e.type)
+    assert str(cwl.inputs[0].default) == '../../foo'
+    assert cwl.inputs[0].type == 'Directory'
+    assert cwl.inputs[0].inputBinding is None
+    assert str(cwl.inputs[1].default) == '../../baz'
+    assert cwl.inputs[1].type == 'File'
+    assert cwl.inputs[1].inputBinding is None
+
+    assert len(cwl.outputs) == 1
+    assert cwl.outputs[0].outputBinding.glob == 'qux'


### PR DESCRIPTION
# Description

Renku can read additional lists of inputs and inputs from files. When execution of a script finishes and before any further processing, Renku looks for existence of `.renku/tmp/inputs.txt` and `.renku/tmp/outputs.txt`. Each line in these files correspond to a filename in the Renku project directory. Renku marks all these filenames as explicit inputs and outputs and deletes those two files. It then resumes the rest of the processing.  

Renku delete the `inputs.txt` and `outputs.txt` files before running the script.

The location of these two files within the Renku project directory can be controlled by setting `RENKU_FILELIST_PATH` environment variable. If set, it points to the directory within the project directory which `inputs.txt` and `outputs.txt` reside.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/630

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

**Do not create pull request unless you checked all points.**

- [ ] I have read and understood the **CONTRIBUTING** document.
- [x] I have performed a self-review of my own code.
- [ ] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [x] I have added tests to cover my changes.
- [x] I have **NOT** removed any existing tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have described *all* changes in the **CHANGELOG.rst**.
- [x] I have run ``./run-tests.sh`` locally.