### PR TITLE
fix: renku config overwrite when running tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -55,6 +55,19 @@ def runner(monkeypatch):
     return CliRunner()
 
 
+@pytest.fixture
+def config_dir(monkeypatch, tmpdir_factory):
+    """Create a temporary renku config directory."""
+    from renku.api.config import ConfigManagerMixin
+
+    with monkeypatch.context() as m:
+        home_dir = tmpdir_factory.mktemp('fake_home')
+        conf_path = home_dir / 'renku.ini'
+        m.setattr(ConfigManagerMixin, 'config_path', conf_path)
+
+        yield m
+
+
 @pytest.fixture()
 def run_shell():
     """Create a shell cmd runner."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -764,7 +764,7 @@ def test_outputs(runner, project):
 @pytest.mark.skipif(
     shutil.which('docker') is None, reason='requires docker command line'
 )
-def test_image_pull(runner, project):
+def test_image_pull(runner, project, config_dir):
     """Test image pulling."""
     cmd = ['image', 'pull']
     result = runner.invoke(cli.cli, cmd)
@@ -952,7 +952,7 @@ def test_config_load_get_value(client):
     assert 'zenodo' not in config.sections()
 
 
-def test_config_manager_cli(client, runner, project):
+def test_config_manager_cli(client, runner, project, config_dir):
     """Check config command for global cfg."""
     result = runner.invoke(
         cli.cli, [


### PR DESCRIPTION
Runs test with a temporary config directory