### PR TITLE
fix: Dataverse integration tests

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -117,7 +117,9 @@ jobs:
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
       env:
+        DATAVERSE_ACCESS_TOKEN: ${{ secrets.DATAVERSE_ACCESS_TOKEN }}
         IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
+        ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
       run: pytest -m integration -v
 
   test-macos-integration:
@@ -147,7 +149,9 @@ jobs:
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
       env:
+        DATAVERSE_ACCESS_TOKEN: ${{ secrets.DATAVERSE_ACCESS_TOKEN }}
         IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
+        ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
       run: pytest -m integration -v
 
   # test-macos-integration-pr:
@@ -177,7 +181,9 @@ jobs:
   #       git config --global --add user.email "renku@datascience.ch"
   #   - name: Test with pytest
   #     env:
+  #       DATAVERSE_ACCESS_TOKEN: ${{ secrets.DATAVERSE_ACCESS_TOKEN }}
   #       IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
+  #       ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
   #     run: pytest -m integration -v
 
   publish-pypi:

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -154,38 +154,6 @@ jobs:
         ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
       run: pytest -m integration -v
 
-  # test-macos-integration-pr:
-  #   runs-on: macos-latest
-  #   strategy:
-  #     max-parallel: 4
-  #     matrix:
-  #       python-version: [3.7]
-  #   needs: [test-macos]
-  #   if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #   - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-  #   - name: Set up Python ${{ matrix.python-version }}
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
-  #   - name: Install dependencies
-  #     run: |
-  #       brew update
-  #       brew install git-lfs shellcheck node || brew link --overwrite node
-  #       python -m pip install --upgrade pip
-  #       python -m pip install -e .[all]
-  #       git config --global --add user.name "Renku @ SDSC"
-  #       git config --global --add user.email "renku@datascience.ch"
-  #   - name: Test with pytest
-  #     env:
-  #       DATAVERSE_ACCESS_TOKEN: ${{ secrets.DATAVERSE_ACCESS_TOKEN }}
-  #       IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
-  #       ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
-  #     run: pytest -m integration -v
-
   publish-pypi:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -1,0 +1,70 @@
