### PR TITLE
fix: resolve symlinks when pulling LFS

### DIFF
--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -175,8 +175,12 @@ class StorageApiMixin(RepositoryApiMixin):
             client, commit, path = self.resolve_in_submodules(
                 self.repo.commit(), path
             )
-            rel_path = Path(path).relative_to(client.path)
-            client_dict[client.path].append(str(rel_path))
+            try:
+                absolute_path = Path(path).resolve()
+                relative_path = absolute_path.relative_to(client.path)
+            except ValueError:
+                relative_path = path
+            client_dict[client.path].append(str(relative_path))
 
         for client_path, paths in client_dict.items():
             batch_size = math.ceil(len(paths) / ARGUMENT_BATCH_SIZE)

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1467,3 +1467,17 @@ def test_add_remove_credentials(runner, client, monkeypatch):
     o = client._add_from_url(dataset, url, client.path, extract=False)
 
     assert 'https://example.com/index.html' == o[0]['url']
+
+
+def test_pull_data_from_lfs(runner, client, tmpdir):
+    """Test pulling data from LFS using relative paths."""
+    data = tmpdir.join('data.txt')
+    data.write('DATA')
+
+    result = runner.invoke(cli, ['dataset', 'add', '-c', 'my-data', str(data)])
+    assert 0 == result.exit_code
+
+    relative_path = Path('data') / 'my-data' / 'data.txt'
+
+    result = runner.invoke(cli, ['storage', 'pull', str(relative_path)])
+    assert 0 == result.exit_code


### PR DESCRIPTION
# Description
Resolves symlinks before pulling data from LFS.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/462
