### PR TITLE
bug: Fixes missing commit on generation object for Dataset entities

### DIFF
--- a/renku/models/provenance/activities.py
+++ b/renku/models/provenance/activities.py
@@ -144,7 +144,7 @@ class Activity(CommitMixin):
             if str(path).startswith(
                 os.path.join(client.renku_home, client.DATASETS)
             ):
-                entity = client.get_dataset(Path(path))
+                entity = client.get_dataset(Path(path), commit=commit)
             else:
                 entity = entity_cls(
                     commit=commit,


### PR DESCRIPTION
`commit` was not getting set when loading a `Dataset` node in the graph, resulting in an exception when `renku log`ing to ascii.