### PR TITLE
681 add to dataset without submodules

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -65,31 +65,34 @@ URL schemes. For example,
 
     $ renku dataset add my-dataset git+ssh://host.io/namespace/project.git
 
-Sometimes you want to import just a specific path within the parent project.
-In this case, use the ``--target`` flag:
+Sometimes you want to import just specific paths within the parent project.
+In this case, use the ``--source`` or ``-s`` flag:
 
 .. code-block:: console
 
-    $ renku dataset add my-dataset --target relative-path/datafile \
+    $ renku dataset add my-dataset --source path/within/repo/to/datafile \
         git+ssh://host.io/namespace/project.git
 
-To trim part of the path from the parent directory, use the ``--relative-to``
-option. For example, the command above will result in a structure like
+The command above will result in a structure like
 
 .. code-block:: console
 
     data/
       my-dataset/
-        relative-path/
-          datafile
+        datafile
 
-Using instead
+You can use ``--destination`` or ``-d`` flag to change the name of the target
+file or directory. The semantics here are similar to the POSIX copy command:
+if the destination does not exist or if it is a file then the source will be
+renamed; if the destination exists and is a directory the source will be copied
+to it. You will get an error message if you try to move a directory to a file
+or copy multiple files into one.
 
 .. code-block:: console
 
     $ renku dataset add my-dataset \
-        --target relative-path/datafile \
-        --relative-to relative-path \
+        --source path/within/repo/to/datafile \
+        --destination new-dir/new-filename \
         git+ssh://host.io/namespace/project.git
 
 will yield:
@@ -98,7 +101,8 @@ will yield:
 
     data/
       my-dataset/
-        datafile
+        new-dir/
+          new-filename
 
 Tagging a dataset:
 
@@ -380,18 +384,27 @@ def edit(dataset_id):
 @click.argument('name')
 @click.argument('urls', nargs=-1)
 @click.option('--link', is_flag=True, help='Creates a hard link.')
-@click.option('--relative-to', default=None)
-@click.option(
-    '-t',
-    '--target',
-    default=None,
-    multiple=True,
-    help='Target path in the git repo.'
-)
 @click.option(
     '--force', is_flag=True, help='Allow adding otherwise ignored files.'
 )
