### PR TITLE
99 import dataset from renku aware repo

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -474,3 +474,30 @@ def sleep_after():
     import time
     yield
     time.sleep(0.5)
+
+
+@pytest.fixture
+def remote_project(data_repository, directory_tree):
+    """A second Renku project with a dataset."""
+    from renku.cli import cli
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem() as project_path:
+        runner.invoke(cli, ['-S', 'init'])
+        result = runner.invoke(
+            cli, ['-S', 'dataset', 'create', 'remote-dataset']
+        )
+        assert 0 == result.exit_code
+
+        result = runner.invoke(
+            cli,
+            [
+                '-S', 'dataset', 'add', '-s', 'file', '-s', 'dir2',
+                'remote-dataset', directory_tree.strpath
+            ],
+            catch_exceptions=False,
+        )
+        assert 0 == result.exit_code
+
+        yield runner, project_path

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -115,6 +115,26 @@ To add a specific version of files, use ``--ref`` option for selecting a
 branch, commit, or tag. The value passed to this option must be a valid
 reference in the remote Git repository.
 
+Updating a dataset:
+
+After adding files from a remote Git repository, you can check for updates in
+those files by using ``renku dataset update`` command. This command checks all
+remote files and copies over new content if there are any. It does not delete
+files from the local dataset if they are deleted from the remote Git
+repository; to force the delete use ``--delete`` argument.
+
+You can limit the scope of updated files by specifying dataset names, using
+``--include`` and ``--exclude`` to filter based on file names, or using
+``--creators`` to filter based on creators. For example, the following command
+updates only CSV files from ``my-dataset``:
+
+.. code-block:: console
+
+    $ renku dataset update -I '*.csv' my-dataset
+
+Note that putting glob patterns in quotation is needed to tell Unix shell not
+to expand them.
+
 Tagging a dataset:
 
 A dataset can be tagged with an arbitrary tag to refer to the dataset at that

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -119,7 +119,7 @@ Updating a dataset:
 
 After adding files from a remote Git repository, you can check for updates in
 those files by using ``renku dataset update`` command. This command checks all
-remote files and copies over new content if there are any. It does not delete
+remote files and copies over new content if there is any. It does not delete
 files from the local dataset if they are deleted from the remote Git
 repository; to force the delete use ``--delete`` argument.
 
@@ -132,7 +132,7 @@ updates only CSV files from ``my-dataset``:
 
     $ renku dataset update -I '*.csv' my-dataset
 
-Note that putting glob patterns in quotation is needed to tell Unix shell not
+Note that putting glob patterns in quotes is needed to tell Unix shell not
 to expand them.
 
 Tagging a dataset:
@@ -669,8 +669,21 @@ def import_(uri, name, extract):
 @click.option(
     '--ref', default=None, help='Update to a specific commit/tag/branch.'
 )
-def update(names, creators, include, exclude, ref):
+@click.option(
+    '--delete',
+    is_flag=True,
+    help='Delete local files that are deleted from remote.'
+)
+def update(names, creators, include, exclude, ref, delete):
     """Updates files in dataset from a remote Git repo."""
     progress_context = partial(progressbar, label='Updating files')
-    update_datasets(names, creators, include, exclude, ref, progress_context)
+    update_datasets(
+        names=names,
+        creators=creators,
+        include=include,
+        exclude=exclude,
+        ref=ref,
+        delete=delete,
+        progress_context=progress_context
+    )
     click.secho('OK', fg='green')

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -121,7 +121,8 @@ After adding files from a remote Git repository, you can check for updates in
 those files by using ``renku dataset update`` command. This command checks all
 remote files and copies over new content if there is any. It does not delete
 files from the local dataset if they are deleted from the remote Git
-repository; to force the delete use ``--delete`` argument.
+repository; to force the delete use ``--delete`` argument. You can update to a
+specific branch, commit, or tag by passing ``--ref`` option.
 
 You can limit the scope of updated files by specifying dataset names, using
 ``--include`` and ``--exclude`` to filter based on file names, or using

--- a/renku/cli/exception_handler.py
+++ b/renku/cli/exception_handler.py
@@ -90,6 +90,8 @@ class RenkuExceptionsHandler(click.Group):
             return super().main(*args, **kwargs)
         except RenkuException as e:
             click.echo('Error: {}'.format(e))
