### PR TITLE
feat: use URIs for dataset ids

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -56,5 +56,5 @@ recursive-include renku *.sh
 recursive-include renku *.txt
 recursive-include renku *.yml
 recursive-include renku Dockerfile
-recursive-include tests *.py *.gz
+recursive-include tests *.py *.gz *.yml
 prune .github

--- a/conftest.py
+++ b/conftest.py
@@ -452,3 +452,16 @@ def cli(client, run):
         return exit_code, content
 
     return renku_cli
+
+
+@pytest.fixture
+def doi_dataset():
+    """Return a yaml of dataset using DOI for its id."""
+    from pathlib import Path
+    dataset_path = Path(
+        __file__
+    ).parent / 'tests' / 'fixtures' / 'doi-dataset.yml'
+    with open(dataset_path.as_posix()) as f:
+        dataset_yaml = f.read()
+
+    return dataset_yaml

--- a/renku/core/commands/checks/migration.py
+++ b/renku/core/commands/checks/migration.py
@@ -20,6 +20,7 @@ import shutil
 import uuid
 from collections import defaultdict
 from pathlib import Path
+from urllib.parse import quote
 
 import click
 
@@ -152,7 +153,18 @@ def migrate_broken_dataset_paths(client):
     for dataset in client.datasets.values():
         dataset_path = Path(dataset.path)
 
