### PR TITLE
feat(dataset): bypass import confirmation

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -675,7 +675,10 @@ def export_(
     is_flag=True,
     help='Extract files before importing to dataset.'
 )
-def import_(uri, short_name, extract):
+@click.option(
+    '-y', '--yes', is_flag=True, help='Bypass download confirmation.'
+)
+def import_(uri, short_name, extract, yes):
     """Import data from a 3rd party provider.
 
     Supported providers: [Zenodo, Dataverse]
@@ -685,6 +688,7 @@ def import_(uri, short_name, extract):
         short_name=short_name,
         extract=extract,
         with_prompt=True,
+        yes=yes,
         progress=_DownloadProgressbar
     )
     click.secho('OK', fg='green')

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -496,6 +496,7 @@ def import_dataset(
     short_name='',
     extract=False,
     with_prompt=False,
+    yes=False,
     commit_message=None,
     progress=None,
 ):
@@ -510,7 +511,7 @@ def import_dataset(
         files = dataset.files
         total_size = 0
 
-        if with_prompt:
+        if with_prompt and not yes:
             click.echo(
                 tabulate(
                     files,

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -196,9 +196,10 @@ def test_dataset_import_expected_err(runner, project, doi, err):
 @flaky(max_runs=10, min_passes=1)
 def test_dataset_import_real_http(runner, project, url, sleep_after):
     """Test dataset import through HTTPS."""
-    result = runner.invoke(cli, ['dataset', 'import', url], input='y')
+    result = runner.invoke(cli, ['dataset', 'import', '-y', url], input='n')
 
     assert 0 == result.exit_code
+    assert 'Do you wish to download this version?' not in result.output
     assert 'OK' in result.output
 
 


### PR DESCRIPTION
# Description

Can avoid download confirmation prompt when importing a dataset by passing `-y` or `--yes`.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/915