+            if e.__cause__ is not None:
+                click.echo('\n{}'.format(traceback.format_exc()))
             exit_code = 1
             if isinstance(e, (ParameterError, UsageError)):
                 exit_code = 2

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -171,7 +171,7 @@ def add_to_dataset(
             raise UsageError('No URL is specified')
         elif len(urls) > 1:
             raise UsageError(
-                'Cannot add multiple URLs whit --source or --destination'
+                'Cannot add multiple URLs with --source or --destination'
             )
 
     # check for identifier before creating the dataset

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -525,6 +525,7 @@ def update_datasets(
     include,
     exclude,
     ref,
+    delete,
     progress_context=contextlib.nullcontext
 ):
     """Update files from a remote Git repo."""
@@ -566,7 +567,15 @@ def update_datasets(
     with progress_context(
         possible_updates, item_show_func=lambda x: x.path if x else None
     ) as progressbar:
-        client.update_dataset_files(progressbar, ref)
+        deleted_files = client.update_dataset_files(
+            files=progressbar, ref=ref, delete=delete
+        )
+
+    if deleted_files and not delete:
+        click.echo(
+            'Some files are deleted from remote. To also delete them locally '
+            'run update command with `--delete` flag.'
+        )
 
 
 def _include_exclude(file_path, include=None, exclude=None):

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -517,7 +517,12 @@ def import_dataset(
             )
 
 
-@pass_local_client(clean=True, commit=True, commit_only=DATASET_METADATA_PATHS)
+@pass_local_client(
+    clean=True,
+    commit=True,
+    commit_only=DATASET_METADATA_PATHS,
+    commit_empty=False
+)
 def update_datasets(
     client,
     names,

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -215,10 +215,10 @@ def add_to_dataset(
             '"renku dataset add {0}" command with "--create" option for '
             'automatic dataset creation.'.format(name)
         )
-    except (FileNotFoundError, git.exc.NoSuchPathError):
+    except (FileNotFoundError, git.exc.NoSuchPathError) as e:
         raise ParameterError(
             'Could not find paths/URLs: \n{0}'.format('\n'.join(urls))
-        )
+        ) from e
 
 
 @pass_local_client(clean=False, commit=False)

--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -367,8 +367,8 @@ class GitError(RenkuException):
     """Raised when a remote Git repo cannot be accessed."""
 
 
-class UrlSchemaNotSupported(RenkuException):
-    """Raised when adding data from unsupported URL schemas."""
+class UrlSchemeNotSupported(RenkuException):
+    """Raised when adding data from unsupported URL schemes."""
 
 
 class OperationError(RenkuException):

--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -84,9 +84,11 @@ class ParameterError(RenkuException):
         if param_hint:
             if isinstance(param_hint, (tuple, list)):
                 param_hint = ' / '.join('"{}"'.format(x) for x in param_hint)
-            message = 'Invalid value for {}: {}'.format(param_hint, message)
+            message = 'Invalid parameter value for {}: {}'.format(
+                param_hint, message
+            )
         else:
-            message = 'Invalid value: {}'.format(message)
+            message = 'Invalid parameter value: {}'.format(message)
 
         super().__init__(message)
 
@@ -367,3 +369,7 @@ class GitError(RenkuException):
 
 class UrlSchemaNotSupported(RenkuException):
     """Raised when adding data from unsupported URL schemas."""
+
+
+class OperationError(RenkuException):
+    """Raised when an operation at runtime raises an error."""

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -814,8 +814,8 @@ class DatasetsApiMixin(object):
             )
         except GitCommandError as e:
             raise errors.GitError(
-                'Cannot clone remote Git repo: {}\n\n{}'.format(url, e)
-            )
+                'Cannot clone remote Git repo: {}'.format(url)
+            ) from e
         else:
             return repo, repo_path
 

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -347,7 +347,7 @@ class DatasetsApiMixin(object):
             repo_path = Path(repo.git_dir).parent.resolve()
 
             # if repo path is a parent of the url, treat the url as a source
