### PR TITLE
fix(dataset): commit only dataset files

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -366,6 +366,8 @@ def zenodo_sandbox(client):
     os.environ['ZENODO_USE_SANDBOX'] = 'true'
     access_token = os.getenv('ZENODO_ACCESS_TOKEN', '')
     client.set_value('zenodo', 'access_token', access_token)
+    client.repo.git.add('.renku/renku.ini')
+    client.repo.index.commit('update renku.ini')
 
 
 @pytest.fixture

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -35,7 +35,6 @@ from renku.core.compat import contextlib
 from renku.core.errors import DatasetNotFound, InvalidAccessToken, \
     OperationError, ParameterError, UsageError
 from renku.core.management.datasets import DATASET_METADATA_PATHS
-from renku.core.management.git import COMMIT_DIFF_STRATEGY
 from renku.core.models.datasets import Dataset, Url, \
     generate_default_short_name
 from renku.core.models.provenance.agents import Person
@@ -125,7 +124,7 @@ def edit_dataset(client, dataset_id, transform_fn, commit_message=None):
 @pass_local_client(
     clean=False,
     commit=True,
-    commit_only=COMMIT_DIFF_STRATEGY,
+    commit_only=DATASET_METADATA_PATHS,
     commit_empty=False,
     raise_if_empty=True
 )
@@ -299,7 +298,7 @@ def list_files(
 @pass_local_client(
     clean=False,
     commit=True,
-    commit_only=COMMIT_DIFF_STRATEGY,
+    commit_only=DATASET_METADATA_PATHS,
 )
 @contextmanager
 def file_unlink(client, short_name, include, exclude, commit_message=None):
@@ -326,7 +325,7 @@ def file_unlink(client, short_name, include, exclude, commit_message=None):
 @pass_local_client(
     clean=False,
     commit=True,
-    commit_only=COMMIT_DIFF_STRATEGY,
+    commit_only=DATASET_METADATA_PATHS,
 )
 def dataset_remove(
     client,
@@ -382,11 +381,7 @@ def dataset_remove(
                 ref.delete()
 
 
-@pass_local_client(
-    clean=True,
-    commit=True,
-    commit_only=COMMIT_DIFF_STRATEGY,
-)
+@pass_local_client(clean=True, commit=False)
 def export_dataset(
     client,
     short_name,
@@ -493,7 +488,7 @@ def export_dataset(
 @pass_local_client(
     clean=False,
     commit=True,
-    commit_only=COMMIT_DIFF_STRATEGY,
+    commit_only=DATASET_METADATA_PATHS,
 )
 def import_dataset(
     client,
@@ -718,7 +713,7 @@ def _filter(
 @pass_local_client(
     clean=False,
     commit=True,
-    commit_only=COMMIT_DIFF_STRATEGY,
+    commit_only=DATASET_METADATA_PATHS,
 )
 def tag_dataset_with_client(
     client, short_name, tag, description, force=False, commit_message=None
@@ -744,7 +739,7 @@ def tag_dataset(client, short_name, tag, description, force=False):
 @pass_local_client(
     clean=False,
     commit=True,
-    commit_only=COMMIT_DIFF_STRATEGY,
+    commit_only=DATASET_METADATA_PATHS,
 )
 def remove_dataset_tags(client, short_name, tags, commit_message=True):
     """Removes tags from a dataset."""

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -327,7 +327,8 @@ class DatasetsApiMixin(object):
         self.repo.git.add(*files_to_commit, force=True)
         self.repo.git.add(self.renku_pointers_path, force=True)
 
-        if self.repo.is_dirty():
+        staged_files = self.repo.index.diff('HEAD')
+        if staged_files:
             msg = 'renku dataset: committing {} newly added files'.format(
                 len(files_to_commit)
             )
@@ -1206,5 +1207,7 @@ def _check_url(url):
 
 DATASET_METADATA_PATHS = [
     Path(RENKU_HOME) / Path(DatasetsApiMixin.DATASETS),
+    Path(RENKU_HOME) / Path(DatasetsApiMixin.POINTERS),
     Path(RENKU_HOME) / Path(LinkReference.REFS),
+    '.gitattributes',
 ]

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -601,6 +601,9 @@ def test_export_dataset_unauthorized(
 ):
     """Test unauthorized exception raised."""
     client.set_value(provider, 'access_token', 'not-a-token')
+    client.repo.git.add('.renku/renku.ini')
+    client.repo.index.commit('update renku.ini')
+
     result = runner.invoke(cli, ['dataset', 'create', 'my-dataset'])
     assert 0 == result.exit_code
     assert 'OK' in result.output


### PR DESCRIPTION
# Description

When the repo is dirty some renku commands (e.g. `renku dataset add`) commit all the dirty changes when finished. This PR fixes this issue by committing only files that are modified by the command.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/1108
