### PR TITLE
fix: ensure person ids are valid

### DIFF
--- a/docs/models/datasets.rst
+++ b/docs/models/datasets.rst
@@ -37,11 +37,3 @@ Manage files in the dataset.
 .. autoclass:: renku.core.models.datasets.DatasetFile
    :members:
    :inherited-members:
-
-
-Creator
--------
-
-.. autoclass:: renku.core.models.datasets.Creator
-   :members:
-   :inherited-members:

--- a/renku/cli/exception_handler.py
+++ b/renku/cli/exception_handler.py
@@ -134,10 +134,10 @@ class IssueFromTraceback(RenkuExceptionsHandler):
             with capture_internal_exceptions():
                 from git import Repo
                 from renku.core.commands import get_git_home
-                from renku.core.models.datasets import Creator
+                from renku.core.models.provenance.agents import Person
 
                 repo = Repo(get_git_home())
-                user = Creator.from_git(repo)
+                user = Person.from_git(repo)
 
                 scope.user = {'name': user.name, 'email': user.email}
 

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -42,7 +42,8 @@ from renku.core.errors import DatasetNotFound, InvalidAccessToken, \
     MigrationRequired, ParameterError
 from renku.core.management.datasets import DATASET_METADATA_PATHS
 from renku.core.management.git import COMMIT_DIFF_STRATEGY
-from renku.core.models.datasets import Creator, Dataset
+from renku.core.models.datasets import Dataset
+from renku.core.models.provenance.agents import Person
 from renku.core.models.refs import LinkReference
 from renku.core.models.tabulate import tabulate
 from renku.core.utils.doi import extract_doi
@@ -107,7 +108,7 @@ def create_dataset(client, name, handle_duplicate_fn=None):
     existing = client.load_dataset(name=name)
     if (not existing or handle_duplicate_fn and handle_duplicate_fn(existing)):
         with client.with_dataset(name=name) as dataset:
-            creator = Creator.from_git(client.repo)
+            creator = Person.from_git(client.repo)
             if creator not in dataset.creator:
                 dataset.creator.append(creator)
 

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -35,10 +35,10 @@ import requests
 
 from renku.core import errors
 from renku.core.management.config import RENKU_HOME
-from renku.core.models.datasets import Creator, Dataset, DatasetFile, \
-    DatasetTag
+from renku.core.models.datasets import Dataset, DatasetFile, DatasetTag
 from renku.core.models.git import GitURL
 from renku.core.models.locals import with_reference
+from renku.core.models.provenance.agents import Person
 from renku.core.models.refs import LinkReference
 
 
@@ -391,7 +391,7 @@ class DatasetsApiMixin(object):
                 creators = []
                 # grab all the creators from the commit history
                 for commit in repo.iter_commits(paths=path):
-                    creator = Creator.from_commit(commit)
+                    creator = Person.from_commit(commit)
                     if creator not in creators:
                         creators.append(creator)
 

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -394,8 +394,8 @@ class RepositoryApiMixin(GitCore):
         self.repo.description = name or path.name
 
         # Check that an creator can be determined from Git.
-        from renku.core.models.datasets import Creator
-        Creator.from_git(self.repo)
+        from renku.core.models.provenance.agents import Person
+        Person.from_git(self.repo)
 
         # TODO read existing gitignore and create a unique set of rules
         import pkg_resources

--- a/renku/core/models/projects.py
+++ b/renku/core/models/projects.py
@@ -23,8 +23,8 @@ import os
 import attr
 
 from renku.core.models import jsonld
-from renku.core.models.datasets import Creator
 from renku.core.models.datastructures import Collection
+from renku.core.models.provenance.agents import Person
 from renku.core.utils.datetime8601 import parse_date
 
 PROJECT_URL_PATH = 'projects'
@@ -89,14 +89,14 @@ class Project(object):
         """Initialize computed attributes."""
         if not self.creator and self.client:
             if self.client.renku_metadata_path.exists():
-                self.creator = Creator.from_commit(
+                self.creator = Person.from_commit(
                     self.client.find_previous_commit(
                         self.client.renku_metadata_path, return_first=True
                     ),
                 )
             else:
                 # this assumes the project is being newly created
-                self.creator = Creator.from_git(self.client.repo)
+                self.creator = Person.from_git(self.client.repo)
 
         self._id = self.project_id
 

--- a/renku/core/models/provenance/agents.py
+++ b/renku/core/models/provenance/agents.py
@@ -17,9 +17,11 @@
 # limitations under the License.
 """Represent provenance agents."""
 
+import configparser
 import re
 import uuid
 
+from renku.core import errors
 from renku.core.models import jsonld as jsonld
 from renku.version import __version__, version_url
 
@@ -33,7 +35,6 @@ from renku.version import __version__, version_url
         'schema': 'http://schema.org/',
         'prov': 'http://www.w3.org/ns/prov#',
     },
