### PR TITLE
chore: use bot CI token for Pipfile updates

### DIFF
--- a/.github/pr_labels.yml
+++ b/.github/pr_labels.yml
@@ -3,3 +3,4 @@ invalidStatus: "pending"
 labelRule:
   not:
     - "documentation:pending"
+    - "pr:do-not-merge"

--- a/.github/workflows/pipfile-update.yml
+++ b/.github/workflows/pipfile-update.yml
@@ -22,10 +22,14 @@ jobs:
         pip install pipenv
         pipenv lock
     - name: Commit changed Pipfile.lock
-      uses: stefanzweifel/git-auto-commit-action@v2.5.0
+      run: |
+        git config --local user.email "renku@datascience.ch"
+        git config --local user.name "RenkuBot"
+        git add Pipfile.lock
+        git commit -m 'chore: automatically update Pipfile.lock' || true
+    #     git push origin ${{ github.head_ref }}
+    - name: Push changes
+      uses: ad-m/github-push-action@master
       with:
-        commit_message: "chore: automatically update Pipfile.lock"
+        github_token: ${{ secrets.RENKU_CI_TOKEN }}
         branch: ${{ github.head_ref }}
-        file_pattern: Pipfile.lock
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -149,35 +149,35 @@ jobs:
         IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
       run: pytest -m integration -v
 
-  test-macos-integration-pr:
-    runs-on: macos-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.7]
-    needs: [test-macos]
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        brew update
-        brew install git-lfs shellcheck node || brew link --overwrite node
-        python -m pip install --upgrade pip
-        python -m pip install -e .[all]
-        git config --global --add user.name "Renku @ SDSC"
-        git config --global --add user.email "renku@datascience.ch"
-    - name: Test with pytest
-      env:
-        IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
-      run: pytest -m integration -v
+  # test-macos-integration-pr:
+  #   runs-on: macos-latest
+  #   strategy:
+  #     max-parallel: 4
+  #     matrix:
+  #       python-version: [3.7]
+  #   needs: [test-macos]
+  #   if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #     with:
+  #       fetch-depth: 0
+  #   - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+  #   - name: Set up Python ${{ matrix.python-version }}
+  #     uses: actions/setup-python@v1
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
+  #   - name: Install dependencies
+  #     run: |
+  #       brew update
+  #       brew install git-lfs shellcheck node || brew link --overwrite node
+  #       python -m pip install --upgrade pip
+  #       python -m pip install -e .[all]
+  #       git config --global --add user.name "Renku @ SDSC"
+  #       git config --global --add user.email "renku@datascience.ch"
+  #   - name: Test with pytest
+  #     env:
+  #       IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
+  #     run: pytest -m integration -v
 
   publish-pypi:
     runs-on: ubuntu-latest

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,0 @@
-pull_request_rules:
-  - name: Automatic merge on approval
-    conditions:
-      - "#approved-reviews-by>=1"
-    actions:
-      merge:
-        method: rebase
-        strict: smart
-        


### PR DESCRIPTION
Instead of the default `GITHUB_TOKEN` use the bot-user token to ensure that the automated Pipfile commits trigger a new build. 

This includes and will close #958 