### PR TITLE
fix(dataset): --no-external-storage flag not working

### DIFF
--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -83,17 +83,19 @@ class StorageApiMixin(RepositoryApiMixin):
         :raises: ``errors.ExternalStorageNotInstalled``
         :raises: ``errors.ExternalStorageDisabled``
         """
+        if not self.use_external_storage:
+            return False
+
         repo_config = self.repo.config_reader(config_level='repository')
         lfs_enabled = repo_config.has_section('filter "lfs"')
 
-        storage_enabled = lfs_enabled and self.storage_installed
-        if self.use_external_storage and not storage_enabled:
+        if not lfs_enabled:
             raise errors.ExternalStorageDisabled(self.repo)
 
-        if lfs_enabled and not self.storage_installed:
+        if not self.storage_installed:
             raise errors.ExternalStorageNotInstalled(self.repo)
 
-        return lfs_enabled and self.storage_installed
+        return True
 
     def init_external_storage(self, force=False):
         """Initialize the external storage for data."""

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -1195,7 +1195,7 @@ def test_renku_clone(runner, monkeypatch):
             monkey.setattr(StorageApiMixin, 'storage_installed', False)
             # Repo is using external storage but it's not installed.
             result = runner.invoke(cli, ['run', 'touch', 'output'])
-            assert 'is not configured' in result.output
+            assert 'External storage is not installed' in result.output
             assert 1 == result.exit_code
 
 

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -1195,7 +1195,7 @@ def test_renku_clone(runner, monkeypatch):
             monkey.setattr(StorageApiMixin, 'storage_installed', False)
             # Repo is using external storage but it's not installed.
             result = runner.invoke(cli, ['run', 'touch', 'output'])
-            assert 'External storage is not installed' in result.output
+            assert 'External storage is not configured' in result.output
             assert 1 == result.exit_code
 
 

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -320,7 +320,7 @@ def test_configuration_of_no_external_storage(isolated_runner, monkeypatch):
         monkey.setattr(StorageApiMixin, 'storage_installed', False)
         # Missing --no-external-storage flag.
         result = runner.invoke(cli, ['run', 'touch', 'output'])
-        assert 'is not configured' in result.output
+        assert 'External storage is not configured' in result.output
         assert 1 == result.exit_code
 
         # Since repo is not using external storage.
@@ -354,7 +354,7 @@ def test_configuration_of_external_storage(isolated_runner, monkeypatch):
         monkey.setattr(StorageApiMixin, 'storage_installed', False)
         # Repo is using external storage but it's not installed.
         result = runner.invoke(cli, ['run', 'touch', 'output'])
-        assert 'is not configured' in result.output
+        assert 'External storage is not installed' in result.output
         assert 1 == result.exit_code
 
     # Clean repo and check external storage.
@@ -374,9 +374,13 @@ def test_file_tracking(isolated_runner):
     )
     assert 0 == result.exit_code
 
-    result = runner.invoke(cli, ['run', 'touch', 'output'])
+    result = runner.invoke(cli, ['run', 'touch', 'tracked'])
     assert 0 == result.exit_code
-    assert 'output' in Path('.gitattributes').read_text()
+    assert 'tracked' in Path('.gitattributes').read_text()
+
+    result = runner.invoke(cli, ['-S', 'run', 'touch', 'untracked'])
+    assert 0 == result.exit_code
+    assert 'untracked' not in Path('.gitattributes').read_text()
 
 
 @pytest.mark.xfail

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -354,8 +354,12 @@ def test_configuration_of_external_storage(isolated_runner, monkeypatch):
         monkey.setattr(StorageApiMixin, 'storage_installed', False)
         # Repo is using external storage but it's not installed.
         result = runner.invoke(cli, ['run', 'touch', 'output'])
-        assert 'External storage is not installed' in result.output
         assert 1 == result.exit_code
+        assert 'External storage is not configured' in result.output
+
+        result = runner.invoke(cli, ['-S', 'run', 'touch', 'output'])
+        assert 1 == result.exit_code
+        assert 'External storage is not installed' in result.output
 
     # Clean repo and check external storage.
     subprocess.call(['git', 'clean', '-df'])


### PR DESCRIPTION
# Description

Running renku with `--no-external-storage` was still tracking files in LFS which will be fixed by this PR.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/1129
