### PR TITLE
feat: metadata on dataset creation

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -386,6 +386,9 @@ def dataset(ctx, revision, datadir, format):
 @dataset.command()
 @click.argument('name')
 @click.option(
+    '--short-name', default='', help='A convenient name for dataset.'
+)
+@click.option(
     '-d', '--description', default='', help='Dataset\'s description.'
 )
 @click.option(
@@ -395,16 +398,19 @@ def dataset(ctx, revision, datadir, format):
     multiple=True,
     help='Creator\'s name and email ("Name <email>").'
 )
-def create(name, description, creator):
+def create(name, short_name, description, creator):
     """Create an empty dataset in the current repo."""
     creators = creator or ()
 
     dataset = create_dataset(
-        name=name, description=description, creators=creators
+        name=name,
+        short_name=short_name,
+        description=description,
+        creators=creators
     )
     click.echo(
         'Use the name "{}" to refer to this dataset.'.format(
-            dataset.internal_name
+            dataset.short_name
         )
     )
     click.secho('OK', fg='green')
@@ -625,14 +631,16 @@ def export_(id, provider, publish, tag):
 
 @dataset.command('import')
 @click.argument('uri')
-@click.option('--name', default='', help='Renku-compatible name for dataset.')
+@click.option(
+    '--short-name', default='', help='A convenient name for dataset.'
+)
 @click.option(
     '-x',
     '--extract',
     is_flag=True,
     help='Extract files before importing to dataset.'
 )
-def import_(uri, name, extract):
+def import_(uri, short_name, extract):
     """Import data from a 3rd party provider.
 
     Supported providers: [Zenodo, Dataverse]
@@ -658,7 +666,7 @@ def import_(uri, name, extract):
 
     import_dataset(
         uri=uri,
-        internal_name=name,
+        short_name=short_name,
         extract=extract,
         with_prompt=True,
         pool_init_fn=_init,

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -399,7 +399,14 @@ def create(name, description, creator):
     """Create an empty dataset in the current repo."""
     creators = creator or ()
 
-    create_dataset(name=name, description=description, creators=creators)
+    dataset = create_dataset(
+        name=name, description=description, creators=creators
+    )
+    click.echo(
+        'Use the name "{}" to refer to this dataset.'.format(
+            dataset.internal_name
+        )
+    )
     click.secho('OK', fg='green')
 
 

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -385,7 +385,6 @@ def dataset(ctx, revision, datadir, format):
 
 @dataset.command()
 @click.argument('name')
-@click.option('--display-name', default='', help='Dataset\'s display name.')
 @click.option(
     '-d', '--description', default='', help='Dataset\'s description.'
 )
@@ -396,16 +395,11 @@ def dataset(ctx, revision, datadir, format):
     multiple=True,
     help='Creator\'s name and email ("Name <email>").'
 )
-def create(name, display_name, description, creator):
+def create(name, description, creator):
     """Create an empty dataset in the current repo."""
     creators = creator or ()
 
-    create_dataset(
-        name=name,
-        display_name=display_name,
-        description=description,
-        creators=creators
-    )
+    create_dataset(name=name, description=description, creators=creators)
     click.secho('OK', fg='green')
 
 
@@ -624,14 +618,14 @@ def export_(id, provider, publish, tag):
 
 @dataset.command('import')
 @click.argument('uri')
-@click.option('--display-name', default='', help='Alias for dataset\'s name.')
+@click.option('--name', default='', help='Renku-compatible name for dataset.')
 @click.option(
     '-x',
     '--extract',
     is_flag=True,
     help='Extract files before importing to dataset.'
 )
-def import_(uri, display_name, extract):
+def import_(uri, name, extract):
     """Import data from a 3rd party provider.
 
     Supported providers: [Zenodo, Dataverse]
