### PR TITLE
feat: use project name as default path when cloning

### DIFF
--- a/renku/core/management/clone.py
+++ b/renku/core/management/clone.py
@@ -23,6 +23,7 @@ from git import GitCommandError, Repo
 
 from renku.core import errors
 from renku.core.management.githooks import install
+from renku.core.models.git import GitURL
 
 
 def clone(
@@ -38,7 +39,7 @@ def clone(
     """Clone Renku project repo, install Git hooks and LFS."""
     from renku.core.management.client import LocalClient
 
-    path = path or '.'
+    path = path or GitURL.parse(url).name
     # Clone the project
     if skip_smudge:
         os.environ['GIT_LFS_SKIP_SMUDGE'] = '1'

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -927,3 +927,20 @@ def test_renku_clone(runner, monkeypatch):
             result = runner.invoke(cli, ['run', 'touch', 'output'])
             assert 'is not configured' in result.output
             assert 1 == result.exit_code
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    'path,expected_path', [('', 'datasets-test'), ('.', '.'),
+                           ('new-name', 'new-name')]
+)
+def test_renku_clone_uses_project_name(
+    runner, monkeypatch, path, expected_path
+):
+    """Test renku clone uses project name as target-path by default."""
+    REMOTE = 'https://dev.renku.ch/gitlab/virginiafriedrich/datasets-test.git'
+
+    with runner.isolated_filesystem() as project_path:
+        result = runner.invoke(cli, ['clone', REMOTE, path])
+        assert 0 == result.exit_code
+        assert (Path(project_path) / expected_path / 'Dockerfile').exists()


### PR DESCRIPTION
# Description

If we don't provide a path when running renku clone URL, Renku by default uses the current directory to clone the repo which can fail if current directory is not empty. This PR uses project's name as the default target path which is in par with what Git does.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/856
