### PR TITLE
feat(service): create projects from templates

### DIFF
--- a/renku/core/utils/templates.py
+++ b/renku/core/utils/templates.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Templates utils."""
+
+TEMPLATE = {
+    'URL': 'https://github.com/SwissDataScienceCenter/renku-project-template',
+    'REF': '0.1.9',
+    'DEFAULT': {
+        'ID': 'python-minimal',
+        'INDEX': 1,
+    }
+}

--- a/renku/service/entrypoint.py
+++ b/renku/service/entrypoint.py
@@ -40,12 +40,27 @@ from renku.service.views.datasets import DATASET_BLUEPRINT_TAG, \
     list_dataset_files_view, list_datasets_view
 from renku.service.views.jobs import JOBS_BLUEPRINT_TAG, jobs_blueprint, \
     list_jobs
+from renku.service.views.templates import TEMPLATES_BLUEPRINT_TAG, \
+    read_manifest_from_template, templates_blueprint
 
 logging.basicConfig(level=os.getenv('SERVICE_LOG_LEVEL', 'WARNING'))
 
 
 def create_app():
     """Creates a Flask app with a necessary configuration."""
+
+    # ! TEMP REMOVE Wait for the VS Code debugger to attach if requested
+    # VSCODE_DEBUG = os.environ.get("VSCODE_DEBUG") == "1"
+    # if VSCODE_DEBUG:
+    #     import ptvsd
+
+    #     print("Waiting for debugger attach")
+    #     ptvsd.enable_attach(
+    #         address=("localhost", 5678),
+    #         redirect_output=True,
+    #     )
+    #     ptvsd.wait_for_attach()
+
     app = Flask(__name__)
     app.secret_key = os.getenv('RENKU_SVC_SERVICE_KEY', uuid.uuid4().hex)
     app.json_encoder = SvcJSONEncoder
@@ -84,6 +99,7 @@ def build_routes(app):
     app.register_blueprint(cache_blueprint)
     app.register_blueprint(dataset_blueprint)
     app.register_blueprint(jobs_blueprint)
+    app.register_blueprint(templates_blueprint)
 
     swaggerui_blueprint = get_swaggerui_blueprint(
         SWAGGER_URL, API_SPEC_URL, config={'app_name': 'Renku Service'}
@@ -103,6 +119,10 @@ def build_routes(app):
     docs.register(list_dataset_files_view, blueprint=DATASET_BLUEPRINT_TAG)
 
     docs.register(list_jobs, blueprint=JOBS_BLUEPRINT_TAG)
+
+    docs.register(
+        read_manifest_from_template, blueprint=TEMPLATES_BLUEPRINT_TAG
+    )
 
 
 app = create_app()

--- a/renku/service/serializers/templates.py
+++ b/renku/service/serializers/templates.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renku service template serializers."""
+
+from marshmallow import Schema, fields
+
+from renku.service.serializers.rpc import JsonRPCResponse
+
+
+class ManifestTemplatesRequest(Schema):
+    """Request schema for listing manifest templates."""
+
+    # url = fields.String(required=True)
+    # ref = fields.String(missing='master')
+    project_id = fields.String(required=True)
+
+
+class ManifestTemplateSchema(Schema):
+    """Manifest template schema."""
+
+    description = fields.String(required=True)
+    folder = fields.String(required=True)
+    name = fields.String(required=True)
+    variables = fields.Dict(missing={})
+
+
+class ManifestTemplatesResponse(Schema):
+    """Manifest templates response."""
+
+    templates = fields.List(
+        fields.Nested(ManifestTemplateSchema), required=True
+    )
+
+
+class ManifestTemplatesResponseRPC(JsonRPCResponse):
+    """RPC schema for listing manifest templates."""
+
+    result = fields.Nested(ManifestTemplatesResponse)

--- a/renku/service/views/cache.py
+++ b/renku/service/views/cache.py
@@ -210,6 +210,8 @@ def project_clone(user, cache):
         }
     )
 
+    # TODO: switch repo?
+
     project = cache.make_project(user, ctx)
 
     return result_response(ProjectCloneResponseRPC(), project)