-        expected_path = (client.renku_datasets_path / Path(dataset.identifier))
+        expected_path = (
+            client.renku_datasets_path /
+            Path(quote(dataset.identifier, safe=''))
+        )
+
+        # migrate the refs
+        ref = LinkReference.create(
+            client=client,
+            name='datasets/{0}'.format(dataset.display_name),
+            force=True,
+        )
+        ref.set_reference(expected_path / client.METADATA)
 
         if not dataset_path.exists():
             dataset_path = (

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -45,6 +45,7 @@ from renku.core.management.git import COMMIT_DIFF_STRATEGY
 from renku.core.models.datasets import Creator, Dataset
 from renku.core.models.refs import LinkReference
 from renku.core.models.tabulate import tabulate
+from renku.core.utils.doi import extract_doi
 
 from .client import pass_local_client
 from .echo import WARNING
@@ -162,8 +163,12 @@ def add_to_dataset(
     urlscontext=contextlib.nullcontext
 ):
     """Add data to a dataset."""
+    # check for identifier before creating the dataset
+    identifier = extract_doi(
+        with_metadata.identifier
+    ) if with_metadata else None
     try:
-        with client.with_dataset(name=name) as dataset:
+        with client.with_dataset(name=name, identifier=identifier) as dataset:
             with urlscontext(urls) as bar:
                 client.add_data_to_dataset(
                     dataset,

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -111,8 +111,6 @@ class DatasetsApiMixin(object):
     @contextmanager
     def with_dataset(self, name=None, identifier=None):
         """Yield an editable metadata object for a dataset."""
-        from urllib.parse import quote
-
         dataset = self.load_dataset(name=name)
         clean_up_required = False
 

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -109,13 +109,18 @@ class DatasetsApiMixin(object):
                 return self.get_dataset(path)
 
     @contextmanager
-    def with_dataset(self, name=None):
+    def with_dataset(self, name=None, identifier=None):
         """Yield an editable metadata object for a dataset."""
+        from urllib.parse import quote
+
         dataset = self.load_dataset(name=name)
 
         if dataset is None:
-            identifier = str(uuid.uuid4())
-            path = (self.renku_datasets_path / identifier / self.METADATA)
+            identifier = identifier or str(uuid.uuid4())
+            path = (
+                self.renku_datasets_path / quote(identifier, safe='') /
+                self.METADATA
+            )
             path.parent.mkdir(parents=True, exist_ok=True)
 
             with with_reference(path):

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -175,6 +175,37 @@ class RepositoryApiMixin(GitCore):
         if self.renku_metadata_path.exists():
             return Project.from_yaml(self.renku_metadata_path, client=self)
 
+    @property
+    def remote(self, remote_name='origin'):
+        """Return host, owner and name of the remote if it exists."""
+        from renku.core.models.git import GitURL
+
+        host = owner = name = None
+        try:
+            remote_branch = \
+                self.repo.head.reference.tracking_branch()
+            if remote_branch is not None:
+                remote_name = remote_branch.remote_name
+        except TypeError:
+            pass
+
+        try:
+            url = GitURL.parse(self.repo.remotes[remote_name].url)
+
+            # Remove gitlab. unless running on gitlab.com.
+            hostname_parts = url.hostname.split('.')
+            if len(hostname_parts) > 2 and hostname_parts[0] == 'gitlab':
+                hostname_parts = hostname_parts[1:]
+            url = attr.evolve(url, hostname='.'.join(hostname_parts))
+        except IndexError:
+            url = None
+
+        if url:
+            host = url.hostname
+            owner = url.owner
+            name = url.name
+        return {'host': host, 'owner': owner, 'name': name}
+
     def process_commit(self, commit=None, path=None):
         """Build an :class:`~renku.core.models.provenance.activities.Activity`.
 

--- a/renku/core/models/migrations/__init__.py
+++ b/renku/core/models/migrations/__init__.py
@@ -18,9 +18,9 @@
 """Renku JSON-LD migrations."""
 
 from renku.core.models.migrations.dataset import migrate_absolute_paths, \
-    migrate_dataset_schema
+    migrate_dataset_schema, migrate_doi_identifier
 
 JSONLD_MIGRATIONS = {
     'dctypes:Dataset': [migrate_dataset_schema, migrate_absolute_paths],
-    'schema:Dataset': [migrate_absolute_paths],
+    'schema:Dataset': [migrate_absolute_paths, migrate_doi_identifier],
 }

--- a/renku/core/models/migrations/dataset.py
+++ b/renku/core/models/migrations/dataset.py
@@ -62,6 +62,18 @@ def migrate_absolute_paths(data):
     return data
 
 
+def migrate_doi_identifier(data):
+    """If the dataset has a doi, make identifier be based on it."""
+    from renku.core.utils.doi import is_doi, extract_doi
+
+    if is_doi(data.get('_id', '')):
+        data['identifier'] = extract_doi(data.get('_id'))
+        data['same_as'] = data['_id']
+        if data.get('@context'):
+            data['@context'].setdefault('same_as', 'schema:sameAs')
+    return data
+
+
 DATASET_MIGRATIONS = [
     migrate_absolute_paths,
     migrate_dataset_schema,

--- a/renku/core/models/provenance/activities.py
+++ b/renku/core/models/provenance/activities.py
@@ -56,6 +56,7 @@ def _nodes(output, parent=None):
     context={
         'prov': 'http://www.w3.org/ns/prov#',
         'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+        'schema': 'http://schema.org/'
     },
     cmp=False,
 )

--- a/renku/core/models/refs.py
+++ b/renku/core/models/refs.py
@@ -103,7 +103,6 @@ class LinkReference:
         """Create symlink to object in reference path."""
         ref = cls(client=client, name=name)
         path = ref.path
-
         if not force and path.exists():
             raise OSError(str(path))
         elif force and path.exists():

--- a/renku/core/utils/datetime8601.py
+++ b/renku/core/utils/datetime8601.py
@@ -41,6 +41,8 @@ def validate_iso8601(str_val):
 
 def parse_date(value):
     """Convert date to datetime."""
+    if value is None:
+        return
     if isinstance(value, datetime.datetime):
         date = value
     else:

--- a/tests/cli/test_migrate.py
+++ b/tests/cli/test_migrate.py
@@ -59,7 +59,7 @@ def test_list_with_old_repository(isolated_runner, old_project):
 
 
 @pytest.mark.migration
-def test_migrate_with_old_repository(isolated_runner, old_project):
+def test_migrate_datasets_with_old_repository(isolated_runner, old_project):
     """Test migrate on old repository."""
     result = isolated_runner.invoke(cli, ['migrate', 'datasets'])
     assert 0 == result.exit_code

--- a/tests/core/commands/test_serialization.py
+++ b/tests/core/commands/test_serialization.py
@@ -69,3 +69,22 @@ def test_dataset_deserialization(client, dataset):
 
     for attribute, type_ in creator_types.items():
         assert type(creator.get(attribute)) is type_
+
+
+def test_doi_migration(doi_dataset):
+    """Test migration of id with doi."""
+    import yaml
+    from urllib.parse import quote, urljoin
+    from renku.core.utils.doi import is_doi
+    from renku.core.models.datasets import Dataset
+    from renku.core.models.jsonld import NoDatesSafeLoader
+
+    dataset = Dataset.from_jsonld(
+        yaml.load(doi_dataset, Loader=NoDatesSafeLoader)
+    )
+
+    assert is_doi(dataset.identifier)
+    assert urljoin(
+        'https://localhost', 'datasets/' + quote(dataset.identifier, safe='')
+    ) == dataset._id
+    assert dataset.same_as == urljoin('https://doi.org', dataset.identifier)

--- a/tests/fixtures/doi-dataset.yml
+++ b/tests/fixtures/doi-dataset.yml
@@ -1,0 +1,57 @@
+'@context':
+  _id: '@id'
+  _label: rdfs:label
+  _project: schema:isPartOf
+  created: schema:dateCreated
+  creator: schema:creator
+  date_published: schema:datePublished
+  description: schema:description
+  files: schema:hasPart
+  identifier: schema:identifier
+  in_language: schema:inLanguage
+  keywords: schema:keywords
+  license: schema:license
+  name: schema:name
+  path: prov:atLocation
+  prov: http://www.w3.org/ns/prov#
+  schema: http://schema.org/
+  url: schema:url
+  version: schema:version
+  wfprov: http://purl.org/wf4ever/wfprov#
+'@type':
+- prov:Entity
+- schema:Dataset
+- wfprov:Artifact
+_id: https://doi.org/10.5281/zenodo.3247009
+_label: f2e6b3f3-5987-4800-9b7c-07d4821aa5c6
+_project:
+  '@context':
+    _id: '@id'
+    foaf: http://xmlns.com/foaf/0.1/
+    prov: http://www.w3.org/ns/prov#
+  '@type':
+  - foaf:Project
+  - prov:Location
+  _id: https://dev.renku.ch/virginiafriedrich/datasets-test
+created: '2019-07-31T07:22:25.503110+02:00'
+creator:
+- '@type': schema:Person
+  _id: https://orcid.org/0000-0002-3730-5348
+  affiliation: RWTH University Aachen
+  alternate_name: null
+  email: null
+  name: Kather, Jakob Nikolas
+date_published:
+  '@type': schema:Date
+  '@value': '2019-06-16'
+description: ""
+files: []
+identifier: f2e6b3f3-5987-4800-9b7c-07d4821aa5c6
+in_language: null
+keywords: []
+license:
+  _id: http://creativecommons.org/licenses/by/4.0/legalcode
+name: Tissue blocks for EBV detection in stomach cancer
+path: .renku/datasets/f2e6b3f3-5987-4800-9b7c-07d4821aa5c6
+url: https://zenodo.org/record/3247009
+version: v0.1


### PR DESCRIPTION
This PR tries to solve the problem of poorly-formed dataset `id`s. Specifically: 

* when a doi is available, use it as the identifier; we use just the doi itself e.g. `10.5281/zenodo.3251128` and not the full URI e.g. `https://doi.org/10.5281/zenodo.3251128`
* the id is always a URI that uses the `identifier`; if the `identifier` is a doi, it is URL-escaped
* older metadata (`id=doi` and `identifier=uuid`) is automatically migrated
* adds a `sameAs` triple pointing to the original doi

Example:

```json
{
  "@context": "http://schema.org",
  "id": "https://dev.renku.ch/datasets/10.5281%2Fzenodo.3247009",
  "type": [
    "http://www.w3.org/ns/prov#Entity",
    "Dataset",
    "http://purl.org/wf4ever/wfprov#Artifact"
  ],
  "creator": {
    "id": "https://orcid.org/0000-0002-3730-5348",
    "type": "Person",
    "name": "Kather, Jakob Nikolas"
  },
  "datePublished": "2019-06-16",
  "description": "",
  "hasPart": [
    {
      "id": "blob/f711cb1bd02b951f8f0ecc393471f31a26aa6a92/data/tissue_blocks_for_ebv_de_v01/falseNegative.zip",
      "type": [
        "http://www.w3.org/ns/prov#Entity",
        "DigitalDocument",
        "http://purl.org/wf4ever/wfprov#Artifact"
      ],
      "creator": {
        "id": "https://orcid.org/0000-0002-3730-5348",
        "type": "Person",
        "name": "Kather, Jakob Nikolas"
      },
      "name": "falseNegative.zip",
      "schema:url": "https://zenodo.org/api/files/7cf40388-2871-4a54-87ad-37572274961d/falseNegative.zip",
      "http://www.w3.org/ns/prov#atLocation": "data/tissue_blocks_for_ebv_de_v01/falseNegative.zip",
      "rdfs:label": "data/tissue_blocks_for_ebv_de_v01/falseNegative.zip@f711cb1bd02b951f8f0ecc393471f31a26aa6a92"
    },
    {
      "id": "blob/a26587d5eb9fcdf1f496efc01baadc1e84e7aec8/data/tissue_blocks_for_ebv_de_v01/falsePositive.zip",
      "type": [
        "http://www.w3.org/ns/prov#Entity",
        "DigitalDocument",
        "http://purl.org/wf4ever/wfprov#Artifact"
      ],
      "creator": {
        "id": "https://orcid.org/0000-0002-3730-5348",
        "type": "Person",
        "name": "Kather, Jakob Nikolas"
      },
      "name": "falsePositive.zip",
      "schema:url": "https://zenodo.org/api/files/7cf40388-2871-4a54-87ad-37572274961d/falsePositive.zip",
      "http://www.w3.org/ns/prov#atLocation": "data/tissue_blocks_for_ebv_de_v01/falsePositive.zip",
      "rdfs:label": "data/tissue_blocks_for_ebv_de_v01/falsePositive.zip@a26587d5eb9fcdf1f496efc01baadc1e84e7aec8"
    },
    {
      "id": "blob/d67d63f525061d2ae3ee0490f4551f7e43bfbbb9/data/tissue_blocks_for_ebv_de_v01/trueNegative.zip",
      "type": [
        "http://www.w3.org/ns/prov#Entity",
        "DigitalDocument",
        "http://purl.org/wf4ever/wfprov#Artifact"
      ],
      "creator": {
        "id": "https://orcid.org/0000-0002-3730-5348",
        "type": "Person",
        "name": "Kather, Jakob Nikolas"
      },
      "name": "trueNegative.zip",
      "schema:url": "https://zenodo.org/api/files/7cf40388-2871-4a54-87ad-37572274961d/trueNegative.zip",
      "http://www.w3.org/ns/prov#atLocation": "data/tissue_blocks_for_ebv_de_v01/trueNegative.zip",
      "rdfs:label": "data/tissue_blocks_for_ebv_de_v01/trueNegative.zip@d67d63f525061d2ae3ee0490f4551f7e43bfbbb9"
    },
    {
      "id": "blob/1d175c156820c92fdd34bcf65693d47b4cfbb969/data/tissue_blocks_for_ebv_de_v01/truePositive.zip",
      "type": [
        "http://www.w3.org/ns/prov#Entity",
        "DigitalDocument",
        "http://purl.org/wf4ever/wfprov#Artifact"
      ],
      "creator": {
        "id": "https://orcid.org/0000-0002-3730-5348",
        "type": "Person",
        "name": "Kather, Jakob Nikolas"
      },
      "name": "truePositive.zip",
      "schema:url": "https://zenodo.org/api/files/7cf40388-2871-4a54-87ad-37572274961d/truePositive.zip",
      "http://www.w3.org/ns/prov#atLocation": "data/tissue_blocks_for_ebv_de_v01/truePositive.zip",
      "rdfs:label": "data/tissue_blocks_for_ebv_de_v01/truePositive.zip@1d175c156820c92fdd34bcf65693d47b4cfbb969"
    }
  ],
  "identifier": "10.5281/zenodo.3247009",
  "keywords": [],
  "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
  "name": "Tissue blocks for EBV detection in stomach cancer",
  "schema:sameAs": "https://doi.org/10.5281/zenodo.3247009",
  "subjectOf": [],
  "schema:url": "https://zenodo.org/record/3247009",
  "version": "v0.1",
  "http://www.w3.org/ns/prov#atLocation": ".renku/datasets/f2e6b3f3-5987-4800-9b7c-07d4821aa5c6",
  "rdfs:label": "10.5281/zenodo.3247009"
}
```

---

closes #719 
closes #661 
