### PR TITLE
fix: dataset import causes renku exception due to duplicate LocalClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,7 @@ jobs:
       language: python
       env:
         - REQUIREMENTS=release
+      script: pytest -m integration -v
     - stage: integration
       python: "3.7"
       os: linux
@@ -127,6 +128,7 @@ jobs:
       language: python
       env:
         - REQUIREMENTS=release
+      script: pytest -m integration -v
     - stage: integration
       os: linux
       dist: xenial
@@ -141,6 +143,7 @@ jobs:
       language: python
       env:
         - REQUIREMENTS=lowest
+      script: pytest -m integration -v
     - stage: integration
       python: "3.7"
       os: linux
@@ -148,7 +151,7 @@ jobs:
       language: python
       env:
         - REQUIREMENTS=lowest
-
+      script: pytest -m integration -v
     - stage: test OSX
       if: branch = master
       language: generic

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -211,7 +211,7 @@ import yaml
 from renku.core.commands.dataset import add_file, create_dataset, \
     dataset_parent, dataset_remove, edit_dataset, export_dataset, \
     file_unlink, import_dataset, list_files, list_tags, remove_dataset_tags, \
-    tag_dataset
+    tag_dataset_with_client
 from renku.core.commands.echo import WARNING, echo_via_pager
 from renku.core.commands.format.dataset_files import DATASET_FILES_FORMATS
 from renku.core.commands.format.dataset_tags import DATASET_TAGS_FORMATS
@@ -373,7 +373,7 @@ def remove(names):
 @click.option('--force', is_flag=True, help='Allow overwriting existing tags.')
 def tag(name, tag, description, force):
     """Create a tag for a dataset."""
-    tag_dataset(name, tag, description, force)
+    tag_dataset_with_client(name, tag, description, force)
     click.secho('OK', fg='green')
 
 
@@ -426,7 +426,10 @@ def export_(id, provider, publish, tag):
     is_flag=True,
     help='Extract files before importing to dataset.'
 )
-def import_(uri, name, extract):
+@click.option(
+    '-y', '--yes', is_flag=True, help='Confirm unlinking of all files.'
+)
+def import_(uri, name, extract, yes):
     """Import data from a 3rd party provider.
 
     Supported providers: [Zenodo, Dataverse]
@@ -436,6 +439,7 @@ def import_(uri, name, extract):
         name,
         extract,
         with_prompt=True,
-        handle_duplicate_fn=write_dataset
+        handle_duplicate_fn=write_dataset,
+        force=yes
     )
     click.secho('OK', fg='green')

--- a/renku/core/commands/client.py
+++ b/renku/core/commands/client.py
@@ -62,6 +62,14 @@ def pass_local_client(
 
     def new_func(*args, **kwargs):
         ctx = click.get_current_context()
+
+        client = next((a for a in args if isinstance(a, LocalClient)), None)
+        client = client or kwargs.get('client', None)
+
+        if client and isinstance(client, LocalClient):
+            result = ctx.invoke(method, *args, **kwargs)
+            return result
+
         client = ctx.ensure_object(LocalClient)
         stack = contextlib.ExitStack()
 

--- a/renku/core/commands/client.py
+++ b/renku/core/commands/client.py
@@ -62,14 +62,6 @@ def pass_local_client(
 
     def new_func(*args, **kwargs):
         ctx = click.get_current_context()
-
-        client = next((a for a in args if isinstance(a, LocalClient)), None)
-        client = client or kwargs.get('client', None)
-
-        if client and isinstance(client, LocalClient):
-            result = ctx.invoke(method, *args, **kwargs)
-            return result
-
         client = ctx.ensure_object(LocalClient)
         stack = contextlib.ExitStack()
 


### PR DESCRIPTION
Closes #718 

Replaced code with a decorated wrapper function and the actual functionality so a client can be manually passed to the function if necessary. 