### PR TITLE
fix: service dataset.create with additional metadata

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -402,15 +402,16 @@ def create(name, short_name, description, creator):
     """Create an empty dataset in the current repo."""
     creators = creator or ()
 
-    dataset = create_dataset(
+    new_dataset = create_dataset(
         name=name,
         short_name=short_name,
         description=description,
         creators=creators
     )
+
     click.echo(
-        'Use the name "{}" to refer to this dataset.'.format(
-            dataset.short_name
+        'Use the name "{0}" to refer to this dataset.'.format(
+            new_dataset.short_name
         )
     )
     click.secho('OK', fg='green')

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -102,7 +102,12 @@ def dataset_parent(client, revision, datadir, format, ctx=None):
     clean=False, commit=True, commit_only=DATASET_METADATA_PATHS
 )
 def create_dataset(
-    client, name, short_name, description, creators, commit_message=None
+    client,
+    name,
+    short_name=None,
+    description=None,
+    creators=None,
+    commit_message=None,
 ):
     """Create an empty dataset in the current repo.
 
@@ -110,8 +115,12 @@ def create_dataset(
     """
     if not creators:
         creators = [Person.from_git(client.repo)]
-    else:
+
+    elif hasattr(creators, '__iter__') and isinstance(creators[0], str):
         creators = [Person.from_string(c) for c in creators]
+
+    elif hasattr(creators, '__iter__') and isinstance(creators[0], dict):
+        creators = [Person.from_dict(creator) for creator in creators]
 
     dataset, _, __ = client.create_dataset(
         name=name,

--- a/renku/core/models/provenance/agents.py
+++ b/renku/core/models/provenance/agents.py
@@ -130,20 +130,27 @@ class Person:
     @classmethod
     def from_string(cls, string):
         """Create an instance from a 'Name <email>' string."""
-        REGEX = r'([^<]*)<{0,1}([^@<>]+@[^@<>]+\.[^@<>]+)*>{0,1}'
-        name, email = re.search(REGEX, string).groups()
+        regex_pattern = r'([^<]*)<{0,1}([^@<>]+@[^@<>]+\.[^@<>]+)*>{0,1}'
+        name, email = re.search(regex_pattern, string).groups()
         name = name.rstrip()
+
         # Check the git configuration.
         if not name:  # pragma: no cover
             raise errors.ParameterError(
-                'Name is not valid: Valid format is "Name <email>"'
+                'Name is invalid: A valid format is "Name <email>"'
             )
+
         if not email:  # pragma: no cover
             raise errors.ParameterError(
-                'Email is not valid: Valid format is "Name <email>"'
+                'Email is invalid: A valid format is "Name <email>"'
             )
 
         return cls(name=name, email=email)
+
+    @classmethod
+    def from_dict(cls, obj):
+        """Create and instance from a dictionary."""
+        return cls(**obj)
 
     def __attrs_post_init__(self):
         """Finish object initialization."""

--- a/renku/service/serializers/datasets.py
+++ b/renku/service/serializers/datasets.py
@@ -21,17 +21,18 @@ from marshmallow import Schema, fields, post_load, pre_load
 from renku.service.serializers.rpc import JsonRPCResponse
 
 
-class DatasetAuthors(Schema):
-    """Schema for the dataset authors."""
+class DatasetCreators(Schema):
+    """Schema for the dataset creators."""
 
     name = fields.String(required=True)
+    email = fields.String()
     affiliation = fields.String()
 
 
 class DatasetCreateRequest(Schema):
     """Request schema for dataset create view."""
 
-    authors = fields.List(fields.Nested(DatasetAuthors))
+    creators = fields.List(fields.Nested(DatasetCreators))
     commit_message = fields.String()
     dataset_name = fields.String(required=True)
     description = fields.String()

--- a/renku/service/views/datasets.py
+++ b/renku/service/views/datasets.py
@@ -230,7 +230,10 @@ def create_dataset_view(user, cache):
 
     with chdir(project_path):
         create_dataset(
-            ctx['dataset_name'], commit_message=ctx['commit_message']
+            ctx['dataset_name'],
+            commit_message=ctx['commit_message'],
+            creators=ctx.get('creators'),
+            description=ctx.get('description'),
         )
 
     if not repo_sync(project_path):

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -259,7 +259,7 @@ def test_dataset_creator_is_invalid(client, runner, creator, field):
     """Test create dataset with invalid creator format."""
     result = runner.invoke(cli, ['dataset', 'create', 'ds', '-c', creator])
     assert 2 == result.exit_code
-    assert field + ' is not valid' in result.output
+    assert field + ' is invalid' in result.output
 
 
 @pytest.mark.parametrize('output_format', DATASETS_FORMATS.keys())


### PR DESCRIPTION
closes: #874 

* improves the interface of dataset create for the service needs
* addresses a problems raised by linter
* adds ability to set metadata from the service