### PR TITLE
Remove click dependencies from import and export commands

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -206,30 +206,127 @@ Unlink all files from a dataset:
 """
 import click
 import editor
+import requests
 import yaml
+
+from functools import partial
+from tqdm import tqdm
 
 from renku.core.commands.dataset import add_file, create_dataset, \
     dataset_parent, dataset_remove, edit_dataset, export_dataset, \
     file_unlink, import_dataset, list_files, list_tags, remove_dataset_tags, \
     tag_dataset_with_client
-from renku.core.commands.echo import WARNING, echo_via_pager
+from renku.core.commands.echo import WARNING, echo_via_pager, progressbar
 from renku.core.commands.format.dataset_files import DATASET_FILES_FORMATS
 from renku.core.commands.format.dataset_tags import DATASET_TAGS_FORMATS
 from renku.core.commands.format.datasets import DATASETS_FORMATS
+from renku.core.errors import DatasetNotFound, InvalidAccessToken
 
 
-def write_dataset(client, name):
+def prompt_duplicate_dataset(existing_dataset):
     """Check if existing dataset should be overwritten.
-
-    :param client: `LocalClient` instance.
-    :param name: Dataset name.
-    :return: True if dataset exists and user confirmed overwriting.
+    :return: True if user confirmed overwriting.
     """
-    if client.load_dataset(name=name):
-        warn_ = WARNING + 'This dataset already exists.'
-        click.echo(warn_)
-        return click.confirm('Do you wish to overwrite it?', abort=True)
-    return True
+    warn_ = WARNING + 'This dataset already exists.'
+    click.echo(warn_)
+    return click.confirm('Do you wish to overwrite it?', abort=True)
+
+
+def prompt_access_token(exporter):
+    """Prompt user for an access token for a provider.
+    :return: The new access token"""
+    text_prompt = ('You must configure an access token\n')
+    text_prompt += 'Create one at: {0}\n'.format(exporter.access_token_url())
+    text_prompt += 'Access token'
+
+    return click.prompt(text_prompt, type=str)
+
+
+def prompt_tag_selection(tags):
+    """Prompt user to chose a tag or <HEAD>."""
+    # Prompt user to select a tag to export
+    tags = sorted(tags, key=lambda t: t.created)
+
+    text_prompt = 'Tag to export: \n\n<HEAD>\t[1]\n'
+
+    text_prompt += '\n'.join(
+        '{}\t[{}]'.format(t.name, i) for i, t in enumerate(tags, start=2)
+    )
+
+    text_prompt += '\n\nTag'
+    selection = click.prompt(
+        text_prompt, type=click.IntRange(1,
+                                         len(tags) + 1), default=1
+    )
+
+    if selection > 1:
+        return tags[selection - 2]
+    return None
+
+
+def download_file_with_progress(extract, data_folder, file, chunk_size=16384):
+    """Download a file with progress tracking."""
+    global current_process_position
+
+    local_filename = Path(file.filename).name
+    download_to = Path(data_folder) / Path(local_filename)
+
+    def extract_dataset(data_folder_, filename):
+        """Extract downloaded dataset."""
+        import patoolib
+        filepath = Path(data_folder_) / Path(filename)
+        patoolib.extract_archive(filepath, outdir=data_folder_)
+        filepath.unlink()
+
+    def stream_to_file(request):
+        """Stream bytes to file."""
+        with open(str(download_to), 'wb') as f_:
+            scaling_factor = 1e-6
+            unit = 'MB'
+
+            # We round sizes to 0.1, files smaller than 1e5 would
+            # get rounded to 0, so we display bytes instead
+            if file.filesize < 1e5:
+                scaling_factor = 1.0
+                unit = 'B'
+
+            total = round(file.filesize * scaling_factor, 1)
+            progressbar_ = tqdm(
+                total=total,
+                position=current_process_position,
+                desc=file.filename[:32],
+                bar_format=(
+                    '{{percentage:3.0f}}% '
+                    '{{n_fmt}}{unit}/{{total_fmt}}{unit}| '
+                    '{{bar}} | {{desc}}'.format(unit=unit)
+                ),
+                leave=False,
+            )
+
+            try:
+                bytes_downloaded = 0
+                for chunk in request.iter_content(chunk_size=chunk_size):
+                    if chunk:  # remove keep-alive chunks
+                        f_.write(chunk)
+                        bytes_downloaded += chunk_size
+                        progressbar_.n = min(
+                            float(
+                                '{0:.1f}'.format(
+                                    bytes_downloaded * scaling_factor
+                                )
+                            ), total
+                        )
+                        progressbar_.update(0)
+            finally:
+                sleep(0.1)
+                progressbar_.close()
+
+        if extract:
+            extract_dataset(data_folder, local_filename)
+
+    with requests.get(file.url.geturl(), stream=True) as r:
+        r.raise_for_status()
+        stream_to_file(r)
 
 
 @click.group(invoke_without_command=True)
@@ -257,7 +354,7 @@ def dataset(ctx, revision, datadir, format):
 @click.argument('name')
 def create(name):
     """Create an empty dataset in the current repo."""
-    create_dataset(name, handle_duplicate_fn=write_dataset)
+    create_dataset(name, handle_duplicate_fn=prompt_duplicate_dataset)
     click.secho('OK', fg='green')
 
 
@@ -289,7 +386,10 @@ def edit(dataset_id):
 )
 def add(name, urls, link, relative_to, target, force):
     """Add data to a dataset."""
-    add_file(urls, name, link, force, relative_to, target)
+    progress = partial(progressbar, label='Adding data to dataset')
+    add_file(
+        urls, name, link, force, relative_to, target, urlscontext=progress
+    )
 
 
 @dataset.command('ls-files')
@@ -360,7 +460,22 @@ def unlink(name, include, exclude, yes):
 @click.argument('names', nargs=-1)
 def remove(names):
     """Delete a dataset."""
-    dataset_remove(names, with_output=True)
+    datasetscontext = partial(
+        progressbar,
+        label='Removing metadata files'.ljust(30),
+        item_show_func=lambda item: str(item) if item else ''
+    )
+    referencescontext = partial(
+        progressbar,
+        label='Removing aliases'.ljust(30),
+        item_show_func=lambda item: item.name if item else '',
+    )
+    dataset_remove(
+        names,
+        with_output=True,
+        datadatasetscontext=datasetscontext,
+        referencescontext=referencescontext
+    )
     click.secho('OK', fg='green')
 
 
@@ -412,7 +527,20 @@ def ls_tags(name, format):
 @click.option('-t', '--tag', help='Dataset tag to export')
 def export_(id, provider, publish, tag):
     """Export data to 3rd party provider."""
-    output = export_dataset(id, provider, publish, tag, with_prompt=True)
+    try:
+        output = export_dataset(
+            id,
+            provider,
+            publish,
+            tag,
+            handle_access_token_fn=prompt_access_token,
+            handle_tag_selection_fn=prompt_tag_selection
+        )
+    except (
+        ValueError, InvalidAccessToken, DatasetNotFound, requests.HTTPError
+    ) as e:
+        raise click.BadParameter(e)
+
     click.echo(output)
     click.secho('OK', fg='green')
 
@@ -434,12 +562,31 @@ def import_(uri, name, extract, yes):
 
     Supported providers: [Zenodo, Dataverse]
     """
