### PR TITLE
fix: force current project for entities

### DIFF
--- a/renku/models/provenance/entities.py
+++ b/renku/models/provenance/entities.py
@@ -45,7 +45,7 @@ class CommitMixin:
 
     _id = jsonld.ib(context='@id', kw_only=True)
     _label = jsonld.ib(context='rdfs:label', kw_only=True)
-    _project = jsonld.ib(context='schema:isPartOf', kw_only=True)
+    _project = jsonld.ib(context='schema:isPartOf', kw_only=True, default=None)
 
     @property
     def submodules(self):
@@ -72,18 +72,16 @@ class CommitMixin:
             return '{self.path}@{hexsha}'.format(hexsha=hexsha, self=self)
         return '{hexsha}'.format(hexsha=hexsha, self=self)
 
-    @_project.default
-    def default_project(self):
-        """Generate a default location."""
-        if self.client:
-            return self.client.project
-
     def __attrs_post_init__(self):
         """Post-init hook."""
         if self.path:
             path = Path(self.path)
             if path.is_absolute():
                 self.path = str(path.relative_to(self.client.path))
+
+        # always force "project" to be the current project
+        if self.client:
+            self._project = self.client.project
 
 
 @jsonld.s(


### PR DESCRIPTION
@vfried and @jachro reported a problem that datasets were not showing up in queries for forked projects. This PR forces the project to be set to the current project even if this is not what is recorded in the metadata. This might seem strange, but:

- the information that the dataset/file is already a part of the parent project is already recorded in the KG
- the use is unlikely to scrutinize or use this part of the dataset metadata since it is internal to renku