-def add(name, urls, link, relative_to, target, force):
+@click.option(
+    '-s',
+    '--src',
+    '--source',
+    'sources',
+    default=None,
+    multiple=True,
+    help='Path(s) within remote git repo to be added'
+)
+@click.option(
+    '-d',
+    '--dst',
+    '--destination',
+    'destination',
+    default='',
+    help='Destination file or directory within the dataset path'
+)
+def add(name, urls, link, force, sources, destination):
     """Add data to a dataset."""
     progress = partial(progressbar, label='Adding data to dataset')
     add_file(

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -408,7 +408,13 @@ def add(name, urls, link, force, sources, destination):
     """Add data to a dataset."""
     progress = partial(progressbar, label='Adding data to dataset')
     add_file(
-        urls, name, link, force, relative_to, target, urlscontext=progress
+        urls=urls,
+        name=name,
+        link=link,
+        force=force,
+        sources=sources,
+        destination=destination,
+        urlscontext=progress
     )
 
 

--- a/renku/core/commands/checks/migration.py
+++ b/renku/core/commands/checks/migration.py
@@ -31,7 +31,10 @@ from ..echo import WARNING
 
 def dataset_pre_0_3(client):
     """Return paths of dataset metadata for pre 0.3.4."""
-    return (client.path / 'data').rglob(client.METADATA)
+    project_is_pre_0_3 = int(client.project.version) < 2
+    if project_is_pre_0_3:
+        return (client.path / 'data').rglob(client.METADATA)
+    return []
 
 
 def check_dataset_metadata(client):

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -138,14 +138,14 @@ def add_file(
     name,
     link=False,
     force=False,
-    relative_to=None,
-    target=None,
+    sources=(),
+    destination='',
     with_metadata=None,
     urlscontext=contextlib.nullcontext
 ):
     """Add data file to a dataset."""
     add_to_dataset(
-        client, urls, name, link, force, relative_to, target, with_metadata,
+        client, urls, name, link, force, sources, destination, with_metadata,
         urlscontext
     )
 
@@ -156,25 +156,22 @@ def add_to_dataset(
     name,
     link=False,
     force=False,
-    relative_to=None,
-    target=None,
+    sources=(),
+    destination='',
     with_metadata=None,
     urlscontext=contextlib.nullcontext
 ):
     """Add data to a dataset."""
     try:
         with client.with_dataset(name=name) as dataset:
-            target = target if target else None
-
-            urls = urlscontext(urls)
-            with urls as bar:
+            with urlscontext(urls) as bar:
                 client.add_data_to_dataset(
                     dataset,
                     bar,
                     link=link,
-                    target=target,
-                    relative_to=relative_to,
                     force=force,
+                    sources=sources,
+                    destination=destination,
                 )
 
             if with_metadata:

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -21,11 +21,13 @@ import os
 import re
 import shutil
 import stat
+import tempfile
 import uuid
 import warnings
 from configparser import NoSectionError
 from contextlib import contextmanager
 from pathlib import Path
+from subprocess import PIPE, SubprocessError, run
 from urllib import error, parse
 
 import attr
@@ -34,7 +36,7 @@ import requests
 from renku.core import errors
 from renku.core.management.config import RENKU_HOME
 from renku.core.models.datasets import Creator, Dataset, DatasetFile, \
-    DatasetTag, NoneType
+    DatasetTag
 from renku.core.models.git import GitURL
 from renku.core.models.locals import with_reference
 from renku.core.models.refs import LinkReference
@@ -139,7 +141,14 @@ class DatasetsApiMixin(object):
         dataset.to_yaml()
 
     def add_data_to_dataset(
-        self, dataset, urls, git=False, force=False, **kwargs
+        self,
+        dataset,
+        urls,
+        git=False,
+        force=False,
+        sources=(),
+        destination='',
+        link=False
     ):
         """Import the data into the data directory."""
         dataset_path = self.path / self.datadir / dataset.name
@@ -149,25 +158,18 @@ class DatasetsApiMixin(object):
         for url in urls:
             git = git or check_for_git_repo(url)
 
-            target = kwargs.pop('target', None)
-
             if git:
-                if isinstance(target, (str, NoneType)):
-                    files.extend(
-                        self._add_from_git(
-                            dataset, dataset_path, url, target, **kwargs
-                        )
+                sources = sources or ()
+                files.extend(
+                    self._add_from_git(
+                        dataset, dataset_path, url, sources, destination
                     )
-                else:
-                    for t in target:
-                        files.extend(
-                            self._add_from_git(
-                                dataset, dataset_path, url, t, **kwargs
-                            )
-                        )
+                )
             else:
                 files.extend(
-                    self._add_from_url(dataset, dataset_path, url, **kwargs)
+                    self._add_from_url(
+                        dataset, dataset_path, url, link, destination
+                    )
                 )
 
         ignored = self.find_ignored_paths(*(data['path']
@@ -190,6 +192,9 @@ class DatasetsApiMixin(object):
         # Generate the DatasetFiles
         dataset_files = []
         for data in files:
+            if os.path.basename(str(data['path'])) == '.git':
+                continue
+
             datasetfile = DatasetFile.from_revision(self, **data)
 
             # Set dataset file path relative to projects root for submodules
@@ -198,7 +203,7 @@ class DatasetsApiMixin(object):
             dataset_files.append(datasetfile)
         dataset.update_files(dataset_files)
 
-    def _add_from_url(self, dataset, path, url, link=False, **kwargs):
+    def _add_from_url(self, dataset, dataset_path, url, link, destination):
         """Process an add from url and return the location on disk."""
         u = parse.urlparse(url)
 
@@ -207,16 +212,15 @@ class DatasetsApiMixin(object):
                 '{} URLs are not supported'.format(u.scheme)
             )
 
-        # Respect the directory struture inside the source path.
-        relative_to = kwargs.pop('relative_to', None)
-        if relative_to:
-            dst_path = Path(u.path).resolve().absolute().relative_to(
-                Path(relative_to).resolve().absolute()
-            )
-        else:
-            dst_path = os.path.basename(u.path)
+        if destination:
+            destination = self._resolve_paths(dataset_path,
+                                              [destination]).pop()
 
-        dst = path.joinpath(dst_path).absolute()
+        dst = self.path / dataset_path / destination
+
+        # FIXME raise if destination is a file and source is a directory
+        if dst.exists() and dst.is_dir():
+            dst = dst / Path(u.path).name
 
         if u.scheme in ('', 'file'):
             src = Path(u.path).absolute()
@@ -229,10 +233,10 @@ class DatasetsApiMixin(object):
                     files.extend(
                         self._add_from_url(
                             dataset,
-                            dst,
+                            dataset_path,
                             f.absolute().as_posix(),
                             link=link,
-                            **kwargs
+                            destination=dst
                         )
                     )
                 return files
@@ -274,141 +278,195 @@ class DatasetsApiMixin(object):
             'parent': self
         }]
 
-    def _add_from_git(self, dataset, path, url, target, **kwargs):
-        """Process adding resources from another git repository.
-
-        The submodules are placed in ``.renku/vendors`` and linked
-        to the *path* specified by the user.
-        """
+    def _add_from_git(self, dataset, dataset_path, url, sources, destination):
+        """Process adding resources from another git repository."""
         from git import Repo
-
-        # create the submodule
-        if url.startswith('git@'):
-            url = 'git+ssh://' + url
+        from renku import LocalClient
 
         u = parse.urlparse(url)
-        submodule_path = self.renku_path / 'vendors' / (u.netloc or 'local')
 
-        # Respect the directory struture inside the source path.
-        relative_to = kwargs.get('relative_to', None)
-
-        if u.scheme in ('', 'file'):
+        if u.scheme in ('', 'file') and not url.startswith('git@'):
             try:
-                relative_url = Path(url).resolve().relative_to(self.path)
-            except Exception:
-                relative_url = None
-
-            if relative_url:
-                return [{
-                    'path': url,
-                    'url': url,
-                    'creator': dataset.creator,
-                    'dataset': dataset.name,
-                    'parent': self
-                }]
+                Path(u.path).resolve().relative_to(self.path)
+            except ValueError:
+                pass
+            else:
+                if not destination:
+                    return [{
+                        'path': url,
+                        'url': url,
+                        'creator': dataset.creator,
+                        'dataset': dataset.name,
+                        'parent': self
+                    }]
 
             warnings.warn('Importing local git repository, use HTTPS')
-            # determine where is the base repo path
-            r = Repo(url, search_parent_directories=True)
-            src_repo_path = Path(r.git_dir).parent.resolve()
-            submodule_name = src_repo_path.name
-            submodule_path = submodule_path / str(src_repo_path).lstrip('/')
 
-            # if repo path is a parent, rebase the paths and update url
-            if src_repo_path != Path(u.path):
-                top_target = Path(
-                    u.path
-                ).resolve().absolute().relative_to(src_repo_path)
-                if target:
-                    target = top_target / target
-                else:
-                    target = top_target
-                url = src_repo_path.as_posix()
-        elif u.scheme in {'http', 'https', 'git+https', 'git+ssh'}:
-            submodule_name = os.path.splitext(os.path.basename(u.path))[0]
-            submodule_path = submodule_path.joinpath(
-                os.path.dirname(u.path).lstrip('/'), submodule_name
-            )
+            # determine where is the base repo path
+            repo = Repo(url, search_parent_directories=True)
+            repo_path = Path(repo.git_dir).parent.resolve()
+
+            # if repo path is a parent of the url, treat the url as a source
+            if repo_path != Path(u.path):
+                if sources:
+                    raise errors.UsageError(
+                        'Cannot use --source within local repo subdirectories'
+                    )
+                source = Path(u.path).resolve().relative_to(repo_path)
+                sources = (source, )
+                url = repo_path.as_posix()
+        elif u.scheme in {'http', 'https', 'git+https', 'git+ssh'} or \
+                url.startswith('git@'):
+            repo_path = Path(tempfile.mkdtemp())
+            repo = Repo.clone_from(url, repo_path, recursive=True)
         else:
             raise NotImplementedError(
                 'Scheme {} not supported'.format(u.scheme)
             )
 
-        # FIXME: do a proper check that the repos are not the same
-        if submodule_name not in (s.name for s in self.repo.submodules):
-            if u.scheme in {'http', 'https', 'git+https', 'git+ssh'}:
-                url = self.get_relative_url(url)
+        dataset_path = self.path / dataset_path
 
-            # Submodule in python git does some custom magic that does not
-            # allow for relative URLs, so we call the git function directly
-            self.repo.git.submodule([
-                'add', '--force', '--name', submodule_name, url,
-                submodule_path.relative_to(self.path).as_posix()
-            ])
+        sources = self._resolve_paths(u.path, sources)
+        destination = destination or Path('.')
+        destination = self._resolve_paths(dataset_path, [destination]).pop()
 
-        src = submodule_path / (target or '')
+        dst_root = self.path / dataset_path / destination
 
-        if target and relative_to:
-            relative_to = Path(relative_to)
-            if relative_to.is_absolute():
-                assert u.scheme in {
-                    '', 'file'
-                }, 'Only relative paths can be used with URLs.'
-                target = (Path(url).resolve().absolute() / target).relative_to(
-                    relative_to.resolve()
+        # Get all files from repo that match sources
+        files = set()
+        for file in repo.head.commit.tree.traverse():
+            path = file.path
+            result = self._get_src_and_dst(path, repo_path, sources, dst_root)
+
+            if result:
+                files.add(result)
+
+        # Create metadata and move files to dataset
+        results = []
+        client = LocalClient(repo_path)
+
+        paths = set()
+        for path, src, _ in files:
+            if src.is_dir():
+                continue
+            if src.is_symlink():
+                path = str(src.resolve().relative_to(repo_path))
+            paths.add(path)
+        self._fetch_lfs_files(str(repo_path), paths)
+
+        for path, src, dst in files:
+            if not src.is_dir():
+                creators = []
+                # grab all the creators from the commit history
+                for commit in repo.iter_commits(paths=path):
+                    creator = Creator.from_commit(commit)
+                    if creator not in creators:
+                        creators.append(creator)
+
+                if u.scheme in ('', 'file'):
+                    dst_url = None
+                elif path:
+                    dst_url = '{}/{}'.format(url, path)
+                else:
+                    dst_url = url
+
+                base = DatasetFile.from_revision(
+                    client, path=path, url=url, dataset=None, parent=None
+                )
+
+                results.append({
+                    'path': dst.relative_to(self.path),
+                    'url': dst_url,
+                    'creator': creators,
+                    'dataset': dataset.name,
+                    'parent': self,
+                    'source': base
+                })
+
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(str(src), str(dst))
+
+        return results
+
+    def _resolve_paths(self, root_path, paths):
+        """Check if paths are within a root path and resolve them."""
+        results = set()
+
+        for p in paths:
+            try:
+                root_path = Path(root_path).resolve()
+                path = (root_path / p).resolve().relative_to(root_path)
+            except ValueError:
+                raise errors.InvalidFileOperation(
+                    'File {} is not within path {}'.format(p, root_path)
                 )
             else:
-                # src already includes target so we do not have to append it
-                target = src.relative_to(submodule_path / relative_to)
+                results.add(path)
 
-        # link the target into the data directory
-        dst = self.path / path / (target or '')
+        return results
 
-        # if we have a directory, recurse
-        if src.is_dir():
-            files = []
-            dst.mkdir(parents=True, exist_ok=True)
-            # FIXME get all files from submodule index
-            for f in src.iterdir():
-                try:
-                    files.extend(
-                        self._add_from_git(
-                            dataset,
-                            path,
-                            url,
-                            target=f.relative_to(submodule_path),
-                            **kwargs
-                        )
-                    )
-                except ValueError:
-                    pass  # skip files outside the relative path
-            return files
-
-        if not dst.parent.exists():
-            dst.parent.mkdir(parents=True)
-
-        os.symlink(os.path.relpath(str(src), str(dst.parent)), str(dst))
-
-        # grab all the creators from the commit history
-        git_repo = Repo(str(submodule_path.absolute()))
-        creators = []
-        for commit in git_repo.iter_commits(paths=target):
-            creator = Creator.from_commit(commit)
-            if creator not in creators:
-                creators.append(creator)
-
-        if u.scheme in ('', 'file'):
-            url = None
+    def _get_src_and_dst(self, path, repo_path, sources, dst_root):
+        if not sources:
+            source = Path('.')
         else:
-            url = '{}/{}'.format(url, target)
+            source = None
+            for s in sources:
+                try:
+                    Path(path).relative_to(s)
+                except ValueError:
+                    pass
+                else:
+                    source = s
+                    break
 
-        return [{
-            'path': dst.relative_to(self.path),
-            'url': url,
-            'creator': creators,
-            'dataset': dataset.name,
-            'parent': self
-        }]
+            if not source:
+                return
+
+        src = repo_path / path
+        source_name = Path(source).name
+        relative_path = Path(path).relative_to(source)
+
+        if not dst_root.exists():
+            if len(sources) == 1:
+                dst = dst_root / relative_path
+            else:  # Treat destination as a directory
+                dst = dst_root / source_name / relative_path
+        elif dst_root.is_dir():
+            dst = dst_root / source_name / relative_path
+        else:  # Destination is an existing file
+            if len(sources) == 1 and not src.is_dir():
+                dst = dst_root
+            elif not sources:
+                raise errors.InvalidFileOperation('Cannot copy repo to file')
+            else:
+                raise errors.InvalidFileOperation(
+                    'Cannot copy multiple files or directories to a file'
+                )
+
+        return (path, src, dst)
+
+    def _fetch_lfs_files(self, repo_path, paths):
+        """Fetch and checkout paths that are tracked by Git LFS."""
+        try:
+            output = run(('git', 'lfs', 'ls-files', '--name-only'),
+                         stdout=PIPE,
+                         cwd=repo_path,
+                         universal_newlines=True)
+        except SubprocessError:
+            return
+
+        lfs_files = set(output.stdout.split('\n'))
+        files = lfs_files & paths
+        if not files:
+            return
+
+        try:
+            for path in files:
+                run(['git', 'lfs', 'pull', '--include', path], cwd=repo_path)
+        except KeyboardInterrupt:
+            raise
+        except SubprocessError:
+            pass
 
     def get_relative_url(self, url):
         """Determine if the repo url should be relative."""

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -218,7 +218,6 @@ class DatasetsApiMixin(object):
 
         dst = self.path / dataset_path / destination
 
-        # FIXME raise if destination is a file and source is a directory
         if dst.exists() and dst.is_dir():
             dst = dst / Path(u.path).name
 
@@ -227,6 +226,11 @@ class DatasetsApiMixin(object):
 
             # if we have a directory, recurse
             if src.is_dir():
+                if dst.exists() and not dst.is_dir():
+                    raise errors.InvalidFileOperation(
+                        'Cannot copy directory to a file'
+                    )
+
                 files = []
                 dst.mkdir(parents=True, exist_ok=True)
                 for f in src.iterdir():
@@ -371,7 +375,7 @@ class DatasetsApiMixin(object):
                     dst_url = url
 
                 base = DatasetFile.from_revision(
-                    client, path=path, url=url, dataset=None, parent=None
+                    client, path=path, url=url, creator=creators
                 )
 
                 results.append({
@@ -380,11 +384,11 @@ class DatasetsApiMixin(object):
                     'creator': creators,
                     'dataset': dataset.name,
                     'parent': self,
-                    'source': base
+                    'based_on': base
                 })
 
                 dst.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(str(src), str(dst))
+                shutil.copy(str(src), str(dst))
 
         return results
 

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -172,7 +172,8 @@ class RepositoryApiMixin(GitCore):
     @cached_property
     def project(self):
         """Return the FOAF/PROV representation of the project."""
-        return Project.from_yaml(self.renku_metadata_path, client=self)
+        if self.renku_metadata_path.exists():
+            return Project.from_yaml(self.renku_metadata_path, client=self)
 
     def process_commit(self, commit=None, path=None):
         """Build an :class:`~renku.core.models.provenance.activities.Activity`.

--- a/renku/core/models/datasets.py
+++ b/renku/core/models/datasets.py
@@ -262,6 +262,8 @@ class DatasetFile(Entity, CreatorsMixin):
 
     url = jsonld.ib(default=None, context='schema:url', kw_only=True)
 
+    source = jsonld.ib(default=None, context='schema:isBasedOn', kw_only=True)
+
     @added.default
     def _now(self):
         """Define default value for datetime fields."""
@@ -395,6 +397,8 @@ class Dataset(Entity, CreatorsMixin):
         context='schema:keywords',
         kw_only=True
     )
+
+    source = jsonld.ib(default=None, context='schema:isBasedOn', kw_only=True)
 
     license = jsonld.ib(default=None, context='schema:license', kw_only=True)
 

--- a/renku/core/models/datasets.py
+++ b/renku/core/models/datasets.py
@@ -262,7 +262,9 @@ class DatasetFile(Entity, CreatorsMixin):
 
     url = jsonld.ib(default=None, context='schema:url', kw_only=True)
 
-    source = jsonld.ib(default=None, context='schema:isBasedOn', kw_only=True)
+    based_on = jsonld.ib(
+        default=None, context='schema:isBasedOn', kw_only=True
+    )
 
     @added.default
     def _now(self):
@@ -398,7 +400,9 @@ class Dataset(Entity, CreatorsMixin):
         kw_only=True
     )
 
-    source = jsonld.ib(default=None, context='schema:isBasedOn', kw_only=True)
+    based_on = jsonld.ib(
+        default=None, context='schema:isBasedOn', kw_only=True
+    )
 
     license = jsonld.ib(default=None, context='schema:license', kw_only=True)
 

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -408,6 +408,17 @@ def test_relative_git_import_to_dataset(tmpdir, runner, project, client):
     )
     assert 1 == result.exit_code
 
+    # copy a non-existing source
+    result = runner.invoke(
+        cli,
+        [
+            'dataset', 'add', 'relative', '--source', 'non-existing',
+            str(tmpdir)
+        ],
+        catch_exceptions=True,
+    )
+    assert 2 == result.exit_code
+
 
 def test_dataset_add_with_link(tmpdir, runner, project, client):
     """Test adding data to dataset with --link flag."""

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -396,6 +396,18 @@ def test_relative_git_import_to_dataset(tmpdir, runner, project, client):
         )
     )
 
+    # copy a directory to a file
+    result = runner.invoke(
+        cli,
+        [
+            'dataset', 'add', 'relative', '--source', 'first', '--destination',
+            os.path.join('new', 'first', 'first.txt'),
+            str(tmpdir)
+        ],
+        catch_exceptions=True,
+    )
+    assert 1 == result.exit_code
+
 
 def test_dataset_add_with_link(tmpdir, runner, project, client):
     """Test adding data to dataset with --link flag."""

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -269,7 +269,7 @@ def test_repository_file_to_dataset(runner, project, client):
 
     with client.with_dataset('dataset') as dataset:
         assert dataset.name == 'dataset'
-        assert dataset.find_file('a')
+        assert dataset.find_file('a') is not None
 
 
 def test_relative_import_to_dataset(
@@ -284,33 +284,32 @@ def test_relative_import_to_dataset(
     with client.with_dataset('dataset') as dataset:
         assert dataset.name == 'dataset'
 
-    zero_data = tmpdir.join('data.txt')
+    zero_data = tmpdir.join('zero.txt')
     zero_data.write('zero')
 
     first_level = tmpdir.mkdir('first')
     second_level = first_level.mkdir('second')
 
-    first_data = first_level.join('data.txt')
+    first_data = first_level.join('first.txt')
     first_data.write('first')
 
-    second_data = second_level.join('data.txt')
+    second_data = second_level.join('second.txt')
     second_data.write('second')
 
-    paths = [str(zero_data), str(first_data), str(second_data)]
+    paths = [str(zero_data), str(first_level), str(second_level)]
 
     # add data in subdirectory
     result = runner.invoke(
         cli,
-        ['dataset', 'add', 'dataset', '--relative-to',
-         str(tmpdir)] + paths,
+        ['dataset', 'add', 'dataset'] + paths,
         catch_exceptions=False,
     )
     assert 0 == result.exit_code
 
-    assert os.stat(os.path.join('data', 'dataset', 'data.txt'))
-    assert os.stat(os.path.join('data', 'dataset', 'first', 'data.txt'))
+    assert os.stat(os.path.join('data', 'dataset', 'zero.txt'))
+    assert os.stat(os.path.join('data', 'dataset', 'first', 'first.txt'))
     assert os.stat(
-        os.path.join('data', 'dataset', 'first', 'second', 'data.txt')
+        os.path.join('data', 'dataset', 'first', 'second', 'second.txt')
     )
 
 
@@ -326,16 +325,16 @@ def test_relative_git_import_to_dataset(tmpdir, runner, project, client):
 
     data_repo = git.Repo.init(str(tmpdir))
 
-    zero_data = tmpdir.join('data.txt')
+    zero_data = tmpdir.join('zero.txt')
     zero_data.write('zero')
 
     first_level = tmpdir.mkdir('first')
     second_level = first_level.mkdir('second')
 
-    first_data = first_level.join('data.txt')
+    first_data = first_level.join('first.txt')
     first_data.write('first')
 
-    second_data = second_level.join('data.txt')
+    second_data = second_level.join('second.txt')
     second_data.write('second')
 
     paths = [str(zero_data), str(first_data), str(second_data)]
@@ -346,7 +345,7 @@ def test_relative_git_import_to_dataset(tmpdir, runner, project, client):
     result = runner.invoke(
         cli,
         [
-            'dataset', 'add', 'dataset', '--relative-to',
+            'dataset', 'add', 'dataset', '--source',
             str(first_level),
             str(tmpdir)
         ],
@@ -354,20 +353,48 @@ def test_relative_git_import_to_dataset(tmpdir, runner, project, client):
     )
     assert 0 == result.exit_code
 
-    assert os.stat(os.path.join('data', 'dataset', 'data.txt'))
-    assert os.stat(os.path.join('data', 'dataset', 'second', 'data.txt'))
+    assert os.stat(os.path.join('data', 'dataset', 'first', 'first.txt'))
+    assert os.stat(
+        os.path.join('data', 'dataset', 'first', 'second', 'second.txt')
+    )
 
-    # add data in subdirectory
+    # add data to a non-existing destination
     result = runner.invoke(
         cli,
-        ['dataset', 'add', 'relative', '--relative-to', 'first',
-         str(tmpdir)],
+        [
+            'dataset', 'add', 'relative', '--source', 'first', '--destination',
+            'new',
+            str(tmpdir)
+        ],
         catch_exceptions=False,
     )
     assert 0 == result.exit_code
 
-    assert os.stat(os.path.join('data', 'relative', 'data.txt'))
-    assert os.stat(os.path.join('data', 'relative', 'second', 'data.txt'))
+    assert os.stat(os.path.join('data', 'relative', 'new', 'first.txt'))
+    assert os.stat(
+        os.path.join('data', 'relative', 'new', 'second', 'second.txt')
+    )
+
+    # add data to a existing destination
+    result = runner.invoke(
+        cli,
+        [
+            'dataset', 'add', 'relative', '--source', 'first', '--destination',
+            'new',
+            str(tmpdir)
+        ],
+        catch_exceptions=False,
+    )
+    assert 0 == result.exit_code
+
+    assert os.stat(
+        os.path.join('data', 'relative', 'new', 'first', 'first.txt')
+    )
+    assert os.stat(
+        os.path.join(
+            'data', 'relative', 'new', 'first', 'second', 'second.txt'
+        )
+    )
 
 
 def test_dataset_add_with_link(tmpdir, runner, project, client):
@@ -468,7 +495,7 @@ def test_dataset_file_path_from_subdirectory(runner, project, client):
 
     with client.with_dataset('dataset') as dataset:
         datasetfile = dataset.find_file('a')
-        assert datasetfile
+        assert datasetfile is not None
 
         assert datasetfile.full_path == client.path / 'a'
 

--- a/tests/cli/test_move.py
+++ b/tests/cli/test_move.py
@@ -91,7 +91,7 @@ def test_move_symlinks(data_repository, runner, project, client, destination):
     # add data from local git repo
     result = runner.invoke(
         cli, [
-            'dataset', 'add', 'dataset', '-t', 'file',
+            'dataset', 'add', 'dataset', '-s', 'file',
             data_repository.working_dir
         ],
         catch_exceptions=False
@@ -99,10 +99,7 @@ def test_move_symlinks(data_repository, runner, project, client, destination):
     assert 0 == result.exit_code
 
     src = client.path / client.datadir / 'dataset' / 'file'
-    assert src.is_symlink()
     assert src.exists()
-
-    linked = src.resolve()
 
     result = runner.invoke(
         cli, ['mv', str(src), destination], catch_exceptions=False
@@ -110,7 +107,4 @@ def test_move_symlinks(data_repository, runner, project, client, destination):
     assert 0 == result.exit_code
 
     dst = client.path / destination
-    assert dst.is_symlink()
     assert dst.exists()
-
-    assert linked == dst.resolve()

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -97,9 +97,7 @@ def test_data_add(
                     'email': 'me@example.com',
                     'identifier': 'me_id'
                 }]
-                client.add_data_to_dataset(
-                    d, ['{}{}'.format(scheme, path)], nocopy=True
-                )
+                client.add_data_to_dataset(d, ['{}{}'.format(scheme, path)])
             assert os.path.exists('data/dataset/file')
 
 
@@ -129,13 +127,13 @@ def test_git_repo_import(client, dataset, tmpdir, data_repository):
     )
     assert os.stat('data/dataset/dir2/file2')
     assert dataset.files[0].path.endswith('dir2/file2')
-    assert os.stat('.renku/vendors/local')
 
     # check that the creators are properly parsed from commits
     client.add_data_to_dataset(
-        dataset, [os.path.dirname(data_repository.git_dir)], target='file'
+        dataset, [os.path.dirname(data_repository.git_dir)], sources=['file']
     )
 
+    assert dataset.files[1].name == 'file'
     assert len(dataset.files[1].creator) == 2
     assert all(x.name in ('me', 'me2') for x in dataset.files[1].creator)
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

# Description

This PR removes the need to use submodules for importing datasets from Git repos in Renku. It stores the source of each file added to a dataset by using a `schema:isBasedOn` (https://schema.org/isBasedOnUrl) field to point to the remote file.

It also changes the command line interface: The `--target` and `--relative-to` options are removed from `dataset add` commands. Now, one can use `--source` and `--destination` options to say which files are copied from a remote repo and to which location.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/681
Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/670
closes #214 

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

**Do not create pull request unless you checked all points.**

- [ ] I have read and understood the **CONTRIBUTING** document.
- [ ] I have performed a self-review of my own code.
- [ ] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [x] I have added tests to cover my changes.
- [ ] I have **NOT** removed any existing tests.
- [x] I have updated the documentation accordingly.
- [ ] I have described *all* changes in the **CHANGELOG.rst**.
- [ ] I have run ``./run-tests.sh`` locally.
