### PR TITLE
fix: upload metadata before actual files

### DIFF
--- a/renku/cli/_providers/zenodo.py
+++ b/renku/cli/_providers/zenodo.py
@@ -441,14 +441,14 @@ class ZenodoExporter(ExporterApi):
         # Step 1. Create new deposition
         deposition = ZenodoDeposition(exporter=self)
 
-        # Step 2. Upload all files to created deposition
+        # Step 2. Attach metadata to deposition
+        deposition.attach_metadata(self.dataset)
+
+        # Step 3. Upload all files to created deposition
         with tqdm(total=len(self.dataset.files)) as progressbar:
             for file_ in self.dataset.files:
                 deposition.upload_file(file_.full_path, )
                 progressbar.update(1)
-
-        # Step 3. Attach metadata to deposition
-        deposition.attach_metadata(self.dataset)
 
         # Step 4. Publish newly created deposition
         if publish:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

# Description

There is no validation on the metadata uploaded to Zenodo before hand. Users get error about missing metadata when they uploaded their possible huge data. This PR uploads the metadata first and then uploads the actual files. User would see error before spending much time. I've tested this on Zenodo with a dummy dataset and all files where uploaded along with the metadata.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/625

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

**Do not create pull request unless you checked all points.**

- [ ] I have read and understood the **CONTRIBUTING** document.
- [x] I have performed a self-review of my own code.
- [ ] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [ ] I have added tests to cover my changes.
- [x] I have **NOT** removed any existing tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have described *all* changes in the **CHANGELOG.rst**.
- [x] I have run ``./run-tests.sh`` locally.