+    manager = mp.Manager()
+    id_queue = manager.Queue()
+
+    for i in range(pool_size):
+        id_queue.put(i)
+
+    def _init(lock, id_queue):
+        """Set up tqdm lock and worker process index.
+
+        See https://stackoverflow.com/a/42817946
+        Fixes tqdm line position when |files| > terminal-height
+        so only |workers| progressbars are shown at a time
+        """
+        global current_process_position
+        current_process_position = id_queue.get()
+        tqdm.set_lock(lock)
+
     import_dataset(
         uri,
         name,
         extract,
         with_prompt=True,
-        handle_duplicate_fn=write_dataset,
+        handle_duplicate_fn=prompt_duplicate_dataset,
+        pool_init_fn=_init,
+        download_file_fn=download_file_with_progress,
         force=yes
     )
     click.secho('OK', fg='green')

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -412,7 +412,7 @@ def ls_tags(name, format):
 @click.option('-t', '--tag', help='Dataset tag to export')
 def export_(id, provider, publish, tag):
     """Export data to 3rd party provider."""
-    output = export_dataset(id, provider, publish, tag)
+    output = export_dataset(id, provider, publish, tag, with_prompt=True)
     click.echo(output)
     click.secho('OK', fg='green')
 

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -204,12 +204,12 @@ Unlink all files from a dataset:
 .. note:: The ``unlink`` command does not delete files,
     only the dataset record.
 """
+from functools import partial
+
 import click
 import editor
 import requests
 import yaml
-
-from functools import partial
 from tqdm import tqdm
 
 from renku.core.commands.dataset import add_file, create_dataset, \
@@ -225,6 +225,7 @@ from renku.core.errors import DatasetNotFound, InvalidAccessToken
 
 def prompt_duplicate_dataset(existing_dataset):
     """Check if existing dataset should be overwritten.
