### PR TITLE
feat: do not store url credentials anywhere

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -410,7 +410,10 @@ def edit(dataset_id):
     '--force', is_flag=True, help='Allow adding otherwise ignored files.'
 )
 @click.option(
-    '--create', is_flag=True, help='Create dataset if it does not exist.'
+    '-c',
+    '--create',
+    is_flag=True,
+    help='Create dataset if it does not exist.'
 )
 @click.option(
     '-s',

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -47,6 +47,7 @@ from renku.core.models.provenance.agents import Person
 from renku.core.models.refs import LinkReference
 from renku.core.models.tabulate import tabulate
 from renku.core.utils.doi import extract_doi
+from renku.core.utils.urls import remove_credentials
 
 from .client import pass_local_client
 from .echo import WARNING
@@ -206,6 +207,7 @@ def add_to_dataset(
                                 file_.url = file_.url.geturl()
 
                             file_.path = added_.path
+                            file_.url = remove_credentials(file_.url)
                             file_.creator = with_metadata.creator
                             file_._label = added_._label
                             file_.commit = added_.commit
@@ -505,6 +507,7 @@ def import_dataset(
         pool.close()
 
         dataset_name = name or dataset.display_name
+        dataset.url = remove_credentials(dataset.url)
         add_to_dataset(
             client,
             urls=[str(p) for p in Path(data_folder).glob('*')],

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -41,6 +41,7 @@ from renku.core.models.git import GitURL
 from renku.core.models.locals import with_reference
 from renku.core.models.provenance.agents import Person
 from renku.core.models.refs import LinkReference
+from renku.core.utils.urls import remove_credentials
 
 
 @attr.s
@@ -301,7 +302,7 @@ class DatasetsApiMixin(object):
             else:
                 return [{
                     'path': path_in_repo,
-                    'url': src.as_uri(),
+                    'url': path_in_repo,
                     'creator': dataset.creator,
                     'dataset': dataset.name,
                     'parent': self
@@ -323,7 +324,7 @@ class DatasetsApiMixin(object):
 
         return [{
             'path': destination.relative_to(self.path),
-            'url': src.as_uri(),
+            'url': 'file://' + os.path.relpath(str(src), str(self.path)),
             'creator': dataset.creator,
             'dataset': dataset.name,
             'parent': self
@@ -349,7 +350,7 @@ class DatasetsApiMixin(object):
 
         return [{
             'path': destination.relative_to(self.path),
-            'url': url,
+            'url': remove_credentials(url),
             'creator': dataset.creator,
             'dataset': dataset.name,
             'parent': self
@@ -426,7 +427,7 @@ class DatasetsApiMixin(object):
 
                 results.append({
                     'path': path_in_dst_repo,
-                    'url': url,
+                    'url': remove_credentials(url),
                     'creator': creators,
                     'dataset': dataset.name,
                     'parent': self,

--- a/renku/core/management/git.py
+++ b/renku/core/management/git.py
@@ -33,6 +33,7 @@ import attr
 import gitdb
 
 from renku.core import errors
+from renku.core.utils.urls import remove_credentials
 
 COMMIT_DIFF_STRATEGY = 'DIFF'
 STARTED_AT = int(time.time() * 1e3)
@@ -301,7 +302,8 @@ class GitCore:
                 raise errors.NothingToCommit()
             return
 
-        argv = [os.path.basename(sys.argv[0])] + sys.argv[1:]
+        argv = [os.path.basename(sys.argv[0])
+                ] + [remove_credentials(arg) for arg in sys.argv[1:]]
 
         # Ignore pre-commit hooks since we have already done everything.
         self.repo.index.commit(

--- a/renku/core/utils/urls.py
+++ b/renku/core/utils/urls.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """Helpers utils for handling URLs."""
 
+import urllib
 from urllib.parse import ParseResult
 
 
@@ -39,3 +40,11 @@ def url_to_string(url):
         return url
 
     raise ValueError('url value not recognized')
+
+
+def remove_credentials(url):
+    """Remove username and password from a URL."""
+    if url is None:
+        return ''
+    parsed = urllib.parse.urlparse(url)
+    return parsed._replace(netloc=parsed.hostname).geturl()


### PR DESCRIPTION
# Description

Remove username and passwords from URLs from dataset metadata and commit message when adding data to a dataset. It also removes local paths from metadata when adding a file from local filesystem.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/476
