### PR TITLE
fix: adds _label and commit data to imported dataset files, single commit for imports

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -315,7 +315,7 @@ def add_to_dataset(
                 dataset.update_metadata(with_metadata)
 
     except FileNotFoundError:
-        raise BadParameter('Could not process {0}'.format(', '.join(urls)))
+        raise BadParameter('Could not process \n{0}'.format('\n'.join(urls)))
 
 
 @dataset.command('ls-files')

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -288,15 +288,14 @@ def add_to_dataset(
         with client.with_dataset(name=name) as dataset:
             target = target if target else None
             with progressbar(urls, label='Adding data to dataset') as bar:
-                for url in bar:
-                    client.add_data_to_dataset(
-                        dataset,
-                        url,
-                        link=link,
-                        target=target,
-                        relative_to=relative_to,
-                        force=force,
-                    )
+                client.add_data_to_dataset(
+                    dataset,
+                    bar,
+                    link=link,
+                    target=target,
+                    relative_to=relative_to,
+                    force=force,
+                )
 
             if with_metadata:
 
@@ -309,11 +308,13 @@ def add_to_dataset(
 
                             file_.path = added_.path
                             file_.creator = with_metadata.creator
+                            file_._label = added_._label
+                            file_.commit = added_.commit
 
                 dataset.update_metadata(with_metadata)
 
     except FileNotFoundError:
-        raise BadParameter('Could not process {0}'.format(url))
+        raise BadParameter('Could not process {0}'.format(', '.join(urls)))
 
 
 @dataset.command('ls-files')

--- a/renku/models/datasets.py
+++ b/renku/models/datasets.py
@@ -422,10 +422,16 @@ class Dataset(Entity, CreatorsMixin):
 
     def update_files(self, files):
         """Update files with collection of DatasetFile objects."""
-        to_insert = [
-            new_file
-            for new_file in files if not self.find_file(new_file.path)
-        ]
+        to_insert = []
+
+        for new_file in files:
+            existing_file = self.find_file(new_file.path)
+            if existing_file is None:
+                to_insert.append(new_file)
+            else:
+                existing_file.commit = new_file.commit
+                existing_file._label = new_file._label
+
         self.files += to_insert
 
     def rename_files(self, rename):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -77,7 +77,7 @@ def test_data_add(
                 'email': 'me@example.com',
                 'identifier': 'me_id'
             }]
-            client.add_data_to_dataset(d, '{}{}'.format(scheme, path))
+            client.add_data_to_dataset(d, ['{}{}'.format(scheme, path)])
 
         with open('data/dataset/file') as f:
             assert f.read() == '1234'
@@ -100,7 +100,7 @@ def test_data_add(
                     'identifier': 'me_id'
                 }]
                 client.add_data_to_dataset(
-                    d, '{}{}'.format(scheme, path), nocopy=True
+                    d, ['{}{}'.format(scheme, path)], nocopy=True
                 )
             assert os.path.exists('data/dataset/file')
 
@@ -114,8 +114,7 @@ def test_data_add_recursive(directory_tree, client):
             'identifier': 'me_id'
         }]
         client.add_data_to_dataset(
-            dataset,
-            directory_tree.join('dir2').strpath
+            dataset, [directory_tree.join('dir2').strpath]
         )
 
         assert os.path.basename(
@@ -135,7 +134,7 @@ def dataset_serialization(client, dataset, data_file):
 
     assert all([key in d_dict for key in ('name', 'identifier', 'files')])
     assert not len(d_dict['files'].values())
-    client.add_data_to_dataset(dataset, str(data_file))
+    client.add_data_to_dataset(dataset, [str(data_file)])
     d_dict = dataset.to_dict()
     assert len(d_dict['files'].values())
 
@@ -145,7 +144,7 @@ def test_git_repo_import(client, dataset, tmpdir, data_repository):
     # add data from local repo
     client.add_data_to_dataset(
         dataset,
-        os.path.join(os.path.dirname(data_repository.git_dir), 'dir2')
+        [os.path.join(os.path.dirname(data_repository.git_dir), 'dir2')]
     )
     assert os.stat('data/dataset/dir2/file2')
     assert dataset.files[0].path.endswith('dir2/file2')
@@ -153,7 +152,7 @@ def test_git_repo_import(client, dataset, tmpdir, data_repository):
 
     # check that the creators are properly parsed from commits
     client.add_data_to_dataset(
-        dataset, os.path.dirname(data_repository.git_dir), target='file'
+        dataset, [os.path.dirname(data_repository.git_dir)], target='file'
     )
 
     assert len(dataset.files[1].creator) == 2


### PR DESCRIPTION
closes: #628 

This fixes the bug mentioned in #628 though it does not make DatasetFile properties lazy loading, as that was not the cause of this problem.

When importing a `DatasetFile` via the `renku import` command, the `add_to_dataset` method in `renku/cli/dataset.py` first calls `client.add_data_to_dataset(...)` to add (and commit the files, but then calls `dataset.update_metadata(with_metadata)` to update the metadata. But since `files` are considered metadata by `update_metadata(...)`, the original, uncommitted file entries overwrite the newly created entries.

As this will be reworked soon with the big CLI changes, this is just a quick&dirty hotfix that copies over the labels/commits of the files before they get overwritten (as discussed with @jsam ).

`client.add_data_to_dataset(...)` now takes a list of urls as input and commits them in a single commit, getting rid of the commit spam when importing a dataset with many files.

`dataset.update_files(...)` now actually updates files commits if they get added again instead of just working for new files, though this is not necessary for fixing the issue of this PR. I Just left it in as it makes sense and doesn't break anything. Maybe updating all metadata of the files would be even better. Let me know if this makes sense or not and I can adjust the PR.