### PR TITLE
Add or update a specific commit; LFS fixes

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -111,6 +111,10 @@ will yield:
         new-dir/
           new-filename
 
+To add a specific version of files, use ``--ref`` option for selecting a
+branch, commit, or tag. The value passed to this option must be a valid
+reference in the remote Git repository.
+
 Tagging a dataset:
 
 A dataset can be tagged with an arbitrary tag to refer to the dataset at that

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -404,7 +404,10 @@ def edit(dataset_id):
     default='',
     help='Destination file or directory within the dataset path'
 )
-def add(name, urls, link, force, create, sources, destination):
+@click.option(
+    '--ref', default=None, help='Add files from a specific commit/tag/branch.'
+)
+def add(name, urls, link, force, create, sources, destination, ref):
     """Add data to a dataset."""
     progress = partial(progressbar, label='Adding data to dataset')
     add_file(
@@ -415,6 +418,7 @@ def add(name, urls, link, force, create, sources, destination):
         create=create,
         sources=sources,
         destination=destination,
+        ref=ref,
         urlscontext=progress
     )
 
@@ -638,8 +642,11 @@ def import_(uri, name, extract):
     multiple=True,
     help='Exclude files matching given pattern.'
 )
-def update(names, creators, include, exclude):
+@click.option(
+    '--ref', default=None, help='Update to a specific commit/tag/branch.'
+)
+def update(names, creators, include, exclude, ref):
     """Updates files in dataset from a remote Git repo."""
     progress_context = partial(progressbar, label='Updating files')
-    update_datasets(names, creators, include, exclude, progress_context)
+    update_datasets(names, creators, include, exclude, ref, progress_context)
     click.secho('OK', fg='green')

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -764,6 +764,14 @@ class DatasetsApiMixin(object):
                 'git', 'symbolic-ref', renku_ref, repo.head.reference.path
             ])
             checkout(repo, ref)
+            # Disable Git LFS smudge filter
+            repo.git.execute(
+                command=[
+                    'git', 'lfs', 'install', '--local', '--skip-smudge',
+                    '--force'
+                ],
+                with_exceptions=False
+            )
         except GitCommandError:
             raise errors.GitError(
                 'Cannot access remote Git repo: {}'.format(url)

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -422,14 +422,18 @@ class DatasetsApiMixin(object):
                     client, path=path, url=url
                 )
 
+                path_in_dst_repo = dst.relative_to(self.path)
+
                 results.append({
-                    'path': dst.relative_to(self.path),
+                    'path': path_in_dst_repo,
                     'url': dst_url,
                     'creator': creators,
                     'dataset': dataset.name,
                     'parent': self,
                     'based_on': based_on
                 })
+
+                self.track_paths_in_storage(str(path_in_dst_repo))
 
                 dst.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy(str(src), str(dst))

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -754,6 +754,7 @@ class DatasetsApiMixin(object):
                 )
 
         try:
+            os.environ['GIT_LFS_SKIP_SMUDGE'] = '1'
             repo = Repo.clone_from(url, str(repo_path), recursive=True)
             # Because the name of the default branch is not always 'master', we
             # create an alias of the default branch when cloning the repo. It

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -629,7 +629,7 @@ def test_datasets_import_target(
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    'ref', ['v0.2.0', '8c1a547843f2916818beac5fdcfad547f0785ee0']
+    'ref', ['v0.3.0', 'fe6ec65cc84bcf01e879ef38c0793208f7fab4bb']
 )
 def test_add_specific_refs(ref, runner, client):
     """Test adding a specific version of files."""
@@ -647,13 +647,13 @@ def test_add_specific_refs(ref, runner, client):
     )
     assert 0 == result.exit_code
     content = (client.path / 'data' / 'dataset' / FILENAME).read_text()
-    assert 'v0.2.0' not in content
-    assert 'v0.3.0' not in content
+    assert 'v0.3.0' in content
+    assert 'v0.3.1' not in content
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    'ref', ['v0.3.0', 'fe6ec65cc84bcf01e879ef38c0793208f7fab4bb']
+    'ref', ['v0.3.1', '27e29abd409c83129a3fdb8b8b0b898b23bcb229']
 )
 def test_update_specific_refs(ref, runner, client):
     """Test updating to a specific version of files."""
@@ -665,20 +665,20 @@ def test_update_specific_refs(ref, runner, client):
     # add data from a git repo
     result = runner.invoke(
         cli, [
-            'dataset', 'add', 'dataset', '-s', FILENAME, '--ref', 'v0.2.0',
+            'dataset', 'add', 'dataset', '-s', FILENAME, '--ref', 'v0.3.0',
             'https://github.com/SwissDataScienceCenter/renku-python.git'
         ]
     )
     assert 0 == result.exit_code
     content = (client.path / 'data' / 'dataset' / FILENAME).read_text()
-    assert 'v0.3.0' not in content
+    assert 'v0.3.1' not in content
 
     # update data to a later version
     result = runner.invoke(cli, ['dataset', 'update', '--ref', ref])
     assert 0 == result.exit_code
     content = (client.path / 'data' / 'dataset' / FILENAME).read_text()
-    assert 'v0.3.0' in content
-    assert 'v0.4.0' not in content
+    assert 'v0.3.1' in content
+    assert 'v0.3.2' not in content
 
 
 @pytest.mark.integration


### PR DESCRIPTION
# Description

When adding a file from a Git repository to a dataset, this PR makes it possible to add a specific version of the file by passing a `--ref` option. It can point to a branch, commit, or tag. Similarly, it allows to update a dataset to a specific version.

Moreover, this PR fixes two issues with Git-LFS: 1. Dataset files now are tracked in the LFS, and 2. When cloning a repo only desired files are pulled from LFS.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/802
Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/803
