### PR TITLE
fix: Fixes renku show sibling handling with no paths

### DIFF
--- a/renku/cli/show.py
+++ b/renku/cli/show.py
@@ -44,6 +44,24 @@ Then the following outputs would be shown.
    G
    $ renku show siblings A
    A
+   $ renku show siblings C G
+   C
+   D
+   ---
+   F
+   G
+   $ renku show siblings
+   A
+   ---
+   B
+   ---
+   C
+   D
+   ---
+   E
+   ---
+   F
+   G
 
 
 Input and output files

--- a/renku/core/commands/graph.py
+++ b/renku/core/commands/graph.py
@@ -411,6 +411,8 @@ class Graph(object):
         parent = None
 
         if isinstance(node, Entity):
+            if not node.parent:
+                return {node}
             parent_siblings = self.siblings(node.parent) - {node.parent}
             return set(node.parent.members) | parent_siblings
         elif isinstance(node, Generation):


### PR DESCRIPTION
Fixes some bugs with the `renku show siblings` command and changes the output so it's grouped by sibling-hood, for instance:
```
$ renku show siblings
figs/cumulative.png
figs/grid_plot.png
---
data/.gitkeep
---
f2
f1
```

Groups of siblings are separated by `---`, so it's easy to spot which paths belong together.

Also adds a `--flat` flag that produces a flat list with no duplicates, as well as a `--verbose` flag that also outputs commit information:

```
$ renku show siblings f1 f2
f2
f1
---
f2
f3
$ renku show siblings -f f1 f2
f1
f3
f2
$ renku show siblings -f -v f1 f2
f2 @ 5822f230ded10d296ffc48d362e6e92a9a5df585
f2 @ 433c96eeebf545bff7badb916bee8d195fd1477b
f1 @ 433c96eeebf545bff7badb916bee8d195fd1477b
f3 @ 5822f230ded10d296ffc48d362e6e92a9a5df585
$ renku show siblings -v f1 f2
f2 @ 5822f230ded10d296ffc48d362e6e92a9a5df585
f3 @ 5822f230ded10d296ffc48d362e6e92a9a5df585
---
f2 @ 433c96eeebf545bff7badb916bee8d195fd1477b
f1 @ 433c96eeebf545bff7badb916bee8d195fd1477b
```

Closes  #572 