### PR TITLE
feat: use UI-resolved project path as project ID

### DIFF
--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -31,7 +31,6 @@ from werkzeug.utils import cached_property, secure_filename
 
 from renku.core.compat import Path
 from renku.core.management.config import RENKU_HOME
-from renku.core.models.git import GitURL
 from renku.core.models.projects import Project
 from renku.core.models.refs import LinkReference
 
@@ -139,35 +138,6 @@ class RepositoryApiMixin(GitCore):
         """Return the Project instance."""
         if self.renku_metadata_path.exists():
             return Project.from_yaml(self.renku_metadata_path, client=self)
-
-    @property
-    def remote(self, remote_name='origin'):
-        """Return host, owner and name of the remote if it exists."""
-        host = owner = name = None
-        try:
-            remote_branch = \
-                self.repo.head.reference.tracking_branch()
-            if remote_branch is not None:
-                remote_name = remote_branch.remote_name
-        except TypeError:
-            pass
-
-        try:
-            url = GitURL.parse(self.repo.remotes[remote_name].url)
-
-            # Remove gitlab. unless running on gitlab.com.
-            hostname_parts = url.hostname.split('.')
-            if len(hostname_parts) > 2 and hostname_parts[0] == 'gitlab':
-                hostname_parts = hostname_parts[1:]
-            url = attr.evolve(url, hostname='.'.join(hostname_parts))
-        except IndexError:
-            url = None
-
-        if url:
-            host = url.hostname
-            owner = url.owner
-            name = url.name
-        return {'host': host, 'owner': owner, 'name': name}
 
     @property
     def remote(self, remote_name='origin'):


### PR DESCRIPTION
closes #554

also, updates the `id` of the serialized project if a remote exists and the previous `id` contains `file://`. 

The resulting json-ld looks like:

```
{
  "@context": {
    "schema": "http://schema.org/",
    "prov": "http://www.w3.org/ns/prov#"
  },
  "@id": "https://renkulab.io/projects/rok.roskar/test-init",
  "@type": [
    "prov:Location",
    "schema:Project"
  ],
  "schema:creator": {
    "@id": "mailto:rok.roskar@sdsc.ethz.ch",
    "@type": "schema:Person",
    "schema:email": "rok.roskar@sdsc.ethz.ch",
    "schema:name": "Rok Roskar"
  },
  "schema:dateCreated": "2019-09-20T11:30:38.639529+00:00",
  "schema:dateUpdated": "2019-09-20T11:30:38.641184+00:00",
  "schema:name": "test-init",
  "schema:schemaVersion": "2"
}
```