@@ -657,7 +651,7 @@ def import_(uri, display_name, extract):
 
     import_dataset(
         uri=uri,
-        display_name=display_name,
+        internal_name=name,
         extract=extract,
         with_prompt=True,
         pool_init_fn=_init,

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -385,9 +385,27 @@ def dataset(ctx, revision, datadir, format):
 
 @dataset.command()
 @click.argument('name')
-def create(name):
+@click.option('--display-name', default='', help='Dataset\'s display name.')
+@click.option(
+    '-d', '--description', default='', help='Dataset\'s description.'
+)
+@click.option(
+    '-c',
+    '--creator',
+    default=None,
+    multiple=True,
+    help='Creator\'s name and <email>.'
+)
+def create(name, display_name, description, creator):
     """Create an empty dataset in the current repo."""
-    create_dataset(name)
+    creators = creator or ()
+
+    create_dataset(
+        name=name,
+        display_name=display_name,
+        description=description,
+        creators=creators
+    )
     click.secho('OK', fg='green')
 
 
@@ -606,14 +624,14 @@ def export_(id, provider, publish, tag):
 
 @dataset.command('import')
 @click.argument('uri')
-@click.option('-n', '--name', help='Dataset name.')
+@click.option('--display-name', default='', help='Alias for dataset\'s name.')
 @click.option(
     '-x',
     '--extract',
     is_flag=True,
     help='Extract files before importing to dataset.'
 )
-def import_(uri, name, extract):
+def import_(uri, display_name, extract):
     """Import data from a 3rd party provider.
 
     Supported providers: [Zenodo, Dataverse]
@@ -638,9 +656,9 @@ def import_(uri, name, extract):
         tqdm.set_lock(lock)
 
     import_dataset(
-        uri,
-        name,
-        extract,
+        uri=uri,
+        display_name=display_name,
+        extract=extract,
         with_prompt=True,
         pool_init_fn=_init,
         pool_init_args=(mp.RLock(), id_queue),

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -394,7 +394,7 @@ def dataset(ctx, revision, datadir, format):
     '--creator',
     default=None,
     multiple=True,
-    help='Creator\'s name and <email>.'
+    help='Creator\'s name and email ("Name <email>").'
 )
 def create(name, display_name, description, creator):
     """Create an empty dataset in the current repo."""

--- a/renku/core/commands/checks/migration.py
+++ b/renku/core/commands/checks/migration.py
@@ -162,7 +162,7 @@ def migrate_broken_dataset_paths(client):
         # migrate the refs
         ref = LinkReference.create(
             client=client,
-            name='datasets/{0}'.format(dataset.display_name),
+            name='datasets/{0}'.format(dataset.internal_name),
             force=True,
         )
         ref.set_reference(expected_path / client.METADATA)

--- a/renku/core/commands/checks/migration.py
+++ b/renku/core/commands/checks/migration.py
@@ -162,7 +162,7 @@ def migrate_broken_dataset_paths(client):
         # migrate the refs
         ref = LinkReference.create(
             client=client,
-            name='datasets/{0}'.format(dataset.internal_name),
+            name='datasets/{0}'.format(dataset.short_name),
             force=True,
         )
         ref.set_reference(expected_path / client.METADATA)

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -282,7 +282,7 @@ def dataset_remove(
     commit_message=None
 ):
     """Delete a dataset."""
-    datasets = {name: client.dataset_path(name) for name in names}
+    datasets = {name: client.get_dataset_path(name) for name in names}
 
     if not datasets:
         raise ParameterError(

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -111,12 +111,11 @@ def create_dataset(client, name, description, creators, commit_message=None):
     else:
         creators = [Person.from_string(c) for c in creators]
 
-    client.create_dataset(
-        name=name,
-        internal_name=name,
-        description=description,
-        creators=creators
+    dataset, _, __ = client.create_dataset(
+        name=name, description=description, creators=creators
     )
+
+    return dataset
 
 
 @pass_local_client(
@@ -482,7 +481,9 @@ def import_dataset(
 
     if files:
         if not internal_name:
-            internal_name = generate_default_internal_name(dataset)
+            internal_name = generate_default_internal_name(
+                dataset.name, dataset.version
+            )
 
         dataset.internal_name = internal_name
 

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -101,9 +101,7 @@ def dataset_parent(client, revision, datadir, format, ctx=None):
 @pass_local_client(
     clean=False, commit=True, commit_only=DATASET_METADATA_PATHS
 )
-def create_dataset(
-    client, name, display_name, description, creators, commit_message=None
-):
+def create_dataset(client, name, description, creators, commit_message=None):
     """Create an empty dataset in the current repo.
 
     :raises: ``renku.core.errors.ParameterError``

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -110,6 +110,9 @@ def create_dataset(
     """
     if not creators:
         creators = [Person.from_git(client.repo)]
+    else:
+        creators = [Person.from_string(c) for c in creators]
+
     client.create_dataset(
         name=name,
         display_name=display_name,

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -485,7 +485,9 @@ def import_dataset(
 
         dataset.display_name = display_name
 
-        client.create_dataset(name=dataset.name, display_name=display_name)
+        client.create_dataset(
+            name=dataset.name, display_name=display_name, is_import=True
+        )
 
         data_folder = tempfile.mkdtemp()
 
@@ -644,7 +646,7 @@ def _filter(client, names=None, creators=None, include=None, exclude=None):
 
     records = []
     for path_, dataset in client.datasets.items():
-        if not names or dataset.name in names:
+        if not names or dataset.name in names or dataset.display_name in names:
             for file_ in dataset.files:
                 file_.dataset = dataset.name
                 path_ = file_.full_path.relative_to(client.path)

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -106,10 +106,8 @@ def create_dataset(client, name, commit_message=None):
 
     :raises: ``renku.core.errors.ParameterError``
     """
-    with client.with_dataset(name=name, create=True) as dataset:
-        creator = Person.from_git(client.repo)
-        if creator not in dataset.creator:
-            dataset.creator.append(creator)
+    creator = Person.from_git(client.repo)
+    client.create_dataset(name=name, creators=[creator])
 
 
 @pass_local_client(

--- a/renku/core/commands/format/datasets.py
+++ b/renku/core/commands/format/datasets.py
@@ -31,7 +31,7 @@ def tabular(client, datasets):
         datasets,
         headers=OrderedDict((
             ('uid', 'id'),
-            ('internal_name', None),
+            ('short_name', None),
             ('version', None),
             ('created', None),
             ('creators_csv', 'creators'),

--- a/renku/core/commands/format/datasets.py
+++ b/renku/core/commands/format/datasets.py
@@ -31,7 +31,7 @@ def tabular(client, datasets):
         datasets,
         headers=OrderedDict((
             ('uid', 'id'),
-            ('display_name', None),
+            ('internal_name', None),
             ('version', None),
             ('created', None),
             ('creators_csv', 'creators'),

--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -128,7 +128,7 @@ class MissingEmail(ConfigurationError):
             'Please use the "git config" command to configure it.\n\n'
             '\tgit config --set user.email "john.doe@example.com"\n'
         )
-        super(MissingUsername, self).__init__(message)
+        super().__init__(message)
 
 
 class AuthenticationError(RenkuException):

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -37,7 +37,7 @@ from renku.core import errors
 from renku.core.management.clone import clone
 from renku.core.management.config import RENKU_HOME
 from renku.core.models.datasets import Dataset, DatasetFile, DatasetTag, \
-    generate_default_internal_name, is_dataset_name_valid
+    generate_default_short_name, is_dataset_name_valid
 from renku.core.models.git import GitURL
 from renku.core.models.locals import with_reference
 from renku.core.models.provenance.agents import Person
@@ -133,7 +133,7 @@ class DatasetsApiMixin(object):
                 'Dataset exists: "{}".'.format(name)
             )
 
-        dataset_path = self.path / self.datadir / dataset.internal_name
+        dataset_path = self.path / self.datadir / dataset.short_name
         dataset_path.mkdir(parents=True, exist_ok=True)
 
         try:
@@ -155,23 +155,23 @@ class DatasetsApiMixin(object):
         dataset.to_yaml()
 
     def create_dataset(
-        self, name, internal_name='', description='', creators=()
+        self, name, short_name=None, description='', creators=()
     ):
         """Create a dataset."""
         if not name:
             raise errors.ParameterError('Dataset name must be provided.')
 
-        if not internal_name:
-            internal_name = generate_default_internal_name(name, None)
+        if not short_name:
+            short_name = generate_default_short_name(name, None)
 
-        if not is_dataset_name_valid(internal_name):
+        if not is_dataset_name_valid(short_name):
             raise errors.ParameterError(
-                'Dataset name "{}" is not valid.'.format(internal_name)
+                'Dataset name "{}" is not valid.'.format(short_name)
             )
 
-        if self.load_dataset(name=internal_name):
+        if self.load_dataset(name=short_name):
             raise errors.DatasetExistsError(
-                'Dataset exists: "{}".'.format(internal_name)
+                'Dataset exists: "{}".'.format(short_name)
             )
 
         identifier = str(uuid.uuid4())
@@ -188,13 +188,13 @@ class DatasetsApiMixin(object):
                 client=self,
                 identifier=identifier,
                 name=name,
-                internal_name=internal_name,
+                short_name=short_name,
                 description=description,
                 creator=creators
             )
 
         dataset_ref = LinkReference.create(
-            client=self, name='datasets/' + internal_name
+            client=self, name='datasets/' + short_name
         )
         dataset_ref.set_reference(path)
 
@@ -214,7 +214,7 @@ class DatasetsApiMixin(object):
     ):
         """Import the data into the data directory."""
         warning_message = ''
-        dataset_path = self.path / self.datadir / dataset.internal_name
+        dataset_path = self.path / self.datadir / dataset.short_name
 
         destination = destination or Path('.')
         destination = self._resolve_path(dataset_path, destination)

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -85,16 +85,17 @@ class DatasetsApiMixin(object):
         result = {}
         paths = (self.path / self.renku_datasets_path).rglob(self.METADATA)
         for path in paths:
-            result[path] = self.get_dataset(path)
+            result[path] = self.load_dataset_from_path(path)
         return result
 
-    def get_dataset(self, path, commit=None):
+    def load_dataset_from_path(self, path, commit=None):
         """Return a dataset from a given path."""
+        path = Path(path)
         if not path.is_absolute():
             path = self.path / path
         return Dataset.from_yaml(path, client=self, commit=commit)
 
-    def dataset_path(self, name):
+    def get_dataset_path(self, name):
         """Get dataset path from name."""
         path = self.renku_datasets_path / name / self.METADATA
         if not path.exists():
@@ -107,9 +108,9 @@ class DatasetsApiMixin(object):
     def load_dataset(self, name=None):
         """Load dataset reference file."""
         if name:
-            path = self.dataset_path(name)
+            path = self.get_dataset_path(name)
             if path.exists():
-                return self.get_dataset(path)
+                return self.load_dataset_from_path(path)
 
     @contextmanager
     def with_dataset(self, name=None, identifier=None, create=False):

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -37,7 +37,7 @@ from renku.core import errors
 from renku.core.management.clone import clone
 from renku.core.management.config import RENKU_HOME
 from renku.core.models.datasets import Dataset, DatasetFile, DatasetTag, \
-    is_dataset_name_valid
+    generate_default_internal_name, is_dataset_name_valid
 from renku.core.models.git import GitURL
 from renku.core.models.locals import with_reference
 from renku.core.models.provenance.agents import Person
@@ -162,11 +162,11 @@ class DatasetsApiMixin(object):
             raise errors.ParameterError('Dataset name must be provided.')
 
         if not internal_name:
-            internal_name = name
+            internal_name = generate_default_internal_name(name, None)
 
         if not is_dataset_name_valid(internal_name):
             raise errors.ParameterError(
-                'Dataset name {} is not valid.'.format(internal_name)
+                'Dataset name "{}" is not valid.'.format(internal_name)
             )
 
         if self.load_dataset(name=internal_name):

--- a/renku/core/models/datasets.py
+++ b/renku/core/models/datasets.py
@@ -277,8 +277,7 @@ class Dataset(Entity, CreatorMixin):
 
     EDITABLE_FIELDS = [
         'creator', 'date_published', 'description', 'in_language', 'keywords',
-        'license', 'name', 'url', 'version', 'created', 'files',
-        'internal_name'
+        'license', 'name', 'url', 'version', 'created', 'files', 'short_name'
     ]
 
     _id = jsonld.ib(default=None, context='@id', kw_only=True)
@@ -352,20 +351,22 @@ class Dataset(Entity, CreatorMixin):
 
     same_as = jsonld.ib(context='schema:sameAs', default=None, kw_only=True)
 
-    internal_name = jsonld.ib(default='', context=None, kw_only=True)
+    short_name = jsonld.ib(
+        default=None, context='schema:alternateName', kw_only=True
+    )
 
     @created.default
     def _now(self):
         """Define default value for datetime fields."""
         return datetime.datetime.now(datetime.timezone.utc)
 
-    @internal_name.validator
-    def internal_name_validator(self, attribute, value):
-        """Validate internal_name."""
-        # internal_name might have been scaped and have '%' in it
+    @short_name.validator
+    def short_name_validator(self, attribute, value):
+        """Validate short_name."""
+        # short_name might have been scaped and have '%' in it
         if value and not is_dataset_name_valid(value, safe='%'):
             raise errors.ParameterError(
-                'Invalid "internal_name": {}'.format(value)
+                'Invalid "short_name": {}'.format(value)
             )
 
     @property
@@ -521,8 +522,8 @@ class Dataset(Entity, CreatorMixin):
             # if with_dataset is used, the dataset is not committed yet
             pass
 
-        if not self.internal_name:
-            self.internal_name = generate_default_internal_name(
+        if not self.short_name:
+            self.short_name = generate_default_short_name(
                 self.name, self.version
             )
 
@@ -536,9 +537,9 @@ def is_dataset_name_valid(name, safe=''):
     )
 
 
-def generate_default_internal_name(dataset_name, dataset_version):
-    """Get dataset internal_name."""
-    # For compatibility with older versions use name as internal_name
+def generate_default_short_name(dataset_name, dataset_version):
+    """Get dataset short_name."""
+    # For compatibility with older versions use name as short_name
     # if it is valid; otherwise, use encoded name
     if is_dataset_name_valid(dataset_name):
         return dataset_name

--- a/renku/core/models/datasets.py
+++ b/renku/core/models/datasets.py
@@ -277,7 +277,8 @@ class Dataset(Entity, CreatorMixin):
 
     EDITABLE_FIELDS = [
         'creator', 'date_published', 'description', 'in_language', 'keywords',
-        'license', 'name', 'url', 'version', 'created', 'files', 'display_name'
+        'license', 'name', 'url', 'version', 'created', 'files',
+        'internal_name'
     ]
 
     _id = jsonld.ib(default=None, context='@id', kw_only=True)
@@ -351,22 +352,20 @@ class Dataset(Entity, CreatorMixin):
 
     same_as = jsonld.ib(context='schema:sameAs', default=None, kw_only=True)
 
-    display_name = jsonld.ib(
-        default=None, context='schema:alternateName', kw_only=True
-    )
+    internal_name = jsonld.ib(default='', context=None, kw_only=True)
 
     @created.default
     def _now(self):
         """Define default value for datetime fields."""
         return datetime.datetime.now(datetime.timezone.utc)
 
-    @display_name.validator
-    def display_name_validator(self, attribute, value):
-        """Validate display_name."""
-        # display_name might have been scaped and have '%' in it
+    @internal_name.validator
+    def internal_name_validator(self, attribute, value):
+        """Validate internal_name."""
+        # internal_name might have been scaped and have '%' in it
         if value and not is_dataset_name_valid(value, safe='%'):
             raise errors.ParameterError(
-                'Invalid "display_name": {}'.format(value)
+                'Invalid "internal_name": {}'.format(value)
             )
 
     @property
@@ -522,13 +521,13 @@ class Dataset(Entity, CreatorMixin):
             # if with_dataset is used, the dataset is not committed yet
             pass
 
-        if not self.display_name:
-            # For compatibility with older versions use name as display_name
+        if not self.internal_name:
+            # For compatibility with older versions use name as internal_name
             # if it is valid; otherwise, use encoded name
             if is_dataset_name_valid(self.name):
-                self.display_name = self.name
+                self.internal_name = self.name
             else:
-                self.display_name = generate_default_display_name(self)
+                self.internal_name = generate_default_internal_name(self)
 
 
 def is_dataset_name_valid(name, safe=''):
@@ -540,13 +539,13 @@ def is_dataset_name_valid(name, safe=''):
     )
 
 
-def generate_default_display_name(dataset):
-    """Get dataset display name."""
-    name = re.sub(' +', ' ', dataset.name.lower()[:24])
+def generate_default_internal_name(dataset):
+    """Get dataset internal_name."""
+    name = re.sub(r'\s+', ' ', dataset.name.lower()[:24])
 
     def to_unix(el):
         """Parse string to unix friendly name."""
-        parsed_ = re.sub('[^a-zA-Z0-9]', '', re.sub(' +', ' ', el))
+        parsed_ = re.sub('[^a-zA-Z0-9]', '', re.sub(r'\s+', ' ', el))
         parsed_ = re.sub(' .+', '.', parsed_.lower())
         return parsed_
 

--- a/renku/core/models/provenance/activities.py
+++ b/renku/core/models/provenance/activities.py
@@ -156,7 +156,7 @@ class Activity(CommitMixin):
             if str(path).startswith(
                 os.path.join(client.renku_home, client.DATASETS)
             ):
-                entity = client.get_dataset(Path(path), commit=commit)
+                entity = client.load_dataset_from_path(path, commit=commit)
             else:
                 entity = entity_cls(
                     commit=commit,

--- a/renku/core/models/provenance/agents.py
+++ b/renku/core/models/provenance/agents.py
@@ -127,6 +127,24 @@ class Person:
 
         return cls(name=name, email=email)
 
+    @classmethod
+    def from_string(cls, string):
+        """Create an instance from a 'Name <email>' string."""
+        REGEX = r'([^<]*)<{0,1}([^@<>]+@[^@<>]+\.[^@<>]+)*>{0,1}'
+        name, email = re.search(REGEX, string).groups()
+        name = name.rstrip()
+        # Check the git configuration.
+        if not name:  # pragma: no cover
+            raise errors.ParameterError(
+                'Name is not valid: Valid format is "Name <email>"'
+            )
+        if not email:  # pragma: no cover
+            raise errors.ParameterError(
+                'Email is not valid: Valid format is "Name <email>"'
+            )
+
+        return cls(name=name, email=email)
+
     def __attrs_post_init__(self):
         """Finish object initialization."""
         # handle the case where ids were improperly set

--- a/renku/core/models/refs.py
+++ b/renku/core/models/refs.py
@@ -58,7 +58,7 @@ class LinkReference:
     def name_validator(self, attribute, value):
         """Validate reference name."""
         if not self.check_ref_format(value):
-            raise errors.UsageError(
+            raise errors.ParameterError(
                 'The reference name "{0}" is not valid.'.format(value)
             )
 

--- a/renku/core/models/refs.py
+++ b/renku/core/models/refs.py
@@ -37,7 +37,7 @@ class LinkReference:
     """Define a name of the folder with references in the Renku folder."""
 
     @classmethod
-    def check_ref_format(cls, name):
+    def check_ref_format(cls, name, no_slashes=False):
         r"""Ensures that a reference name is well formed.
 
         It follows Git naming convention:
@@ -51,8 +51,9 @@ class LinkReference:
         - it ends with ".lock", or
         - it contains a "@{" portion
         """
-        return subprocess.run(('git', 'check-ref-format', name)
-                              ).returncode == 0
+        params = ('--allow-onelevel', name) if no_slashes else (name, )
+        return subprocess.run(('git', 'check-ref-format') +
+                              params).returncode == 0
 
     @name.validator
     def name_validator(self, attribute, value):

--- a/renku/data/shacl_shape.json
+++ b/renku/data/shacl_shape.json
@@ -380,6 +380,14 @@
                "sh:class": {
                   "@id": "prov:Generation"
                }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:alternateName",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1
             }
          ]
       },

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -861,7 +861,7 @@ def test_dataset_date_created_format(runner, client, project):
     assert 0 == result.exit_code
     assert 'OK' in result.output
 
-    path = client.dataset_path('dataset')
+    path = client.get_dataset_path('dataset')
     assert path.exists()
 
     with path.open(mode='r') as fp:
@@ -880,7 +880,7 @@ def test_dataset_file_date_created_format(tmpdir, runner, client, project):
     assert 0 == result.exit_code
     assert 'OK' in result.output
 
-    path = client.dataset_path('dataset')
+    path = client.get_dataset_path('dataset')
     assert path.exists()
 
     # Create data file.

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -60,38 +60,22 @@ def test_datasets_create_with_metadata(runner, client):
     """Test creating a dataset with metadata."""
     result = runner.invoke(
         cli, [
-            'dataset', 'create', 'dataset', '--display-name', 'dataset-name',
-            '--description', 'some description here', '-c',
-            'John Doe <john.doe@mail.ch>', '-c',
+            'dataset', 'create', 'my-dataset', '--description',
+            'some description here', '-c', 'John Doe <john.doe@mail.ch>', '-c',
             'John Smiths<john.smiths@mail.ch>'
         ]
     )
     assert 0 == result.exit_code
     assert 'OK' in result.output
 
-    dataset = client.load_dataset(name='dataset-name')
-    assert dataset.name == 'dataset'
-    assert dataset.display_name == 'dataset-name'
+    dataset = client.load_dataset(name='my-dataset')
+    assert dataset.name == 'my-dataset'
+    assert dataset.internal_name == 'my-dataset'
     assert dataset.description == 'some description here'
     assert 'John Doe' in [c.name for c in dataset.creator]
     assert 'john.doe@mail.ch' in [c.email for c in dataset.creator]
     assert 'John Smiths' in [c.name for c in dataset.creator]
     assert 'john.smiths@mail.ch' in [c.email for c in dataset.creator]
-
-
-def test_datasets_create_different_display_name(runner, client):
-    """Test creating datasets with same name but different display name."""
-    result = runner.invoke(
-        cli, ['dataset', 'create', 'dataset', '--display-name', 'dataset-1']
-    )
-    assert 0 == result.exit_code
-    assert 'OK' in result.output
-
-    result = runner.invoke(
-        cli, ['dataset', 'create', 'dataset', '--display-name', 'dataset-2']
-    )
-    assert 0 == result.exit_code
-    assert 'OK' in result.output
 
 
 def test_datasets_create_with_same_name(runner, client):
@@ -103,17 +87,6 @@ def test_datasets_create_with_same_name(runner, client):
     result = runner.invoke(cli, ['dataset', 'create', 'dataset'])
     assert 1 == result.exit_code
     assert 'Dataset exists: "dataset"' in result.output
-
-
-def test_datasets_display_name_generation(runner, client):
-    """Test display_name is same as name when not provided."""
-    result = runner.invoke(cli, ['dataset', 'create', 'dataset-name'])
-    assert 0 == result.exit_code
-    assert 'OK' in result.output
-
-    dataset = client.load_dataset(name='dataset-name')
-    assert dataset.name == 'dataset-name'
-    assert dataset.display_name == 'dataset-name'
 
 
 def test_datasets_create_dirty(runner, project, client):
@@ -737,30 +710,22 @@ def test_datasets_ls_files_correct_paths(tmpdir, runner, project):
         assert Path(record['path']).exists()
 
 
-def test_datasets_ls_files_with_display_name(directory_tree, runner, project):
+def test_datasets_ls_files(directory_tree, runner, project):
     """Test listing of data within dataset with include/exclude filters."""
     # create a dataset
-    result = runner.invoke(
-        cli,
-        ['dataset', 'create', 'my-dataset', '--display-name', 'dataset-name']
-    )
+    result = runner.invoke(cli, ['dataset', 'create', 'my-dataset'])
     assert 0 == result.exit_code
 
     # add data to dataset
     result = runner.invoke(
         cli,
-        ['dataset', 'add', 'dataset-name', directory_tree.strpath],
+        ['dataset', 'add', 'my-dataset', directory_tree.strpath],
         catch_exceptions=False,
     )
     assert 0 == result.exit_code
 
     # list files with dataset name
     result = runner.invoke(cli, ['dataset', 'ls-files', 'my-dataset'])
-    assert 0 == result.exit_code
-    assert 'dir2/file2' in result.output
-
-    # list files with dataset display name
-    result = runner.invoke(cli, ['dataset', 'ls-files', 'dataset-name'])
     assert 0 == result.exit_code
     assert 'dir2/file2' in result.output
 

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -545,8 +545,7 @@ def test_add_from_git_copies_metadata(runner, client):
     )
     assert 0 == result.exit_code
 
