### PR TITLE
feat: Adds protection for renku relevant paths in dataset add

### DIFF
--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -176,6 +176,20 @@ class IgnoredFiles(RenkuException):
         )
 
 
+class ProtectedFiles(RenkuException):
+    """Raise when trying to work with protected files."""
+
+    def __init__(self, ignored):
+        """Build a custom message."""
+        super(ProtectedFiles, self).__init__(
+            'The following paths are protected as part of renku:'
+            '\n\n' + '\n'.join(
+                '\t' + click.style(str(path), fg='yellow') for path in ignored
+            ) + '\n'
+            'They cannot be used in renku commands.'
+        )
+
+
 class MigrationRequired(RenkuException):
     """Raise when migration is required."""
 

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -313,7 +313,10 @@ class DatasetsApiMixin(object):
 
     def _check_protected_path(self, path):
         """Checks if a path is protected by renku."""
-        path_in_repo = path.relative_to(self.path)
+        try:
+            path_in_repo = path.relative_to(self.path)
+        except ValueError:
+            return False
 
         for protected_path in self.RENKU_PROTECTED_PATHS:
             str_path = str(path_in_repo)
@@ -338,6 +341,10 @@ class DatasetsApiMixin(object):
         if src.is_dir():
             if destination.exists() and not destination.is_dir():
                 raise errors.ParameterError('Cannot copy directory to a file')
+
+            if src.name == '.git':
+                # Cannot have a '.git' directory inside a Git repo
+                return []
 
             if self._check_protected_path(src):
                 raise errors.ProtectedFiles([src])

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -311,6 +311,17 @@ class DatasetsApiMixin(object):
         dataset.update_files(dataset_files)
         return warning_message
 
+    def _check_protected_path(self, path):
+        """Checks if a path is protected by renku."""
+        path_in_repo = path.relative_to(self.path)
+
+        for protected_path in self.RENKU_PROTECTED_PATHS:
+            str_path = str(path_in_repo)
+            if re.match('^{}$'.format(protected_path), str_path):
+                return True
+
+        return False
+
     def _add_from_local(self, dataset, path, link, destination):
         """Add a file or directory from local filesystem."""
         src = Path(path).resolve()
@@ -328,9 +339,8 @@ class DatasetsApiMixin(object):
             if destination.exists() and not destination.is_dir():
                 raise errors.ParameterError('Cannot copy directory to a file')
 
-            if src.name == '.git':
-                # Cannot have a '.git' directory inside a Git repo
-                return []
+            if self._check_protected_path(src):
+                raise errors.ProtectedFiles([src])
 
             files = []
             destination.mkdir(parents=True, exist_ok=True)
@@ -348,6 +358,9 @@ class DatasetsApiMixin(object):
             # Check if file is in the project and return it
             try:
                 path_in_repo = src.relative_to(self.path)
+
+                if self._check_protected_path(src):
+                    raise errors.ProtectedFiles([src])
             except ValueError:
                 pass
             else:

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -92,6 +92,12 @@ class RepositoryApiMixin(GitCore):
     WORKFLOW = 'workflow'
     """Directory for storing workflow in Renku."""
 
+    RENKU_PROTECTED_PATHS = [
+        '\\.renku/.*', 'Dockerfile', '\\.dockerignore', '\\.gitignore',
+        '\\.gitattributes', '\\.gitlab-ci\\.yml', 'environment\\.yml',
+        'requirements\\.txt', '\\.git/.*'
+    ]
+
     def __attrs_post_init__(self):
         """Initialize computed attributes."""
         #: Configure Renku path.

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -95,7 +95,7 @@ class RepositoryApiMixin(GitCore):
     RENKU_PROTECTED_PATHS = [
         '\\.renku/.*', 'Dockerfile', '\\.dockerignore', '\\.gitignore',
         '\\.gitattributes', '\\.gitlab-ci\\.yml', 'environment\\.yml',
-        'requirements\\.txt', '\\.git/.*'
+        'requirements\\.txt'
     ]
 
     def __attrs_post_init__(self):

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1400,9 +1400,51 @@ def test_add_same_filename_multiple(runner, client, directory_tree):
     result = runner.invoke(
         cli, [
             'dataset', 'add', '--force', 'my-dataset1', directory_tree.strpath,
-            'Dockerfile'
+            'README.md'
         ]
     )
