### PR TITLE
chore: updated format of tabular datasets list

### DIFF
--- a/renku/core/commands/format/datasets.py
+++ b/renku/core/commands/format/datasets.py
@@ -31,10 +31,11 @@ def tabular(client, datasets):
         datasets,
         headers=OrderedDict((
             ('uid', 'id'),
-            ('short_name', None),
-            ('version', None),
             ('created', None),
+            ('short_name', None),
             ('creators_csv', 'creators'),
+            ('tags_csv', 'tags'),
+            ('version', None),
         )),
         # workaround for tabulate issue 181
         # https://bitbucket.org/astanin/python-tabulate/issues/181/disable_numparse-fails-on-empty-input

--- a/renku/core/models/datasets.py
+++ b/renku/core/models/datasets.py
@@ -389,6 +389,11 @@ class Dataset(Entity, CreatorMixin):
         return ','.join(creator.short_name for creator in self.creator)
 
     @property
+    def tags_csv(self):
+        """Comma-separated list of tags associated with dataset."""
+        return ','.join(tag.name for tag in self.tags)
+
+    @property
     def editable(self):
         """Subset of attributes which user can edit."""
         obj = self.asjsonld()


### PR DESCRIPTION
* Re-aranges dataset list tabular display to better fit the screen
* Adds a tags to display tabular format


master:
```
ID                                    SHORT_NAME                        VERSION    CREATED              CREATORS
------------------------------------  --------------------------------  ---------  -------------------  ----------
0c829efa-8f54-4dd6-a143-d09a02c77ea0  7b68e6c5afba4e1f90afa59c495d337b             2019-12-03 08:09:03  J.Sam
22147c19-08e7-40c1-9311-79f0b184cb5e  5f480578f60b40f9845015f4c184f965             2019-12-04 17:39:37  J.Sam
```

This PR changes master preview to the following:
```
> renku dataset
ID                                    CREATED              SHORT_NAME                CREATORS    TAGS    VERSION
------------------------------------  -------------------  ------------------------  ----------  ------  ---------
e1ac801f-8a47-47ce-a482-a67fa46f8f7a  2019-12-18 11:32:26  my_super_awesome_data_h   sam,rok
cb1debb6-4140-46df-b57d-85275504cf6c  2019-12-18 11:33:09  234_h1_htmlhtml_my        sam,rok
c1e78b2c-2f25-4347-be0a-1cff709a2be4  2019-12-18 11:31:50  dataset_name              sam,rok
d8e9831d-bd63-43f3-a3e0-0503f591f281  2019-12-18 12:00:52  123_my_super_awesome_bla  sam
7559d249-7d63-4f0d-b930-31c180d337a2  2019-12-18 12:46:32  my_super_awesome_dataset  sam
84b7e61a-2331-42f0-94de-079674e7072c  2019-12-18 12:01:39  1234_my_super_awesome_d   R.Roskar
326adaf8-486d-44e7-b183-ae6b1256d474  2019-12-18 11:40:28  h1_htmlhtml_my_su         sam
6f756af5-c3e8-435d-a7df-44cd8f6bb345  2019-12-18 11:32:45  234_my_super_awesome_b    sam,rok

```

Version field is often left empty for renku created datasets so I find second approach more readable on my screen. So it follows the display logic where we first display required fields and then optional ones.