### PR TITLE
feat: avoid creation of nested datasets

### DIFF
--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -129,7 +129,7 @@ class DatasetsApiMixin(object):
                 path.parent.mkdir(parents=True, exist_ok=False)
             except FileExistsError:
                 raise errors.DatasetExistsError(
-                    'Dataset with UUID {} exists'.format(identifier)
+                    'Dataset with reference {} exists'.format(path.parent)
                 )
 
             with with_reference(path):

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -115,6 +115,12 @@ class DatasetsApiMixin(object):
         clean_up_required = False
 
         if dataset is None:
+            # Avoid nested datasets: name mustn't have '/' in it
+            if len(Path(name).parts) > 1:
+                raise errors.ParameterError(
+                    'Dataset name {} is not valid.'.format(name)
+                )
+
             clean_up_required = True
             dataset_ref = None
             identifier = str(uuid.uuid4())
@@ -123,7 +129,7 @@ class DatasetsApiMixin(object):
                 path.parent.mkdir(parents=True, exist_ok=False)
             except FileExistsError:
                 raise errors.DatasetExistsError(
-                    'Dataset with reference {} exists'.format(path.parent)
+                    'Dataset with UUID {} exists'.format(identifier)
                 )
 
             with with_reference(path):

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -182,6 +182,14 @@ def test_dataset_create_exception_refs(runner, project, client):
     assert 'a' in result.output
 
 
+@pytest.mark.parametrize('name', ['dataset/new', '/dataset', 'dataset/'])
+def test_dataset_name_is_valid(client, runner, project, name):
+    """Test dataset name has no '/' character to avoid nested datasets."""
+    result = runner.invoke(cli, ['dataset', 'create', name])
+    assert result.exit_code == 2
+    assert 'is not valid' in result.output
+
+
 @pytest.mark.parametrize('output_format', DATASETS_FORMATS.keys())
 def test_datasets_list_empty(output_format, runner, project):
     """Test listing without datasets."""

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -186,7 +186,7 @@ def test_dataset_create_exception_refs(runner, project, client):
 def test_dataset_name_is_valid(client, runner, project, name):
     """Test dataset name has no '/' character to avoid nested datasets."""
     result = runner.invoke(cli, ['dataset', 'create', name])
-    assert result.exit_code == 2
+    assert 2 == result.exit_code
     assert 'is not valid' in result.output
 
 


### PR DESCRIPTION
# Description

In previous Renku version, we could create nested datasets (e.g. `new/2018`, `new/2019`). In recent, Renku versions this is not possible, however, the error message printed to the user is not useful. This PR prints a useful error message to users.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/789