+    assert 0 == result.exit_code
+
+
+def test_add_protected_file(runner, client, tmpdir):
+    """Check adding same filename multiple times."""
+    result = runner.invoke(
+        cli, ['dataset', 'add', '-c', 'my-dataset1', '.renku']
+    )
+
+    assert 1 == result.exit_code
+    assert 'Error: The following paths are protected' in result.output
+
+    result = runner.invoke(
+        cli, ['dataset', 'add', '-c', 'my-dataset1', '.renku/']
+    )
+
+    assert 1 == result.exit_code
+    assert 'Error: The following paths are protected' in result.output
+
+    result = runner.invoke(
+        cli, ['dataset', 'add', '-c', 'my-dataset1', 'Dockerfile']
+    )
+
+    assert 1 == result.exit_code
+    assert 'Error: The following paths are protected' in result.output
+
+    result = runner.invoke(
+        cli, ['dataset', 'add', '-c', 'my-dataset1', '.git']
+    )
+
+    assert 1 == result.exit_code
+    assert 'Error: The following paths are protected' in result.output
+
+    # create some data
+    new_file = tmpdir.join('.gitnotactuallygit')
+    new_file.write(str('test'))
+
+    result = runner.invoke(
+        cli, ['dataset', 'add', '-c', 'my-dataset1',
+              str(new_file)]
+    )
+
     assert 0 == result.exit_code
 
 

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1429,19 +1429,20 @@ def test_add_protected_file(runner, client, tmpdir):
     assert 1 == result.exit_code
     assert 'Error: The following paths are protected' in result.output
 
-    result = runner.invoke(
-        cli, ['dataset', 'add', '-c', 'my-dataset1', '.git']
-    )
-
-    assert 1 == result.exit_code
-    assert 'Error: The following paths are protected' in result.output
-
-    # create some data
-    new_file = tmpdir.join('.gitnotactuallygit')
+    new_file = tmpdir.join('.renkunotactuallyrenku')
     new_file.write(str('test'))
 
     result = runner.invoke(
         cli, ['dataset', 'add', '-c', 'my-dataset1',
+              str(new_file)]
+    )
+
+    assert 0 == result.exit_code
+    new_file = tmpdir.join('thisisnot.renku')
+    new_file.write(str('test'))
+
+    result = runner.invoke(
+        cli, ['dataset', 'add', '-c', 'my-dataset2',
               str(new_file)]
     )
 

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1406,43 +1406,28 @@ def test_add_same_filename_multiple(runner, client, directory_tree):
     assert 0 == result.exit_code
 
 
-def test_add_protected_file(runner, client, tmpdir):
-    """Check adding same filename multiple times."""
+@pytest.mark.parametrize('filename', ['.renku', '.renku/', 'Dockerfile'])
+def test_add_protected_file(runner, client, filename):
+    """Check adding a protected file."""
     result = runner.invoke(
-        cli, ['dataset', 'add', '-c', 'my-dataset1', '.renku']
+        cli, ['dataset', 'add', '-c', 'my-dataset1', filename]
     )
 
     assert 1 == result.exit_code
     assert 'Error: The following paths are protected' in result.output
 
-    result = runner.invoke(
-        cli, ['dataset', 'add', '-c', 'my-dataset1', '.renku/']
-    )
 
-    assert 1 == result.exit_code
-    assert 'Error: The following paths are protected' in result.output
+@pytest.mark.parametrize(
+    'filename', ['.renkunotactuallyrenku', 'thisisnot.renku']
+)
+def test_add_nonprotected_file(runner, client, tmpdir, filename):
+    """Check adding an 'almost' protected file."""
 
-    result = runner.invoke(
-        cli, ['dataset', 'add', '-c', 'my-dataset1', 'Dockerfile']
-    )
-
-    assert 1 == result.exit_code
-    assert 'Error: The following paths are protected' in result.output
-
-    new_file = tmpdir.join('.renkunotactuallyrenku')
+    new_file = tmpdir.join('filename')
     new_file.write(str('test'))
 
     result = runner.invoke(
         cli, ['dataset', 'add', '-c', 'my-dataset1',
-              str(new_file)]
-    )
-
-    assert 0 == result.exit_code
-    new_file = tmpdir.join('thisisnot.renku')
-    new_file.write(str('test'))
-
-    result = runner.invoke(
-        cli, ['dataset', 'add', '-c', 'my-dataset2',
               str(new_file)]
     )
 


### PR DESCRIPTION
Adds `.git/, .renku/, Dockerfile, environment.yml, .dockerignore, .gitignore, .gitlab-ci.yml, requirements.txt` as protected files that can't be added to a dataset. Adding to a dataset will store the file on LFS and the gitlab runner doesn't have LFS access, so I added more paths than the original issue asked for.

Closes #873 