+
     :return: True if user confirmed overwriting.
     """
     warn_ = WARNING + 'This dataset already exists.'
@@ -234,7 +235,9 @@ def prompt_duplicate_dataset(existing_dataset):
 
 def prompt_access_token(exporter):
     """Prompt user for an access token for a provider.
-    :return: The new access token"""
+
+    :return: The new access token
+    """
     text_prompt = ('You must configure an access token\n')
     text_prompt += 'Create one at: {0}\n'.format(exporter.access_token_url())
     text_prompt += 'Access token'
@@ -473,7 +476,7 @@ def remove(names):
     dataset_remove(
         names,
         with_output=True,
-        datadatasetscontext=datasetscontext,
+        datasetscontext=datasetscontext,
         referencescontext=referencescontext
     )
     click.secho('OK', fg='green')

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -314,6 +314,7 @@ def export_dataset(
     :raises: ``ValueError``, ``HTTPError``, ``InvalidAccessToken``,
              ``DatasetNotFound``
     """
+    # TODO: all these callbacks are ugly, improve in #737
     config_key_secret = 'access_token'
     provider_id = provider
 

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -23,9 +23,8 @@ import re
 import tempfile
 from collections import OrderedDict
 from contextlib import contextmanager
-from multiprocessing import RLock, freeze_support
+from multiprocessing import freeze_support
 from pathlib import Path
-from time import sleep
 from urllib.parse import ParseResult
 
 import click
@@ -388,7 +387,8 @@ def import_dataset(
     with_prompt=False,
     force=False,
     handle_duplicate_fn=None,
-    pool_init=None,
+    pool_init_fn=None,
+    pool_init_args=None,
     download_file_fn=default_download_file
 ):
     """Import data from a 3rd party provider."""
@@ -444,11 +444,12 @@ def import_dataset(
         )
 
         freeze_support()  # Windows support
+
         pool = mp.Pool(
             pool_size,
             # Windows support
-            initializer=pool_init,
-            initargs=(RLock(), id_queue)
+            initializer=pool_init_fn,
+            initargs=pool_init_args
         )
 
         processing = [

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -33,12 +33,12 @@ import requests
 import yaml
 from click import BadParameter
 from requests import HTTPError
-from tqdm import tqdm
 
 from renku.core.commands.checks.migration import check_dataset_resources, \
     dataset_pre_0_3
 from renku.core.commands.format.dataset_tags import DATASET_TAGS_FORMATS
 from renku.core.commands.providers import ProviderFactory
+from renku.core.compat import contextlib
 from renku.core.errors import DatasetNotFound, InvalidAccessToken, \
     MigrationRequired
 from renku.core.management.datasets import DATASET_METADATA_PATHS
@@ -48,9 +48,35 @@ from renku.core.models.refs import LinkReference
 from renku.core.models.tabulate import tabulate
 
 from .client import pass_local_client
-from .echo import WARNING, progressbar
+from .echo import WARNING
 from .format.dataset_files import DATASET_FILES_FORMATS
 from .format.datasets import DATASETS_FORMATS
+
+
+def default_download_file(extract, data_folder, file, chunk_size=16384):
+    """Download a file."""
+    local_filename = Path(file.filename).name
+    download_to = Path(data_folder) / Path(local_filename)
+
+    def extract_dataset(data_folder_, filename):
+        """Extract downloaded dataset."""
+        import patoolib
+        filepath = Path(data_folder_) / Path(filename)
+        patoolib.extract_archive(filepath, outdir=data_folder_)
+        filepath.unlink()
+
+    def stream_to_file(request):
+        """Stream bytes to file."""
+        with open(str(download_to), 'wb') as f_:
+            for chunk in request.iter_content(chunk_size=chunk_size):
+                if chunk:  # remove keep-alive chunks
+                    f_.write(chunk)
+        if extract:
+            extract_dataset(data_folder, local_filename)
+
+    with requests.get(file.url.geturl(), stream=True) as r:
+        r.raise_for_status()
+        stream_to_file(r)
 
 
 @pass_local_client(clean=False, commit=False)
@@ -78,7 +104,8 @@ def create_dataset(client, name, handle_duplicate_fn=None):
 
     :raises: ``click.BadParameter``
     """
-    if handle_duplicate_fn and handle_duplicate_fn(client, name):
+    existing = client.load_dataset(name=name)
+    if (not existing or handle_duplicate_fn and handle_duplicate_fn(existing)):
         with client.with_dataset(name=name) as dataset:
             creator = Creator.from_git(client.repo)
             if creator not in dataset.creator:
@@ -114,11 +141,13 @@ def add_file(
     force=False,
     relative_to=None,
     target=None,
-    with_metadata=None
+    with_metadata=None,
+    urlscontext=contextlib.nullcontext
 ):
     """Add data file to a dataset."""
     add_to_dataset(
-        client, urls, name, link, force, relative_to, target, with_metadata
+        client, urls, name, link, force, relative_to, target, with_metadata,
+        urlscontext
     )
 
 
@@ -130,13 +159,16 @@ def add_to_dataset(
     force=False,
     relative_to=None,
     target=None,
-    with_metadata=None
+    with_metadata=None,
+    urlscontext=contextlib.nullcontext
 ):
     """Add data to a dataset."""
     try:
         with client.with_dataset(name=name) as dataset:
             target = target if target else None
-            with progressbar(urls, label='Adding data to dataset') as bar:
+
+            urls = urlscontext(urls)
+            with urls as bar:
                 client.add_data_to_dataset(
                     dataset,
                     bar,
@@ -211,7 +243,13 @@ def file_unlink(client, name, include, exclude):
     commit=True,
     commit_only=COMMIT_DIFF_STRATEGY,
 )
-def dataset_remove(client, names, with_output=False):
+def dataset_remove(
+    client,
+    names,
+    with_output=False,
+    datasetscontext=contextlib.nullcontext,
+    referencescontext=contextlib.nullcontext
+):
     """Delete a dataset."""
     datasets = {name: client.dataset_path(name) for name in names}
 
@@ -243,20 +281,16 @@ def dataset_remove(client, names, with_output=False):
 
         return datasets, references
 
-    with progressbar(
-        datasets,
-        label='Removing metadata files'.ljust(30),
-        item_show_func=lambda item: str(item) if item else '',
-    ) as bar:
+    datasets_c = datasetscontext(datasets)
+
+    with datasets_c as bar:
         for dataset in bar:
             if dataset and dataset.exists():
                 dataset.unlink()
 
-    with progressbar(
-        references,
-        label='Removing aliases'.ljust(30),
-        item_show_func=lambda item: item.name if item else '',
-    ) as bar:
+    references_c = referencescontext(references)
+
+    with references_c as bar:
         for ref in bar:
             if ref.reference in datasets:
                 ref.delete()
@@ -267,19 +301,31 @@ def dataset_remove(client, names, with_output=False):
     commit=True,
     commit_only=COMMIT_DIFF_STRATEGY,
 )
