### PR TITLE
fix: avoid empty commits when adding files

### DIFF
--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -131,6 +131,8 @@ def edit_dataset(client, dataset_id, transform_fn):
     clean=False,
     commit=True,
     commit_only=COMMIT_DIFF_STRATEGY,
+    commit_empty=False,
+    raise_if_empty=True
 )
 def add_file(
     client,

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -234,6 +234,10 @@ class DatasetsApiMixin(object):
         # commit all new data
         file_paths = {str(data['path']) for data in files if str(data['path'])}
         self.repo.git.add(*(file_paths - set(ignored)))
+
+        if not self.repo.is_dirty():
+            return warning_message
+
         self.repo.index.commit(
             'renku dataset: commiting {} newly added files'.
             format(len(file_paths) + len(ignored))


### PR DESCRIPTION
# Description

When adding the same file to a dataset, nothing changes but two empty commits are created. This PR fails with an error message in this case and avoids creating empty commits.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/795


