### PR TITLE
fix: use commit author for project creator

### DIFF
--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -217,8 +217,13 @@ class RepositoryApiMixin(GitCore):
         """Check if the path is a valid CWL file."""
         return path.startswith(self.cwl_prefix) and path.endswith('.cwl')
 
-    def find_previous_commit(self, paths, revision='HEAD'):
-        """Return a previous commit for a given path."""
+    def find_previous_commit(self, paths, revision='HEAD', return_first=False):
+        """Return a previous commit for a given path starting from ``revision``.
+
+        :param revision: revision to start from, defaults to ``HEAD``
+        :param return_first: show the first commit in the history
+        :raises KeyError: if path is not present in the given commit
+        """
         file_commits = list(self.repo.iter_commits(revision, paths=paths))
 
         if not file_commits:
@@ -228,7 +233,7 @@ class RepositoryApiMixin(GitCore):
                 )
             )
 
-        return file_commits[0]
+        return file_commits[-1 if return_first else 0]
 
     @cached_property
     def workflow_names(self):

--- a/renku/core/models/datasets.py
+++ b/renku/core/models/datasets.py
@@ -340,7 +340,6 @@ def _convert_keyword(keywords):
 @jsonld.s(
     type='schema:Dataset',
     context={
-        'added': 'schema:dateCreated',
         'affiliation': 'schema:affiliation',
         'alternate_name': 'schema:alternateName',
         'email': 'schema:email',
@@ -570,9 +569,10 @@ class Dataset(Entity, CreatorsMixin):
                     dataset_file.client = client
 
         try:
-            self.commit = self.client.find_previous_commit(
-                self.path, revision=self.commit or 'HEAD'
-            )
+            if self.client:
+                self.commit = self.client.find_previous_commit(
+                    self.path, revision=self.commit or 'HEAD'
+                )
         except KeyError:
             # if with_dataset is used, the dataset is not committed yet
             pass

--- a/renku/core/models/jsonld.py
+++ b/renku/core/models/jsonld.py
@@ -401,7 +401,8 @@ class JSONLDMixin(ReferenceMixin):
 
         for migration in set(migrations):
             data = migration(data)
-            __source__ = migration(__source__)
+            if __source__:
+                __source__ = migration(__source__)
 
         if data['@context'] != cls._jsonld_context:
             try:

--- a/renku/core/models/projects.py
+++ b/renku/core/models/projects.py
@@ -78,7 +78,15 @@ class Project(object):
     def __attrs_post_init__(self):
         """Initialize computed attributes."""
         if not self.creator and self.client:
-            self.creator = Creator.from_git(self.client.repo)
+            if self.client.renku_metadata_path.exists():
+                self.creator = Creator.from_commit(
+                    self.client.find_previous_commit(
+                        self.client.renku_metadata_path, return_first=True
+                    ),
+                )
+            else:
+                # this assumes the project is being newly created
+                self.creator = Creator.from_git(self.client.repo)
 
         if not self._id and self.client:
             self._id = self.client.project_id

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -25,7 +25,7 @@ from contextlib import contextmanager
 import git
 import pytest
 
-from renku.core.models.datasets import Creator, DatasetFile
+from renku.core.models.datasets import Creator, Dataset, DatasetFile
 
 
 def _key(client, dataset, filename):
@@ -162,3 +162,25 @@ def test_creator_parse(creators, data_file):
     # creators must be a set or list of dicts or Creator
     with pytest.raises(ValueError):
         f = DatasetFile(path='file', creator=['name'])
+
+
+def test_dataset_serialization(dataset):
+    """Test dataset (de)serialization."""
+    dataset_metadata = dataset.asjsonld()
+    dataset = Dataset.from_jsonld(dataset_metadata)
+
+    # assert that all attributes found in metadata are set in the instance
+    assert dataset.created
+    assert dataset.creator
+    assert dataset.identifier
+    assert dataset.name
+    assert dataset.path
+    assert dataset._project
+
+    # check values
+    assert str(dataset.created.isoformat()) == dataset_metadata.get('created')
+    assert dataset.creator[0].email == dataset_metadata.get('creator'
+                                                            )[0].get('email')
+    assert dataset.identifier == dataset_metadata.get('identifier')
+    assert dataset.name == dataset_metadata.get('name')
+    assert dataset.path == dataset_metadata.get('path')


### PR DESCRIPTION
The PR corrects the wrong behavior that the user executing the git command was being set as the project creator. Instead, if the project creator does not exist, the git history of `.renku/metadata.yml` is searched for the first commit and its author is used as the project creator. 

closes #713 