### PR TITLE
fix: changes lfs pull paths to be relative to parent

### DIFF
--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -175,7 +175,8 @@ class StorageApiMixin(RepositoryApiMixin):
             client, commit, path = self.resolve_in_submodules(
                 self.repo.commit(), path
             )
-            client_dict[client.path].append(str(path))
+            rel_path = Path(path).relative_to(client.path)
+            client_dict[client.path].append(str(rel_path))
 
         for client_path, paths in client_dict.items():
             batch_size = math.ceil(len(paths) / ARGUMENT_BATCH_SIZE)


### PR DESCRIPTION
LFS does not work with absolute paths, for whatever reason.  So with cwd = `/work/flights-tutorial-data/`.
`git lfs pull -I /work/flights-tutorial-data/data/201901_us_flights_1/2019-01-flights.csv.zip` does not download the file from lfs, but `git lfs pull -I data/201901_us_flights_1/2019-01-flights.csv.zip` does.

I couldn't find any info on this on the net, but this PR fixes it.

Closes #903 