### PR TITLE
fix: fixes nested type scoped context handling for single types

### DIFF
--- a/renku/core/models/jsonld.py
+++ b/renku/core/models/jsonld.py
@@ -246,7 +246,13 @@ def _propagate_reference_contexts(
 
             if '@context' not in current_context:
                 current_context['@context'] = []
-            for subtype in cls._jsonld_type:
+
+            subtypes = cls._jsonld_type
+
+            if not isinstance(subtypes, (tuple, list)):
+                subtypes = [subtypes]
+
+            for subtype in subtypes:
                 # Use nested, type scoped contexts for each semantic type
                 # of a reference, to uniquely bind a context to a type
                 current_context['@context'].append({


### PR DESCRIPTION
Bugfix for issue in #753 where a type of `mls:...` gets interpreted as a list of characters instead, leading to invalid types.