+name: Integration Test when Publishing to External Data Warehouses
+
+on:
+  pull_request:
+    types: 
+    - closed
+    branches:
+    - master
+    paths:
+    - renku/core/commands/providers/*.py
+
+jobs:
+  test-linux-integration:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e .[nodocs]
+        git config --global --add user.name "Renku @ SDSC"
+        git config --global --add user.email "renku@datascience.ch"
+    - name: Test with pytest
+      env:
+        DATAVERSE_ACCESS_TOKEN: ${{ secrets.DATAVERSE_ACCESS_TOKEN }}
+        IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
+        ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
+      run: pytest -m publish -v
+
+  test-macos-integration:
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        brew update
+        brew install git-lfs shellcheck node || brew link --overwrite node
+        python -m pip install --upgrade pip
+        python -m pip install -e .[all]
+        git config --global --add user.name "Renku @ SDSC"
+        git config --global --add user.email "renku@datascience.ch"
+    - name: Test with pytest
+      env:
+        DATAVERSE_ACCESS_TOKEN: ${{ secrets.DATAVERSE_ACCESS_TOKEN }}
+        IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
+        ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
+      run: pytest -m publish -v

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -1,9 +1,7 @@
 name: Integration Test when Publishing to External Data Warehouses
 
 on:
-  pull_request:
-    types: 
-    - closed
+  push:
     branches:
     - master
     paths:
@@ -15,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -43,7 +41,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6]
     if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2

--- a/conftest.py
+++ b/conftest.py
@@ -26,17 +26,21 @@ import tempfile
 import time
 import urllib
 import uuid
+import warnings
 from copy import deepcopy
 from pathlib import Path
 
 import fakeredis
 import git
 import pytest
+import requests
 import responses
 import yaml
 from _pytest.monkeypatch import MonkeyPatch
 from click.testing import CliRunner
 from git import Repo
+
+from renku.core.utils.requests import retry
 
 
 @pytest.fixture(scope='module')
@@ -361,21 +365,53 @@ def local_client():
 def zenodo_sandbox(client):
     """Configure environment to use Zenodo sandbox environment."""
     os.environ['ZENODO_USE_SANDBOX'] = 'true'
-    client.set_value(
-        'zenodo', 'access_token',
-        'HPwXfABPZ7JNiwXMrktL7pevuuo9jt4gsUCkh3Gs2apg65ixa3JPyFukdGup'
-    )
+    access_token = os.getenv('ZENODO_ACCESS_TOKEN', '')
+    client.set_value('zenodo', 'access_token', access_token)
 
 
 @pytest.fixture
-def dataverse_demo(client):
+def dataverse_demo(client, dataverse_demo_cleanup):
     """Configure environment to use Dataverse demo environment."""
-    client.set_value(
-        'dataverse', 'access_token', '4ca13597-cf43-4815-8763-b64994058c19'
-    )
+    access_token = os.getenv('DATAVERSE_ACCESS_TOKEN', '')
+    client.set_value('dataverse', 'access_token', access_token)
     client.set_value('dataverse', 'server_url', 'https://demo.dataverse.org')
     client.repo.git.add('.renku/renku.ini')
     client.repo.index.commit('renku.ini')
+
+
+@pytest.fixture(scope='module')
+def dataverse_demo_cleanup(request):
+    """Delete all Dataverse datasets at the end of the test session."""
+    server_url = 'https://demo.dataverse.org'
+    access_token = os.getenv('DATAVERSE_ACCESS_TOKEN', '')
+    headers = {'X-Dataverse-key': access_token}
+
+    def remove_datasets():
+        url = f'{server_url}/api/v1/dataverses/sdsc-test-dataverse/contents'
+        try:
+            with retry() as session:
+                response = session.get(url=url, headers=headers)
+        except (ConnectionError, requests.exceptions.RequestException):
+            warnings.warn('Cannot clean up Dataverse datasets')
+            return
+
+        if response.status_code != 200:
+            warnings.warn('Cannot clean up Dataverse datasets')
+            return
+
+        datasets = response.json().get('data', [])
+
+        for dataset in datasets:
+            id = dataset.get('id')
+            if id is not None:
+                url = f'https://demo.dataverse.org/api/v1/datasets/{id}'
+                try:
+                    with retry() as session:
+                        session.delete(url=url, headers=headers)
+                except (ConnectionError, requests.exceptions.RequestException):
+                    pass
+
+    request.addfinalizer(remove_datasets)
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -40,8 +40,6 @@ from _pytest.monkeypatch import MonkeyPatch
 from click.testing import CliRunner
 from git import Repo
 
-from renku.core.utils.requests import retry
-
 
 @pytest.fixture(scope='module')
 def renku_path(tmpdir_factory):
@@ -382,6 +380,8 @@ def dataverse_demo(client, dataverse_demo_cleanup):
 @pytest.fixture(scope='module')
 def dataverse_demo_cleanup(request):
     """Delete all Dataverse datasets at the end of the test session."""
+    from renku.core.utils.requests import retry
+
     server_url = 'https://demo.dataverse.org'
     access_token = os.getenv('DATAVERSE_ACCESS_TOKEN', '')
     headers = {'X-Dataverse-key': access_token}

--- a/renku/core/utils/contexts.py
+++ b/renku/core/utils/contexts.py
@@ -59,7 +59,7 @@ class redirect_stdin(contextlib.ContextDecorator):
         setattr(sys, self._stream, self._old_targets.pop())
 
 
-def _wrap_path_or_stream(method, mode):  # noqa: D202
+def _wrap_path_or_stream(method, mode):
     """Open path with context or close stream at the end."""
 
     def decorator(path_or_stream):

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -45,11 +45,11 @@ check_styles(){
 
 build_docs(){
     sphinx-build -qnNW docs docs/_build/html
-    pytest -v -m "not integration" -o testpaths="docs conftest.py"
+    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py"
 }
 
 run_tests(){
-    pytest -v -m "not integration" -o testpaths="tests renku conftest.py"
+    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py"
 }
 
 usage(){

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ all_files = 1
 universal = 1
 
 [pydocstyle]
-add_ignore = D401
+add_ignore = D202,D401
 
 [compile_catalog]
 directory = renku/translations/

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -500,14 +500,16 @@ def test_dataset_export_upload_failure(runner, tmpdir, client, zenodo_sandbox):
     assert 'metadata.description' in result.output
 
 
-@pytest.mark.integration
+@pytest.mark.publish
 @flaky(max_runs=10, min_passes=1)
 @pytest.mark.parametrize(
     'provider,params,output',
     [('zenodo', [], 'zenodo.org/record'),
-     ('dataverse', ['--dataverse-name', 'sdsc-test-dataverse'], 'doi:')]
+     (
+         'dataverse', ['--dataverse-name', 'sdsc-published-test-dataverse'
+                       ], 'doi:'
+     )]
 )
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_export_published_url(
     runner, project, tmpdir, client, zenodo_sandbox, dataverse_demo, provider,
     params, output

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -50,7 +50,6 @@ from renku.core.utils.contexts import chdir
 )
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_real_doi(runner, project, doi, sleep_after):
     """Test dataset import for existing DOI."""
     result = runner.invoke(
@@ -102,7 +101,6 @@ def test_dataset_import_real_doi(runner, project, doi, sleep_after):
 )
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_real_param(doi, runner, project, sleep_after):
     """Test dataset import and check metadata parsing."""
     result = runner.invoke(cli, ['dataset', 'import', doi[0]], input=doi[1])
@@ -126,7 +124,6 @@ def test_dataset_import_real_param(doi, runner, project, sleep_after):
 )
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_uri_404(doi, runner, project, sleep_after):
     """Test dataset import and check that correct exception is raised."""
     result = runner.invoke(cli, ['dataset', 'import', doi[0]], input=doi[1])
@@ -138,7 +135,6 @@ def test_dataset_import_uri_404(doi, runner, project, sleep_after):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_real_doi_warnings(runner, project, sleep_after):
     """Test dataset import for existing DOI and dataset"""
     result = runner.invoke(
@@ -174,7 +170,6 @@ def test_dataset_import_real_doi_warnings(runner, project, sleep_after):
 )
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_fake_doi(runner, project, doi):
     """Test error raising for non-existing DOI."""
     result = runner.invoke(cli, ['dataset', 'import', doi[0]], input='y')
@@ -195,7 +190,6 @@ def test_dataset_import_fake_doi(runner, project, doi):
 )
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_real_http(runner, project, url, sleep_after):
     """Test dataset import through HTTPS."""
     result = runner.invoke(cli, ['dataset', 'import', url], input='y')
@@ -213,7 +207,6 @@ def test_dataset_import_real_http(runner, project, url, sleep_after):
 )
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_fake_http(runner, project, url):
     """Test dataset import through HTTPS."""
     result = runner.invoke(cli, ['dataset', 'import', url], input='y')
@@ -224,7 +217,6 @@ def test_dataset_import_fake_http(runner, project, url):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_and_extract(runner, project, client, sleep_after):
     """Test dataset import and extract files."""
     url = 'https://zenodo.org/record/2658634'
@@ -241,7 +233,6 @@ def test_dataset_import_and_extract(runner, project, client, sleep_after):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_different_names(runner, client, sleep_after):
     """Test can import same DOI under different names."""
     doi = '10.5281/zenodo.2658634'
@@ -260,7 +251,6 @@ def test_dataset_import_different_names(runner, client, sleep_after):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_ignore_uncompressed_files(
     runner, project, sleep_after
 ):
@@ -275,7 +265,6 @@ def test_dataset_import_ignore_uncompressed_files(
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_reimport_removed_dataset(runner, project, sleep_after):
     """Test re-importing of deleted datasets works."""
     doi = '10.5281/zenodo.2658634'
@@ -297,7 +286,6 @@ def test_dataset_reimport_removed_dataset(runner, project, sleep_after):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_import_preserve_names(runner, project, sleep_after):
     """Test import keeps original file names."""
     doi = '10.7910/DVN/F4NUMR'
@@ -314,9 +302,8 @@ def test_dataset_import_preserve_names(runner, project, sleep_after):
 @pytest.mark.parametrize(
     'provider,params,output',
     [('zenodo', [], 'zenodo.org/deposit'),
-     ('dataverse', ['--dataverse-name', 'SDSC-Test'], 'doi:')]
+     ('dataverse', ['--dataverse-name', 'sdsc-test-dataverse'], 'doi:')]
 )
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_export_upload_file(
     runner, project, tmpdir, client, zenodo_sandbox, dataverse_demo, provider,
     params, output
@@ -360,9 +347,8 @@ def test_dataset_export_upload_file(
 @pytest.mark.parametrize(
     'provider,params,output',
     [('zenodo', [], 'zenodo.org/deposit'),
-     ('dataverse', ['--dataverse-name', 'SDSC-Test'], 'doi:')]
+     ('dataverse', ['--dataverse-name', 'sdsc-test-dataverse'], 'doi:')]
 )
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_export_upload_tag(
     runner, project, tmpdir, client, zenodo_sandbox, dataverse_demo, provider,
     params, output
@@ -443,9 +429,8 @@ def test_dataset_export_upload_tag(
 @pytest.mark.parametrize(
     'provider,params,output',
     [('zenodo', [], 'zenodo.org/deposit'),
-     ('dataverse', ['--dataverse-name', 'SDSC-Test'], 'doi:')]
+     ('dataverse', ['--dataverse-name', 'sdsc-test-dataverse'], 'doi:')]
 )
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_export_upload_multiple(
     runner, project, tmpdir, client, zenodo_sandbox, dataverse_demo, provider,
     params, output
@@ -490,7 +475,6 @@ def test_dataset_export_upload_multiple(
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_export_upload_failure(runner, tmpdir, client, zenodo_sandbox):
     """Test failed uploading of a file to Zenodo deposit."""
     result = runner.invoke(cli, ['dataset', 'create', 'my-dataset'])
@@ -521,7 +505,7 @@ def test_dataset_export_upload_failure(runner, tmpdir, client, zenodo_sandbox):
 @pytest.mark.parametrize(
     'provider,params,output',
     [('zenodo', [], 'zenodo.org/record'),
-     ('dataverse', ['--dataverse-name', 'SDSC-Test'], 'doi:')]
+     ('dataverse', ['--dataverse-name', 'sdsc-test-dataverse'], 'doi:')]
 )
 @pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_export_published_url(
@@ -565,10 +549,7 @@ def test_dataset_export_published_url(
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
-def test_export_dataset_wrong_provider(
-    runner, project, tmpdir, client, zenodo_sandbox
-):
+def test_export_dataset_wrong_provider(runner, project, tmpdir, client):
     """Test non-existing provider."""
     result = runner.invoke(cli, ['dataset', 'create', 'my-dataset'])
 
@@ -595,7 +576,6 @@ def test_export_dataset_wrong_provider(
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_export(runner, client, project):
     """Check dataset not found exception raised."""
     result = runner.invoke(
@@ -609,10 +589,10 @@ def test_dataset_export(runner, client, project):
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
 @pytest.mark.parametrize(
-    'provider,params', [('zenodo', []),
-                        ('dataverse', ['--dataverse-name', 'SDSC-Test'])]
+    'provider,params',
+    [('zenodo', []),
+     ('dataverse', ['--dataverse-name', 'sdsc-test-dataverse'])]
 )
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_export_dataset_unauthorized(
     runner, project, client, tmpdir, zenodo_sandbox, dataverse_demo, provider,
     params
@@ -646,7 +626,6 @@ def test_export_dataset_unauthorized(
 
 
 @pytest.mark.integration
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_export_dataverse_no_dataverse_name(
     runner, project, client, dataverse_demo
 ):
@@ -663,7 +642,6 @@ def test_export_dataverse_no_dataverse_name(
 
 
 @pytest.mark.integration
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_export_dataverse_no_dataverse_url(runner, client, dataverse_demo):
     """Test export without providing a dataverse server url."""
     client.remove_value('dataverse', 'server_url')
@@ -705,7 +683,6 @@ def test_export_dataverse_no_dataverse_url(runner, client, dataverse_demo):
     ]
 )
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_add_data_from_git(runner, client, params, path):
     """Test add data to datasets from a git repository."""
     REMOTE = 'https://github.com/SwissDataScienceCenter/renku-jupyter.git'
@@ -732,7 +709,6 @@ def test_add_data_from_git(runner, client, params, path):
 
 
 @pytest.mark.integration
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 @flaky(max_runs=10, min_passes=1)
 def test_add_from_git_copies_metadata(runner, client):
     """Test an import from a git repository keeps creators name."""
@@ -770,7 +746,6 @@ def test_add_from_git_copies_metadata(runner, client):
     ]
 )
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_usage_error_in_add_from_git(runner, client, params, n_urls, message):
     """Test user's errors when adding to a dataset from a git repository."""
     remote = 'https://github.com/SwissDataScienceCenter/renku-jupyter.git'
@@ -812,7 +787,6 @@ def read_dataset_file_metadata(client, dataset_name, filename):
     'params', [[], ['-I', 'CHANGES.rst'], ['-I', 'C*'], ['remote']]
 )
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_update(client, runner, params):
     """Test local copy is updated when remote file is updates."""
     # Add dataset to project
@@ -846,7 +820,6 @@ def test_dataset_update(client, runner, params):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_update_remove_file(client, runner):
     """Test local copy is removed when remote file is removed."""
     # Add dataset to project
@@ -884,7 +857,6 @@ def test_dataset_update_remove_file(client, runner):
     'params', [['-I', 'non-existing'], ['non-existing-dataset']]
 )
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_invalid_update(client, runner, params):
     """Test updating a non-existing path."""
     # Add dataset to project
@@ -910,7 +882,6 @@ def test_dataset_invalid_update(client, runner, params):
     [[], ['-I', 'CHANGES.rst'], ['-I', 'CH*'], ['dataset-1', 'dataset-2']]
 )
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_dataset_update_multiple_datasets(
     client, runner, data_repository, directory_tree, params
 ):
@@ -951,7 +922,6 @@ def test_dataset_update_multiple_datasets(
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_empty_update(client, runner, data_repository, directory_tree):
     """Test update when nothing changed does not create a commit."""
     # Add dataset to project
@@ -976,7 +946,6 @@ def test_empty_update(client, runner, data_repository, directory_tree):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_import_from_renku_project(tmpdir, client, runner):
     """Test an imported dataset from other renku repos will have metadata."""
     from renku.core.management import LocalClient
@@ -1018,7 +987,6 @@ def test_import_from_renku_project(tmpdir, client, runner):
     'ref', ['v0.3.0', 'fe6ec65cc84bcf01e879ef38c0793208f7fab4bb']
 )
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_add_specific_refs(ref, runner, client):
     """Test adding a specific version of files."""
     FILENAME = 'CHANGES.rst'
@@ -1044,7 +1012,6 @@ def test_add_specific_refs(ref, runner, client):
     'ref', ['v0.3.1', '27e29abd409c83129a3fdb8b8b0b898b23bcb229']
 )
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_update_specific_refs(ref, runner, client):
     """Test updating to a specific version of files."""
     filename = 'CHANGES.rst'
@@ -1073,7 +1040,6 @@ def test_update_specific_refs(ref, runner, client):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_update_with_multiple_remotes_and_ref(runner, client):
     """Test updating fails when ref is ambiguous."""
     # create a dataset
@@ -1106,7 +1072,6 @@ def test_update_with_multiple_remotes_and_ref(runner, client):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_files_are_tracked_in_lfs(runner, client):
     """Test files added from a Git repo are tacked in Git LFS."""
     filename = 'CHANGES.rst'
@@ -1128,7 +1093,6 @@ def test_files_are_tracked_in_lfs(runner, client):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_renku_clone(runner, monkeypatch):
     """Test cloning of a Renku repo and existence of required settings."""
     from renku.core.management.storage import StorageApiMixin
@@ -1157,7 +1121,6 @@ def test_renku_clone(runner, monkeypatch):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-@pytest.mark.skip(reason='temporarily disabled, until #1035')
 def test_renku_clone_with_config(tmpdir):
     """Test cloning of a Renku repo and existence of required settings."""
     remote = 'https://dev.renku.ch/gitlab/virginiafriedrich/datasets-test.git'


### PR DESCRIPTION
# Description

Deletes unpublished Dataverse datasets when integration tests are done. For testing published datasets, it creates a GH action that runs this tests on merges to master when one of the files in `renku/core/commands/providers` change.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/1035