-    frozen=True,
     slots=True,
 )
 class Person:
@@ -42,7 +43,12 @@ class Person:
     name = jsonld.ib(context='schema:name')
     email = jsonld.ib(context='schema:email', default=None, kw_only=True)
     label = jsonld.ib(context='rdfs:label', kw_only=True)
-
+    affiliation = jsonld.ib(
+        default=None, kw_only=True, context='schema:affiliation'
+    )
+    alternate_name = jsonld.ib(
+        default=None, kw_only=True, context='schema:alternateName'
+    )
     _id = jsonld.ib(context='@id', kw_only=True)
 
     @_id.default
@@ -72,6 +78,51 @@ class Person:
             name=commit.author.name,
             email=commit.author.email,
         )
+
+    @property
+    def short_name(self):
+        """Gives full name in short form."""
+        names = self.name.split()
+        if len(names) == 1:
+            return self.name
+
+        last_name = names[-1]
+        initials = [name[0] for name in names]
+        initials.pop()
+
+        return '{0}.{1}'.format('.'.join(initials), last_name)
+
+    @classmethod
+    def from_git(cls, git):
+        """Create an instance from a Git repo."""
+        git_config = git.config_reader()
+        try:
+            name = git_config.get_value('user', 'name', None)
+            email = git_config.get_value('user', 'email', None)
+        except (
+            configparser.NoOptionError, configparser.NoSectionError
+        ):  # pragma: no cover
+            raise errors.ConfigurationError(
+                'The user name and email are not configured. '
+                'Please use the "git config" command to configure them.\n\n'
+                '\tgit config --global --add user.name "John Doe"\n'
+                '\tgit config --global --add user.email '
+                '"john.doe@example.com"\n'
+            )
+
+        # Check the git configuration.
+        if not name:  # pragma: no cover
+            raise errors.MissingUsername()
+        if not email:  # pragma: no cover
+            raise errors.MissingEmail()
+
+        return cls(name=name, email=email)
+
+    def __attrs_post_init__(self):
+        """Finish object initialization."""
+        # handle the case where ids were improperly set
+        if self._id == 'mailto:None':
+            self._id = self.default_id()
 
 
 @jsonld.s(

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -25,7 +25,8 @@ from contextlib import contextmanager
 import git
 import pytest
 
-from renku.core.models.datasets import Creator, Dataset, DatasetFile
+from renku.core.models.datasets import Dataset, DatasetFile
+from renku.core.models.provenance.agents import Person
 
 
 def _key(client, dataset, filename):
@@ -140,7 +141,7 @@ def test_git_repo_import(client, dataset, tmpdir, data_repository):
 
 @pytest.mark.parametrize(
     'creators', [
-        [Creator(name='me', email='me@example.com')],
+        [Person(name='me', email='me@example.com')],
         [{
             'name': 'me',
             'email': 'me@example.com',
@@ -150,14 +151,14 @@ def test_git_repo_import(client, dataset, tmpdir, data_repository):
 def test_creator_parse(creators, data_file):
     """Test that different options for specifying creators work."""
     f = DatasetFile(path='file', creator=creators)
-    creator = Creator(name='me', email='me@example.com')
+    creator = Person(name='me', email='me@example.com')
     assert creator in f.creator
 
     # email check
     with pytest.raises(ValueError):
-        Creator(name='me', email='meexample.com')
+        Person(name='me', email='meexample.com')
 
-    # creators must be a set or list of dicts or Creator
+    # creators must be a set or list of dicts or Person
     with pytest.raises(ValueError):
         f = DatasetFile(path='file', creator=['name'])
 

--- a/tests/core/models/test_projects.py
+++ b/tests/core/models/test_projects.py
@@ -159,11 +159,11 @@ def test_project_datetime_loading(project_meta):
 
 def test_project_creator_deserialization(client, project):
     """Check that the correct creator is returned on deserialization."""
-    from renku.core.models.datasets import Creator
+    from renku.core.models.provenance.agents import Person
 
     # modify the project metadata to change the creator
     project = client.project
-    project.creator = Creator(email='johndoe@example.com', name='Johnny Doe')
+    project.creator = Person(email='johndoe@example.com', name='Johnny Doe')
     project.to_yaml()
     client.repo.git.commit(
         '-a', '--amend', '-C', 'HEAD', '--author',


### PR DESCRIPTION
# Description

This change removes `Creator` in favor of having a single `Person` type. Fixes (and adds a test for) the regression described in #812. 

*NOTE*: This PR is against the `0.7.0-maint` branch - when merged, we will tag a patch release `0.7.2`.