### PR TITLE
645 timezone dates

### DIFF
--- a/renku/api/repository.py
+++ b/renku/api/repository.py
@@ -17,10 +17,10 @@
 # limitations under the License.
 """Client for handling a local repository."""
 
-import datetime
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from subprocess import check_output
 
 import attr
@@ -373,6 +373,6 @@ class RepositoryApiMixin(GitCore):
 
         with self.with_metadata() as metadata:
             metadata.name = name
-            metadata.updated = datetime.datetime.utcnow()
+            metadata.updated = datetime.now(timezone.utc)
 
         return str(path)

--- a/renku/cli/_providers/__init__.py
+++ b/renku/cli/_providers/__init__.py
@@ -18,8 +18,8 @@
 """Third party data registry integration."""
 from urllib.parse import urlparse
 
-from renku.cli._providers.zenodo import ZenodoProvider
 from renku.cli._providers.dataverse import DataverseProvider
+from renku.cli._providers.zenodo import ZenodoProvider
 from renku.utils.doi import is_doi
 
 

--- a/renku/models/_jsonld.py
+++ b/renku/models/_jsonld.py
@@ -21,7 +21,7 @@ import json
 import os
 import weakref
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 
 import attr
 from attr._compat import iteritems
@@ -237,6 +237,10 @@ def asjsonld(
             return result
 
         if isinstance(value, datetime):
+            if not value.tzinfo:
+                # set timezone to local timezone
+                tz = datetime.now(timezone.utc).astimezone().tzinfo
+                value = value.replace(tzinfo=tz)
             return value.isoformat()
 
         return value

--- a/renku/models/_tabulate.py
+++ b/renku/models/_tabulate.py
@@ -26,6 +26,8 @@ from tabulate import tabulate as tblte
 def format_cell(cell, datetime_fmt=None):
     """Format a cell."""
     if datetime_fmt and isinstance(cell, datetime):
+        if cell.tzinfo:
+            cell = cell.astimezone()
         return cell.strftime(datetime_fmt)
     return cell
 

--- a/renku/models/datasets.py
+++ b/renku/models/datasets.py
@@ -212,7 +212,7 @@ class DatasetFile(Entity, CreatorsMixin):
     @added.default
     def _now(self):
         """Define default value for datetime fields."""
-        return datetime.datetime.utcnow()
+        return datetime.datetime.now(datetime.timezone.utc)
 
     @filename.default
     def default_filename(self):
@@ -360,7 +360,7 @@ class Dataset(Entity, CreatorsMixin):
     @created.default
     def _now(self):
         """Define default value for datetime fields."""
-        return datetime.datetime.utcnow()
+        return datetime.datetime.now(datetime.timezone.utc)
 
     @property
     def display_name(self):

--- a/renku/models/projects.py
+++ b/renku/models/projects.py
@@ -50,7 +50,7 @@ class Project(object):
     @updated.default
     def _now(self):
         """Define default value for datetime fields."""
-        return datetime.datetime.utcnow()
+        return datetime.datetime.now(datetime.timezone.utc)
 
 
 class ProjectCollection(Collection):

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -17,6 +17,8 @@
 # limitations under the License.
 """Test projects API."""
 
+from datetime import timezone
+
 import yaml
 from freezegun import freeze_time
 
@@ -47,11 +49,11 @@ def test_project_context():
 
 def test_project_serialization():
     """Test project serialization with JSON-LD context."""
-    with freeze_time('2017-03-01 08:00:00') as frozen_time:
+    with freeze_time('2017-03-01T08:00:00.000000+00:00') as frozen_time:
         project = Project(name='demo')
         assert project.name == 'demo'
-        assert project.created == frozen_time()
-        assert project.updated == frozen_time()
+        assert project.created == frozen_time().replace(tzinfo=timezone.utc)
+        assert project.updated == frozen_time().replace(tzinfo=timezone.utc)
 
     data = asjsonld(project)
     assert data['@type'].endswith('Project')


### PR DESCRIPTION
closes #645 

All datetimes are now serialized as full iso strings with timezone information. newly created times are created in UTC (`+00:00` Timezone). Existing datetimes are treated as being in the users local timezone when loaded/for compatibility (eg. `+02:00` timezone in Switzerland right now). 