### PR TITLE
chore: Only execute all macos integration tests on master/tags

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -119,6 +119,37 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
     needs: [test-macos]
+    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        brew update
+        brew install git-lfs shellcheck node || brew link --overwrite node
+        python -m pip install --upgrade pip
+        python -m pip install -e .[all]
+        git config --global --add user.name "Renku @ SDSC"
+        git config --global --add user.email "renku@datascience.ch"
+    - name: Test with pytest
+      env:
+        IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
+      run: pytest -m integration -v
+
+  test-macos-integration-pr:
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+    needs: [test-macos]
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
runs 3.7 macos integration on prs and 3.6, 3.7, 3.8 integrations on master/tags