-def export_dataset(client, id, provider, publish, tag, with_prompt=False):
-    """Export data to 3rd party provider."""
+def export_dataset(
+    client,
+    id,
+    provider,
+    publish,
+    tag,
+    handle_access_token_fn=None,
+    handle_tag_selection_fn=None
+):
+    """Export data to 3rd party provider.
+
+    :raises: ``ValueError``, ``HTTPError``, ``InvalidAccessToken``,
+             ``DatasetNotFound``
+    """
     config_key_secret = 'access_token'
     provider_id = provider
 
     dataset_ = client.load_dataset(id)
     if not dataset_:
-        raise BadParameter('Dataset not found.')
+        raise DatasetNotFound()
 
     try:
         provider = ProviderFactory.from_id(provider_id)
     except KeyError:
-        raise BadParameter('Unknown provider.')
+        raise ValueError('Unknown provider.')
 
     selected_tag = None
     selected_commit = client.repo.head.commit
@@ -288,50 +334,29 @@ def export_dataset(client, id, provider, publish, tag, with_prompt=False):
         selected_tag = next((t for t in dataset_.tags if t.name == tag), None)
 
         if not selected_tag:
-            raise BadParameter('Tag {} not found'.format(tag))
+            raise ValueError('Tag {} not found'.format(tag))
 
         selected_commit = selected_tag.commit
