### PR TITLE
fix: zenodo dataset import error

### DIFF
--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -475,11 +475,10 @@ def import_dataset(
         pool.close()
 
         dataset_name = name or dataset.display_name
+        existing = client.load_dataset(name=dataset_name)
         if (
-            force or (
-                handle_duplicate_fn and
-                handle_duplicate_fn(client, dataset_name)
-            )
+            not existing or force or
+            (handle_duplicate_fn and handle_duplicate_fn(dataset_name))
         ):
             add_to_dataset(
                 client,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

# Description

Fixes a regression remained from refactoring Renku python which prevents importing of Zenodo datasets.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/743

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

**Do not create pull request unless you checked all points.**

- [ ] I have read and understood the **CONTRIBUTING** document.
- [ ] I have performed a self-review of my own code.
- [ ] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [ ] I have added tests to cover my changes.
- [x] I have **NOT** removed any existing tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have described *all* changes in the **CHANGELOG.rst**.
- [x] I have run ``./run-tests.sh`` locally.
