### PR TITLE
fix: clean up dataset references when create or add fails

### DIFF
--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -285,6 +285,10 @@ class DatasetNotFound(RenkuException, click.ClickException):
         super(DatasetNotFound, self).__init__(msg)
 
 
+class DatasetExistsError(RenkuException, click.ClickException):
+    """Raise when trying to create an existing dataset."""
+
+
 class ExternalStorageNotInstalled(RenkuException, click.ClickException):
     """Raise when LFS is required but not found or installed in the repo."""
 

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -110,11 +110,19 @@ class DatasetsApiMixin(object):
     def with_dataset(self, name=None):
         """Yield an editable metadata object for a dataset."""
         dataset = self.load_dataset(name=name)
+        clean_up_required = False
 
         if dataset is None:
+            clean_up_required = True
+            dataset_ref = None
             identifier = str(uuid.uuid4())
             path = (self.renku_datasets_path / identifier / self.METADATA)
-            path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                path.parent.mkdir(parents=True, exist_ok=False)
+            except FileExistsError:
+                raise errors.DatasetExistsError(
+                    'Dataset with reference {} exists'.format(path.parent)
+                )
 
             with with_reference(path):
                 dataset = Dataset(
@@ -122,13 +130,23 @@ class DatasetsApiMixin(object):
                 )
 
             if name:
-                LinkReference.create(client=self, name='datasets/' +
-                                     name).set_reference(path)
+                dataset_ref = LinkReference.create(
+                    client=self, name='datasets/' + name
+                )
+                dataset_ref.set_reference(path)
 
         dataset_path = self.path / self.datadir / dataset.name
         dataset_path.mkdir(parents=True, exist_ok=True)
 
-        yield dataset
+        try:
+            yield dataset
+        except Exception:
+            # TODO use a general clean-up strategy
+            # https://github.com/SwissDataScienceCenter/renku-python/issues/736
+            if clean_up_required and dataset_ref:
+                dataset_ref.delete()
+                shutil.rmtree(path.parent, ignore_errors=True)
+            raise
 
         # TODO
         # if path is None:

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1147,3 +1147,17 @@ def test_dataset_rm_tags_failure(tmpdir, runner, project, client):
         catch_exceptions=False,
     )
     assert 2 == result.exit_code
+
+
+def test_dataset_clean_up_when_add_fails(runner, client):
+    """Test project is cleaned when dataset add fails for a new dataset."""
+    # add a non-existing path to a new dataset
+    result = runner.invoke(
+        cli,
+        ['dataset', 'add', 'new-dataset', 'non-existing-file'],
+        catch_exceptions=True,
+    )
+
+    assert result.exit_code == 1
+    ref = client.renku_path / 'refs' / 'datasets' / 'new-dataset'
+    assert not ref.is_symlink() and not ref.exists()


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

# Description

When creating a dataset (either directly or via add command) fails, we cannot repeat the command by some weird error message. This is because symbolic references to dataset metadata is created and not removed upon an error. This PR fixes this issue by cleaning up after a failure.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/684

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

**Do not create pull request unless you checked all points.**

- [ ] I have read and understood the **CONTRIBUTING** document.
- [ ] I have performed a self-review of my own code.
- [ ] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [x] I have added tests to cover my changes.
- [x] I have **NOT** removed any existing tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have described *all* changes in the **CHANGELOG.rst**.
- [x] I have run ``./run-tests.sh`` locally.