-    elif dataset_.tags and len(dataset_.tags) > 0:
-        # Prompt user to select a tag to export
-        tags = sorted(dataset_.tags, key=lambda t: t.created)
+    elif dataset_.tags and len(dataset_.tags) > 0 and handle_tag_selection_fn:
+        tag_result = handle_tag_selection_fn(dataset_.tags)
 
-        text_prompt = 'Tag to export: \n\n<HEAD>\t[1]\n'
-
-        text_prompt += '\n'.join(
-            '{}\t[{}]'.format(t.name, i) for i, t in enumerate(tags, start=2)
-        )
-
-        text_prompt += '\n\nTag'
-
-        if with_prompt:
-            selection = click.prompt(
-                text_prompt, type=click.IntRange(1,
-                                                 len(tags) + 1), default=1
-            )
-
-            if selection > 1:
-                selected_tag = tags[selection - 2]
-                selected_commit = selected_tag.commit
+        if tag_result:
+            selected_tag = tag_result
+            selected_commit = tag_result.commit
 
     with client.with_commit(selected_commit):
         dataset_ = client.load_dataset(id)
         if not dataset_:
-            raise BadParameter('Dataset not found.')
+            raise DatasetNotFound()
 
         access_token = client.get_value(provider_id, config_key_secret)
         exporter = provider.get_exporter(dataset_, access_token=access_token)
 
         if access_token is None:
-            text_prompt = (
-                'Before exporting, you must configure an access'
-                ' token\n'
-            )
-            text_prompt += 'Create one at: {0}\n'.format(
-                exporter.access_token_url()
-            )
-            text_prompt += 'Access token'
 
-            access_token = click.prompt(text_prompt, type=str)
+            if handle_access_token_fn:
+                access_token = handle_access_token_fn(exporter)
+
             if access_token is None or len(access_token) == 0:
                 raise InvalidAccessToken()
 
@@ -344,7 +369,7 @@ def export_dataset(client, id, provider, publish, tag, with_prompt=False):
             if 'unauthorized' in str(e):
                 client.remove_value(provider_id, config_key_secret)
 
-            raise BadParameter(e)
+            raise
 
     result = 'Exported to: {0}'.format(destination)
     return result
@@ -362,7 +387,9 @@ def import_dataset(
     extract,
     with_prompt=False,
     force=False,
-    handle_duplicate_fn=None
+    handle_duplicate_fn=None,
+    pool_init=None,
+    download_file_fn=default_download_file
 ):
     """Import data from a 3rd party provider."""
     provider, err = ProviderFactory.from_uri(uri)
@@ -416,34 +443,17 @@ def import_dataset(
                           mp.cpu_count() // 2)), 4
         )
 