--- a/renku/service/views/templates.py
+++ b/renku/service/views/templates.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renku service templates view."""
+
+from flask import Blueprint, request
+from flask_apispec import marshal_with, use_kwargs
+
+from renku.core.commands.init import read_template_manifest
+from renku.service.config import SERVICE_PREFIX
+from renku.service.serializers.templates import ManifestTemplatesRequest, \
+    ManifestTemplatesResponseRPC
+from renku.service.views import result_response
+from renku.service.views.decorators import accepts_json, handle_base_except, \
+    handle_git_except, handle_renku_except, handle_validation_except, \
+    header_doc, requires_cache, requires_identity
+
+TEMPLATES_BLUEPRINT_TAG = 'templates'
+templates_blueprint = Blueprint(
+    TEMPLATES_BLUEPRINT_TAG, __name__, url_prefix=SERVICE_PREFIX
+)
+
+
+@use_kwargs(ManifestTemplatesRequest, locations=['query'])
+@marshal_with(ManifestTemplatesResponseRPC)
+@header_doc('List templates in repositpry.', tags=(TEMPLATES_BLUEPRINT_TAG, ))
+@templates_blueprint.route(
+    '/templates.read_manifest',
+    methods=['GET'],
+    provide_automatic_options=False,
+)
+@handle_base_except
+@handle_git_except
+@handle_renku_except
+@handle_validation_except
+@requires_cache
+@requires_identity
+@accepts_json
+def read_manifest_from_template(user, cache):
+    """Read templates from the manifest file of a template repository."""
+
+    ctx = ManifestTemplatesRequest().load(request.args)
+    user = cache.ensure_user(user)
+
+    # read project and manifest
+    project = cache.get_project(user, ctx['project_id'])
+    manifest = read_template_manifest(project.abs_path)
+    # INFO: specific error handling
+    # #try: [...] except errors.InvalidTemplateError as e: [...]
+    # # with chdir(project.abs_path): [...]
+
+    return result_response(
+        ManifestTemplatesResponseRPC(), {'templates': manifest}
+    )

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,10 @@ from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.build_py import build_py as _build_py
 from setuptools.command.develop import develop as _develop
 
-URL = 'https://github.com/SwissDataScienceCenter/renku-project-template'
-REFERENCE = '0.1.9'
+TEMPLATE = {
+    'URL': 'https://github.com/SwissDataScienceCenter/renku-project-template',
+    'REF': '0.1.9',
+}
 
 
 class DownloadTemplates(Command):
@@ -51,7 +53,7 @@ class DownloadTemplates(Command):
             # download and extract template data
             temppath = Path(tempdir)
             print('downloading Renku templates...')
-            fetch_template(URL, REFERENCE, temppath)
+            fetch_template(TEMPLATE['URL'], TEMPLATE['REF'], temppath)
             read_template_manifest(temppath, checkout=True)
 
             # copy templates

--- a/tests/cli/test_errors.py
+++ b/tests/cli/test_errors.py
@@ -20,9 +20,9 @@ import sys
 import tempfile
 
 import pytest
-from tests.core.commands.test_init import TEMPLATE_ID
 
 from renku.cli import cli
+from renku.core.utils.templates import TEMPLATE
 
 
 @pytest.mark.parametrize(
@@ -80,7 +80,7 @@ def test_cli_initialization_err(cmd, runner):
         ['storage', '--help'],
         ['update', '--help'],
         ['workflow', '--help'],
-        ['init', '--template-id', TEMPLATE_ID, '--force'],
+        ['init', '--template-id', TEMPLATE['DEFAULT']['ID'], '--force'],
         ['init', '--help'],
         ['help'],
         ['--help'],

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -19,21 +19,24 @@
 from pathlib import Path
 
 import pytest
-from tests.core.commands.test_init import TEMPLATE_ID, TEMPLATE_INDEX, \
-    TEMPLATE_REF, TEMPLATE_URL
 from tests.utils import raises
 
 from renku.cli import cli
 from renku.cli.init import create_template_sentence, parse_parameters
 from renku.core import errors
+from renku.core.utils.templates import TEMPLATE
 
-INIT = ['init', 'test-new-project', '--template-id', TEMPLATE_ID]
+INIT = ['init', 'test-new-project', '--template-id', TEMPLATE['DEFAULT']['ID']]
 INIT_REMOTE = [
-    '--template-source', TEMPLATE_URL, '--template-ref', TEMPLATE_REF
+    '--template-source', TEMPLATE['URL'], '--template-ref', TEMPLATE['REF']
 ]
 INIT_FORCE = ['--force']
-INIT_INDEX = ['init', 'test-new-project-2', '--template-index', TEMPLATE_INDEX]
-INIT_ID = ['--template-id', TEMPLATE_ID]
+INIT_VARIABLES = ['--template-variables']
+INIT_INDEX = [
+    'init', 'test-new-project-2', '--template-index',
+    TEMPLATE['DEFAULT']['INDEX']
+]
+INIT_ID = ['--template-id', TEMPLATE['DEFAULT']['ID']]
 LIST_TEMPLATES = ['--list-templates']
 PARAMETERS_CORRECT = ['--parameter', 'p1=v1', '--parameter', 'p2=v2']
 PARAMETER_NO_EQUAL = ['--parameter', 'p3:v3']
@@ -97,7 +100,7 @@ def test_list_templates(isolated_runner):
     result = isolated_runner.invoke(cli, INIT + LIST_TEMPLATES)
     assert 0 == result.exit_code
     assert not new_project.exists()
-    assert TEMPLATE_ID in result.output
+    assert TEMPLATE['DEFAULT']['ID'] in result.output
 
 
 def test_init(isolated_runner):

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -29,13 +29,13 @@ from pathlib import Path
 import git
 import pytest
 import yaml
-from tests.core.commands.test_init import TEMPLATE_ID
 
 from renku import __version__
 from renku.cli import cli
 from renku.core.management.storage import StorageApiMixin
 from renku.core.models.cwl.ascwl import CWLClass, ascwl
 from renku.core.models.cwl.workflow import Workflow
+from renku.core.utils.templates import TEMPLATE
 
 
 def test_version(runner):
@@ -276,7 +276,7 @@ def test_show_inputs(tmpdir_factory, project, runner, run):
             'init',
             str(second_project),
             '--template-id',
-            TEMPLATE_ID,
+            TEMPLATE['DEFAULT']['ID'],
         )
     )
 
@@ -310,8 +310,10 @@ def test_configuration_of_no_external_storage(isolated_runner, monkeypatch):
     os.chdir('test-project')
 
     result = runner.invoke(
-        cli,
-        ['--no-external-storage', 'init', '.', '--template-id', TEMPLATE_ID]
+        cli, [
+            '--no-external-storage', 'init', '.', '--template-id',
+            TEMPLATE['DEFAULT']['ID']
+        ]
     )
     assert 0 == result.exit_code
     # Pretend that git-lfs is not installed.
@@ -342,7 +344,10 @@ def test_configuration_of_external_storage(isolated_runner, monkeypatch):
     runner = isolated_runner
 
     result = runner.invoke(
-        cli, ['--external-storage', 'init', '.', '--template-id', TEMPLATE_ID]
+        cli, [
+            '--external-storage', 'init', '.', '--template-id',
+            TEMPLATE['DEFAULT']['ID']
+        ]
     )
     assert 0 == result.exit_code
     # Pretend that git-lfs is not installed.
@@ -369,7 +374,9 @@ def test_file_tracking(isolated_runner):
 
     os.mkdir('test-project')
     os.chdir('test-project')
-    result = runner.invoke(cli, ['init', '.', '--template-id', TEMPLATE_ID])
+    result = runner.invoke(
+        cli, ['init', '.', '--template-id', TEMPLATE['DEFAULT']['ID']]
+    )
     assert 0 == result.exit_code
 
     result = runner.invoke(cli, ['run', 'touch', 'tracked'])
@@ -394,14 +401,20 @@ def test_status_with_submodules(isolated_runner, monkeypatch):
 
     os.chdir('foo')
     result = runner.invoke(
-        cli, ['init', '.', '--template', TEMPLATE_ID, '--no-external-storage'],
+        cli, [
+            'init', '.', '--template', TEMPLATE['DEFAULT']['ID'],
+            '--no-external-storage'
+        ],
         catch_exceptions=False
     )
     assert 0 == result.exit_code
 
     os.chdir('../bar')
     result = runner.invoke(
-        cli, ['init', '.', '--template', TEMPLATE_ID, '--no-external-storage'],
+        cli, [
+            'init', '.', '--template', TEMPLATE['DEFAULT']['ID'],
+            '--no-external-storage'
+        ],
         catch_exceptions=False
     )
     assert 0 == result.exit_code

--- a/tests/core/commands/test_init.py
+++ b/tests/core/commands/test_init.py
@@ -29,13 +29,8 @@ from renku.core import errors
 from renku.core.commands.init import TEMPLATE_MANIFEST, create_from_template, \
     fetch_template, read_template_manifest, validate_template
 from renku.core.management.config import RENKU_HOME
+from renku.core.utils.templates import TEMPLATE
 
-TEMPLATE_URL = (
-    'https://github.com/SwissDataScienceCenter/renku-project-template'
-)
-TEMPLATE_ID = 'python-minimal'
-TEMPLATE_INDEX = 1
-TEMPLATE_REF = '0.1.9'
 METADATA = {'name': 'myname', 'description': 'nodesc'}
 FAKE = 'NON_EXISTING'
 
@@ -43,9 +38,9 @@ template_local = Path(pkg_resources.resource_filename('renku', 'templates'))
 
 
 @pytest.mark.parametrize(
-    'url, ref, result, error', [(TEMPLATE_URL, TEMPLATE_REF, True, None),
-                                (FAKE, TEMPLATE_REF, None, errors.GitError),
-                                (TEMPLATE_URL, FAKE, None, errors.GitError)]
+    'url, ref, result, error', [(TEMPLATE['URL'], TEMPLATE['REF'], True, None),
+                                (FAKE, TEMPLATE['REF'], None, errors.GitError),
+                                (TEMPLATE['URL'], FAKE, None, errors.GitError)]
 )
 @pytest.mark.integration
 def test_fetch_template(url, ref, result, error):
@@ -133,7 +128,7 @@ def test_fetch_template_and_read_manifest():
     """
     with TemporaryDirectory() as tempdir:
         template_path = Path(tempdir)
