### PR TITLE
fix: extended gunicorn worker timeout

### DIFF
--- a/Dockerfile.svc
+++ b/Dockerfile.svc
@@ -18,4 +18,4 @@ RUN requirements-builder -e all --level=pypi setup.py > requirements.txt && \
 COPY . /code/renku
 RUN pip install -e .
 
-ENTRYPOINT ["gunicorn", "renku.service.entrypoint:app", "-b", "0.0.0.0:8080"]
+ENTRYPOINT ["gunicorn", "renku.service.entrypoint:app", "-b", "0.0.0.0:8080", "--timeout", "600"]


### PR DESCRIPTION
Extends gunicorn default timeout to enable long-running file uploads. 