-        manager = mp.Manager()
-        id_queue = manager.Queue()
-
-        for i in range(pool_size):
-            id_queue.put(i)
-
-        def _init(lock, id_queue):
-            """Set up tqdm lock and worker process index.
-
-            See https://stackoverflow.com/a/42817946
-            Fixes tqdm line position when |files| > terminal-height
-            so only |workers| progressbars are shown at a time
-            """
-            global current_process_position
-            current_process_position = id_queue.get()
-            tqdm.set_lock(lock)
-
         freeze_support()  # Windows support
         pool = mp.Pool(
             pool_size,
             # Windows support
-            initializer=_init,
+            initializer=pool_init,
             initargs=(RLock(), id_queue)
         )
 
         processing = [
             pool.apply_async(
-                download_file, args=(
+                download_file_fn, args=(
                     extract,
                     data_folder,
                     file_,
@@ -485,71 +495,6 @@ def import_dataset(
                     'Tag {} created by renku import'.format(dataset.version),
                     force=True
                 )
-
-
-def download_file(extract, data_folder, file, chunk_size=16384):
-    """Download a file with progress tracking."""
-    global current_process_position
-
-    local_filename = Path(file.filename).name
-    download_to = Path(data_folder) / Path(local_filename)
-
-    def extract_dataset(data_folder_, filename):
-        """Extract downloaded dataset."""
-        import patoolib
-        filepath = Path(data_folder_) / Path(filename)
-        patoolib.extract_archive(filepath, outdir=data_folder_)
-        filepath.unlink()
-
-    def stream_to_file(request):
-        """Stream bytes to file."""
-        with open(str(download_to), 'wb') as f_:
-            scaling_factor = 1e-6
-            unit = 'MB'
-
-            # We round sizes to 0.1, files smaller than 1e5 would
-            # get rounded to 0, so we display bytes instead
-            if file.filesize < 1e5:
-                scaling_factor = 1.0
-                unit = 'B'
-
-            total = round(file.filesize * scaling_factor, 1)
-            progressbar_ = tqdm(
-                total=total,
-                position=current_process_position,
-                desc=file.filename[:32],
-                bar_format=(
-                    '{{percentage:3.0f}}% '
-                    '{{n_fmt}}{unit}/{{total_fmt}}{unit}| '
-                    '{{bar}} | {{desc}}'.format(unit=unit)
-                ),
-                leave=False,
-            )
-
-            try:
-                bytes_downloaded = 0
-                for chunk in request.iter_content(chunk_size=chunk_size):
-                    if chunk:  # remove keep-alive chunks
-                        f_.write(chunk)
-                        bytes_downloaded += chunk_size
-                        progressbar_.n = min(
-                            float(
-                                '{0:.1f}'.format(
-                                    bytes_downloaded * scaling_factor
-                                )
-                            ), total
-                        )
-                        progressbar_.update(0)
-            finally:
-                sleep(0.1)
-                progressbar_.close()
-
-        if extract:
-            extract_dataset(data_folder, local_filename)
-
-    with requests.get(file.url.geturl(), stream=True) as r:
-        r.raise_for_status()
-        stream_to_file(r)
 
 
 def _include_exclude(file_path, include=None, exclude=None):

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -266,7 +266,7 @@ def dataset_remove(client, names, with_output=False):
     clean=True,
     commit=True,
     commit_only=COMMIT_DIFF_STRATEGY,
-)  # TODO: Finish refactor (ticket #702)
+)
 def export_dataset(client, id, provider, publish, tag, with_prompt=False):
     """Export data to 3rd party provider."""
     config_key_secret = 'access_token'

--- a/renku/core/compat.py
+++ b/renku/core/compat.py
@@ -20,6 +20,7 @@
 import os
 import sys
 from pathlib import Path
+import contextlib
 
 if sys.version_info < (3, 6):
     original_resolve = Path.resolve
@@ -33,11 +34,32 @@ if sys.version_info < (3, 6):
     Path.resolve = resolve
 
 try:
+    contextlib.nullcontext
+except NameError:
+
+    class nullcontext(AbstractContextManager):
+        """Context manager that does no additional processing.
+        Used as a stand-in for a normal context manager, when a particular
+        block of code is only sometimes used with a normal context manager:
+        cm = optional_cm if condition else nullcontext()
+        with cm:
+            # Perform operation, using optional_cm if condition is True
+        """
+
+        def __init__(self, enter_result=None):
+            self.enter_result = enter_result
+
+        def __enter__(self):
+            return self.enter_result
+
+        def __exit__(self, *excinfo):
+            pass
+
+    contextlib.nullcontext = nullcontext
+
+try:
     FileNotFoundError
 except NameError:  # pragma: no cover
     FileNotFoundError = IOError
 
-__all__ = (
-    'FileNotFoundError',
-    'Path',
-)
+__all__ = ('FileNotFoundError', 'Path', 'contextlib')

--- a/renku/core/compat.py
+++ b/renku/core/compat.py
@@ -17,10 +17,10 @@
 # limitations under the License.
 """Compatibility layer for different Python versions."""
 
+import contextlib
 import os
 import sys
 from pathlib import Path
-import contextlib
 
 if sys.version_info < (3, 6):
     original_resolve = Path.resolve
@@ -35,10 +35,11 @@ if sys.version_info < (3, 6):
 
 try:
     contextlib.nullcontext
-except NameError:
+except AttributeError:
 
-    class nullcontext(AbstractContextManager):
+    class nullcontext(object):
         """Context manager that does no additional processing.
+
         Used as a stand-in for a normal context manager, when a particular
         block of code is only sometimes used with a normal context manager:
         cm = optional_cm if condition else nullcontext()


### PR DESCRIPTION
Removes the click dependencies from `import` and `export` commands by using callbacks and partial context managers.

Still ugly, see #737 to add a sane communication pattern between cli and core. Left as is since it blocks other work and it's good enough for now.

Closes #702 