-    path = client.dataset_path('remote')
-    dataset = client.get_dataset(path)
+    dataset = client.load_dataset('remote')
     assert dataset.files[0].name == 'README.rst'
     assert 'mailto:jiri.kuncar@gmail.com' in str(dataset.files[0].creator)
     assert 'mailto:rokroskar@gmail.co' in str(dataset.files[0].creator)
@@ -596,7 +595,7 @@ def test_usage_error_in_add_from_git(runner, client, params, n_urls, message):
 def read_dataset_file_metadata(client, dataset_name, filename):
     """Return metadata from dataset's YAML file."""
     with client.with_dataset(dataset_name) as dataset:
-        assert client.dataset_path(dataset.name).exists()
+        assert client.get_dataset_path(dataset.name).exists()
 
         for file_ in dataset.files:
             if file_.path.endswith(filename):

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -180,6 +180,11 @@ def test_dataset_serialization(dataset):
 
 def test_create_dataset_custom_message(project):
     """Test create dataset custom message."""
-    create_dataset('ds1', commit_message='my awesome dataset')
+    create_dataset(
+        'ds1',
+        description='',
+        creators=[],
+        commit_message='my awesome dataset'
+    )
     last_commit = Repo('.').head.commit
     assert 'my awesome dataset' == last_commit.message

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -182,6 +182,7 @@ def test_create_dataset_custom_message(project):
     """Test create dataset custom message."""
     create_dataset(
         'ds1',
+        short_name='',
         description='',
         creators=[],
         commit_message='my awesome dataset'

--- a/tests/core/commands/test_serialization.py
+++ b/tests/core/commands/test_serialization.py
@@ -31,7 +31,7 @@ def test_dataset_serialization(client, dataset, data_file):
     """Test Dataset serialization."""
 
     def load_dataset(name):
-        with open(str(client.dataset_path(name))) as f:
+        with open(str(client.get_dataset_path(name))) as f:
             return yaml.safe_load(f)
 
     d_dict = load_dataset('dataset')
@@ -54,7 +54,9 @@ def test_dataset_serialization(client, dataset, data_file):
 def test_dataset_deserialization(client, dataset):
     """Test Dataset deserialization."""
     from renku.core.models.datasets import Dataset
-    dataset_ = Dataset.from_yaml(client.dataset_path('dataset'), client=client)
+    dataset_ = Dataset.from_yaml(
+        client.get_dataset_path('dataset'), client=client
+    )
 
     dataset_types = {
         'created': datetime.datetime,


### PR DESCRIPTION
# Description

When creating datasets, users can provide its description, creators, and display name using command line options. Creator is a string with "Name <email>" format and users can pass multiple creators. 
This also makes a consistent use of `short_name` in the code. `short_name` is used as the dataset's data directory name and dataset's reference name. `name` is not used by Renku other than storing it as a metadata. If users don't provide a short name when creating a dataset then one is automatically created.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/515
Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/791
Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/840