-        fetch_template(TEMPLATE_URL, TEMPLATE_REF, template_path)
+        fetch_template(TEMPLATE['URL'], TEMPLATE['REF'], template_path)
         manifest = read_template_manifest(template_path, checkout=True)
         for template in manifest:
             template_folder = template_path / template['folder']

--- a/tests/service/views/test_templates_views.py
+++ b/tests/service/views/test_templates_views.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renku service templates view tests."""
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from flaky import flaky
+
+from renku.core.commands.init import fetch_template, read_template_manifest
+from renku.core.utils.templates import TEMPLATE
+
+
+@pytest.mark.service
+@pytest.mark.integration
+@flaky(max_runs=10, min_passes=1)
+def test_read_manifest_from_template(svc_client_with_templates):
+    """Check reading manifest template."""
+    svc_client, headers, project_id = svc_client_with_templates
+
+    # TODO: handle ref
+    params = {'project_id': project_id}
+
+    response = svc_client.get(
+        # '/templates.read_manifest', data=json.dumps(payload), headers=headers
+        '/templates.read_manifest',
+        query_string=params,
+        headers=headers
+    )
+
+    assert response
+    assert {'result'} == set(response.json.keys())
+    assert response.json['result']['templates']
+    templates = response.json['result']['templates']
+    assert len(templates) > 0
+    default_template = templates[TEMPLATE['DEFAULT']['INDEX'] - 1]
+    assert default_template['folder'] == TEMPLATE['DEFAULT']['ID']
+
+
+@pytest.mark.service
+@pytest.mark.integration
+@flaky(max_runs=10, min_passes=1)
+def test_compare_manifests(svc_client_with_templates):
+    """Check reading manifest template."""
+
+    svc_client, headers, project_id = svc_client_with_templates
+    params = {'project_id': project_id}
+    response = svc_client.get(
+        '/templates.read_manifest', query_string=params, headers=headers
+    )
+    assert response
+    assert {'result'} == set(response.json.keys())
+    assert response.json['result']['templates']
+
+    with TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        manifest_file = fetch_template(
+            TEMPLATE['URL'], TEMPLATE['REF'], temp_path
+        )
+        manifest = read_template_manifest(temp_path)
+
+        assert manifest_file and manifest_file.exists()
+        assert manifest
+
+        templates_service = response.json['result']['templates']
+        templates_local = manifest
+        default_index = TEMPLATE['DEFAULT']['INDEX'] - 1
+        assert templates_service[default_index
+                                 ] == templates_local[default_index]


### PR DESCRIPTION
# Description

**DRAFT -- ONLY MANIFEST READ**

Allow an authorized user to invoke the service to clone a template repository, get the information from the manifest and initialyze a new project from one of the available templates.

Fixes #862 
