### PR TITLE
bug: Adds missing abort to click prompts

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -579,7 +579,9 @@ def import_(ctx, client, uri, name, extract):
              'URI not found.'.format(uri))
         )
 
-    if files_ and click.confirm(text_prompt):
+    click.confirm(text_prompt, abort=True)
+
+    if files_:
         data_folder = tempfile.mkdtemp()
 
         pool_size = min(
@@ -781,5 +783,5 @@ def write_dataset(client, name):
     if client.load_dataset(name=name):
         warn_ = WARNING + 'This dataset already exists.'
         click.echo(warn_)
-        return click.confirm('Do you wish to overwrite it?')
+        return click.confirm('Do you wish to overwrite it?', abort=True)
     return True

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -805,7 +805,7 @@ def test_dataset_overwrite_no_confirm(runner, project):
     result = runner.invoke(
         cli.cli, ['dataset', 'create', 'rokstar'], input='n'
     )
-    assert 0 == result.exit_code
+    assert 1 == result.exit_code
     assert 'OK' not in result.output
 
 


### PR DESCRIPTION
Closes #642 

click prompts in dataset cli command were missing `abort=True`, leading to empty commits being created.