### PR TITLE
fix: ignore file based project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 # Idea software family
 .idea/
 *.ipr
+*.iml
 *.iws
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ __pycache__/
 
 # Idea software family
 .idea/
+*.ipr
+*.iws
+
 
 # C extensions
 *.so


### PR DESCRIPTION
IdeaJ added support for file based project files (instead of .idea) for Python. This PR adds those  and `iws` files to `.gitignore`.