### PR TITLE
fix(dataset): avoid recursive addition of data directory

### DIFF
--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -394,6 +394,10 @@ class DatasetsApiMixin(object):
         if src.is_dir():
             if destination.exists() and not destination.is_dir():
                 raise errors.ParameterError('Cannot copy directory to a file')
+            if src == (self.path / dataset.datadir).resolve():
+                raise errors.ParameterError(
+                    f'Cannot add dataset\'s data directory recursively: {path}'
+                )
 
             if src.name == '.git':
                 # Cannot have a '.git' directory inside a Git repo

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -516,6 +516,20 @@ def test_add_from_local_repo_warning(
     assert 'Use remote\'s Git URL instead to enable lineage ' in result.output
 
 
+def test_add_data_directory(runner, client):
+    """Test adding a dataset's data directory to it prints an error."""
+    result = runner.invoke(cli, ['dataset', 'create', 'new-dataset'])
+    assert 0 == result.exit_code
+
+    result = runner.invoke(
+        cli,
+        ['dataset', 'add', 'new-dataset', 'data/new-dataset'],
+        catch_exceptions=False,
+    )
+    assert 2 == result.exit_code
+    assert 'Cannot add dataset\'s data directory recursively' in result.output
+
+
 def test_dataset_add_with_link(tmpdir, runner, project, client):
     """Test adding data to dataset with --link flag."""
     import stat


### PR DESCRIPTION
Avoids recursive addition of a dataset's data directory to it.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/1042