-            if repo_path != Path(u.path):
+            if repo_path != Path(u.path).resolve():
                 if sources:
                     raise errors.UsageError(
                         'Cannot use --source within local repo subdirectories'

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1452,7 +1452,7 @@ def test_empty_update(client, runner, data_repository, directory_tree):
     """Test update when nothing changed."""
     # Add dataset to project
     result = runner.invoke(
-        cli, ['dataset', 'add', 'dataset', directory_tree.strpath],
+        cli, ['dataset', 'add', '--create', 'dataset', directory_tree.strpath],
         catch_exceptions=False
     )
     assert 0 == result.exit_code
@@ -1531,7 +1531,7 @@ def test_update_renku_project_dataset(
     assert 0 == result.exit_code
 
     # Update project
-    os.chdir(client.path)
+    os.chdir(str(client.path))
     result = runner.invoke(cli, ['dataset', 'update'], catch_exceptions=False)
     assert 0 == result.exit_code
     content = (client.path / 'data' / 'remote-dataset' / 'file').read_text()

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -431,16 +431,34 @@ def test_relative_git_import_to_dataset(tmpdir, runner, project, client):
     )
     assert 1 == result.exit_code
 
-    # copy a non-existing source
+
+@pytest.mark.parametrize(
+    'add_options,n_urls,message', [
+        (['-s', 'file', '-d', 'new-file'], 0, 'No URL is specified'),
+        (['-s', 'file'], 2, 'Cannot add multiple URLs'),
+        (['-d', 'file'], 2, 'Cannot add multiple URLs'),
+        (['-s', 'non-existing'], 1, 'No such file or directory'),
+    ]
+)
+def test_usage_error_in_import_from_git_repo(
+    data_repository, directory_tree, runner, project, client, add_options,
+    n_urls, message
+):
+    """Test user's errors when adding to a dataset from a git repository."""
+    # create a dataset
+    result = runner.invoke(cli, ['dataset', 'create', 'dataset'])
+    assert 0 == result.exit_code
+
+    urls = n_urls * [directory_tree.strpath]
+
+    # add data in subdirectory
     result = runner.invoke(
         cli,
-        [
-            'dataset', 'add', 'relative', '--source', 'non-existing',
-            str(tmpdir)
-        ],
-        catch_exceptions=True,
+        ['dataset', 'add', 'dataset'] + add_options + urls,
+        catch_exceptions=False,
     )
-    assert 2 == result.exit_code
+    assert result.exit_code == 2
+    assert message in result.output
 
 
 def test_dataset_add_with_link(tmpdir, runner, project, client):
@@ -1246,7 +1264,7 @@ def test_dataset_clean_up_when_add_fails(runner, client):
 
 
 def read_dataset_file_metadata(client, dataset_name, filename):
-
+    """Return metadata from dataset's YAML file."""
     path = client.dataset_path(dataset_name)
     assert path.exists()
 
@@ -1422,3 +1440,103 @@ def test_dataset_update_multiple_datasets(
     assert data == 'new content'
     data = open(str(client.path / 'data' / 'dataset-2' / 'file')).read()
     assert data == 'new content'
+
+
+def test_empty_update(client, runner, data_repository, directory_tree):
+    """Test update when nothing changed."""
+    # Add dataset to project
+    result = runner.invoke(
+        cli, ['dataset', 'add', 'dataset', directory_tree.strpath],
+        catch_exceptions=False
+    )
+    assert 0 == result.exit_code
+
+    commit_sha_before = client.repo.head.object.hexsha
+    result = runner.invoke(cli, ['dataset', 'update'], catch_exceptions=False)
+    assert 0 == result.exit_code
+    commit_sha_after = client.repo.head.object.hexsha
+    assert commit_sha_after == commit_sha_before
+
+
+def test_import_from_renku_project(remote_project, client, runner):
+    """Test an imported dataset from other renku repos will have metadata."""
+    from renku.core.management import LocalClient
+
+    _, remote_project_path = remote_project
+
+    remote_client = LocalClient(remote_project_path)
+    remote = read_dataset_file_metadata(
+        remote_client, 'remote-dataset', 'file'
+    )
+
+    runner.invoke(cli, ['-S', 'dataset', 'create', 'remote-dataset'])
+    result = runner.invoke(
+        cli,
+        [
+            '-S', 'dataset', 'add', '--src', 'data', 'remote-dataset',
+            str(remote_project_path)
+        ],
+        catch_exceptions=False,
+    )
+    assert 0 == result.exit_code
+
+    metadata = read_dataset_file_metadata(client, 'remote-dataset', 'file')
+    assert metadata['creator'] == remote['creator']
+    assert metadata['based_on']['_id'] == remote['_id']
+    assert metadata['based_on']['_label'] == remote['_label']
+    assert metadata['based_on']['path'] == remote['path']
+    assert metadata['based_on']['based_on'] is None
+    assert metadata['based_on']['url'] == remote_project_path
+
+
+def test_update_renku_project_dataset(
+    remote_project, client, runner, directory_tree, data_repository
+):
+    """Test an imported dataset from other renku repos will be updated."""
+    remote_runner, remote_project_path = remote_project
+
+    runner.invoke(cli, ['-S', 'dataset', 'create', 'remote-dataset'])
+    result = runner.invoke(
+        cli,
+        [
+            '-S', 'dataset', 'add', '--src', 'data/remote-dataset/file',
+            'remote-dataset',
+            str(remote_project_path)
+        ],
+        catch_exceptions=False,
+    )
+    assert 0 == result.exit_code
+
+    before = read_dataset_file_metadata(client, 'remote-dataset', 'file')
+
+    # Update and commit original file
+    file_ = directory_tree.join('file')
+    file_.write('new content')
+    data_repository.index.add([file_.strpath])
+    data_repository.index.commit('updated')
+
+    assert (Path(file_.strpath)).read_text() == 'new content'
+
+    # Update remote project
+    os.chdir(remote_project_path)
+    result = remote_runner.invoke(
+        cli, ['dataset', 'update'], catch_exceptions=False
+    )
+    assert 0 == result.exit_code
+
+    # Update project
+    os.chdir(client.path)
+    result = runner.invoke(cli, ['dataset', 'update'], catch_exceptions=False)
+    assert 0 == result.exit_code
+    content = (client.path / 'data' / 'remote-dataset' / 'file').read_text()
+    assert content == 'new content'
+
+    after = read_dataset_file_metadata(client, 'remote-dataset', 'file')
+    assert after['_id'] == before['_id']
+    assert after['_label'] != before['_label']
+    assert after['added'] == before['added']
+    assert after['url'] == before['url']
+    assert after['based_on']['_id'] == before['based_on']['_id']
+    assert after['based_on']['_label'] != before['based_on']['_label']
+    assert after['based_on']['path'] == before['based_on']['path']
+    assert after['based_on']['based_on'] is None

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1295,8 +1295,10 @@ def test_dataset_update(
     assert after['_label'] != before['_label']
     assert after['added'] == before['added']
     assert after['url'] == before['url']
-    assert after['based_on']['_id'] != before['based_on']['_id']
+    assert after['based_on']['_id'] == before['based_on']['_id']
+    assert after['based_on']['_label'] != before['based_on']['_label']
     assert after['based_on']['path'] == before['based_on']['path']
+    assert after['based_on']['based_on'] is None
 
 
 def test_dataset_update_remove_file(

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1341,6 +1341,12 @@ def test_dataset_update_remove_file(
 
     result = runner.invoke(cli, ['dataset', 'update'], catch_exceptions=False)
     assert 0 == result.exit_code
+    assert file_path.exists()
+
+    result = runner.invoke(
+        cli, ['dataset', 'update', '--delete'], catch_exceptions=False
+    )
+    assert 0 == result.exit_code
     assert not file_path.exists()
 
 

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -787,7 +787,7 @@ def test_config_manager_set_value(client, global_config_dir, global_only):
     assert 'zenodo' not in config.sections()
 
 
-def test_config_get_value(client):
+def test_config_get_value(client, global_config_dir):
     """Check reading from configuration."""
     # Value set locally is not visible globally
     client.set_value('local', 'key', 'local-value')

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -25,6 +25,7 @@ from contextlib import contextmanager
 import git
 import pytest
 
+from renku.core import errors
 from renku.core.models.creators import Creator
 from renku.core.models.datasets import Dataset, DatasetFile
 
@@ -59,7 +60,7 @@ def raises(error):
                             ('', 'tempp', git.NoSuchPathError),
                             ('http://', 'example.com/file', None),
                             ('https://', 'example.com/file', None),
-                            ('bla://', 'file', NotImplementedError)]
+                            ('bla://', 'file', errors.UrlSchemaNotSupported)]
 )
 def test_data_add(
     scheme, path, error, client, data_file, directory_tree, dataset_responses

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -60,7 +60,7 @@ def raises(error):
                             ('', 'tempp', git.NoSuchPathError),
                             ('http://', 'example.com/file', None),
                             ('https://', 'example.com/file', None),
-                            ('bla://', 'file', errors.UrlSchemaNotSupported)]
+                            ('bla://', 'file', errors.UrlSchemeNotSupported)]
 )
 def test_data_add(
     scheme, path, error, client, data_file, directory_tree, dataset_responses


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

# Description

This PR enables copying metadata from other Renku projects when adding files to datasets. ATM, only `creator` is copied over from the original dataset's metadata.

Moreover, if fixes some minor issues with `renku dataset add` and `renku dataset update`.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/99
Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/763

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

**Do not create pull request unless you checked all points.**

- [ ] I have read and understood the **CONTRIBUTING** document.
- [ ] I have performed a self-review of my own code.
- [ ] I have signed and sent the [CLA document]
      (https://github.com/SwissDataScienceCenter/documentation/wiki/files/SDSC_Contributor_License_Agreement_v1.0.pdf).
- [x] I have added tests to cover my changes.
- [x] I have **NOT** removed any existing tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have described *all* changes in the **CHANGELOG.rst**.
- [x] I have run ``./run-tests.sh`` locally.
