### PR TITLE
feat(dataset): no failure when adding existing files

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -127,18 +127,16 @@ them.
     $ renku dataset add my-dataset --source 'path/**/datafile' \
         git+ssh://host.io/namespace/project.git
 
-You can use ``--destination`` or ``-d`` flag to change the name of the target
-file or directory. The semantics here are similar to the POSIX copy command:
-if the destination does not exist or if it is a file then the source will be
-renamed; if the destination exists and is a directory the source will be copied
-to it. You will get an error message if you try to move a directory to a file
-or copy multiple files into one.
+You can use ``--destination`` or ``-d`` flag to set the location where the new
+data is copied to. This location be will under the dataset's data directory and
+will be created if does not exists.You will get an error message if the
+destination exists and is a file.
 
 .. code-block:: console
 
     $ renku dataset add my-dataset \
         --source path/within/repo/to/datafile \
-        --destination new-dir/new-filename \
+        --destination new-dir/new-subdir \
         git+ssh://host.io/namespace/project.git
 
 will yield:
@@ -148,7 +146,8 @@ will yield:
     data/
       my-dataset/
         new-dir/
-          new-filename
+          new-subdir/
+            datafile
 
 To add a specific version of files, use ``--ref`` option for selecting a
 branch, commit, or tag. The value passed to this option must be a valid
@@ -531,6 +530,9 @@ def edit(short_name, title, description, creator):
     '--force', is_flag=True, help='Allow adding otherwise ignored files.'
 )
 @click.option(
+    '-o', '--overwrite', is_flag=True, help='Overwrite existing files.'
+)
+@click.option(
     '-c',
     '--create',
     is_flag=True,
@@ -556,7 +558,10 @@ def edit(short_name, title, description, creator):
 @click.option(
     '--ref', default=None, help='Add files from a specific commit/tag/branch.'
 )
-def add(short_name, urls, external, force, create, sources, destination, ref):
+def add(
+    short_name, urls, external, force, overwrite, create, sources, destination,
+    ref
+):
     """Add data to a dataset."""
     progress = partial(progressbar, label='Adding data to dataset')
     add_file(
@@ -564,6 +569,7 @@ def add(short_name, urls, external, force, create, sources, destination, ref):
         short_name=short_name,
         external=external,
         force=force,
+        overwrite=overwrite,
         create=create,
         sources=sources,
         destination=destination,

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -129,7 +129,7 @@ them.
 
 You can use ``--destination`` or ``-d`` flag to set the location where the new
 data is copied to. This location be will under the dataset's data directory and
-will be created if does not exists.You will get an error message if the
+will be created if does not exists. You will get an error message if the
 destination exists and is a file.
 
 .. code-block:: console

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -181,6 +181,7 @@ def add_file(
     short_name,
     external=False,
     force=False,
+    overwrite=False,
     create=False,
     sources=(),
     destination='',
@@ -198,6 +199,7 @@ def add_file(
         short_name=short_name,
         external=external,
         force=force,
+        overwrite=overwrite,
         create=create,
         sources=sources,
         destination=destination,
@@ -215,6 +217,7 @@ def add_to_dataset(
     short_name,
     external=False,
     force=False,
+    overwrite=False,
     create=False,
     sources=(),
     destination='',
@@ -232,10 +235,8 @@ def add_to_dataset(
     """Add data to a dataset."""
     if len(urls) == 0:
         raise UsageError('No URL is specified')
-    if (sources or destination) and len(urls) > 1:
-        raise UsageError(
-            'Cannot add multiple URLs with --source or --destination'
-        )
+    if sources and len(urls) > 1:
+        raise UsageError('Cannot use "--source" with multiple URLs.')
 
     if interactive:
         if total_size is None:
@@ -261,11 +262,12 @@ def add_to_dataset(
             short_name=short_name, create=create
         ) as dataset:
             with urlscontext(urls) as bar:
-                warning_message = client.add_data_to_dataset(
+                warning_messages = client.add_data_to_dataset(
                     dataset,
                     bar,
                     external=external,
                     force=force,
+                    overwrite=overwrite,
                     sources=sources,
                     destination=destination,
                     ref=ref,
@@ -275,8 +277,9 @@ def add_to_dataset(
                     progress=progress,
                 )
 
-            if warning_message:
-                click.echo(WARNING + warning_message)
+            if warning_messages:
+                for msg in warning_messages:
+                    click.echo(WARNING + msg)
 
             if with_metadata:
                 for file_ in dataset.files:

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -294,7 +294,7 @@ def add_to_dataset(
 
     except DatasetNotFound:
         raise DatasetNotFound(
-            'Dataset "{0}" does not exist.\n'
+            message='Dataset "{0}" does not exist.\n'
             'Use "renku dataset create {0}" to create the dataset or retry '
             '"renku dataset add {0}" command with "--create" option for '
             'automatic dataset creation.'.format(short_name)
@@ -446,7 +446,7 @@ def export_dataset(
 
     dataset_ = client.load_dataset(short_name)
     if not dataset_:
-        raise DatasetNotFound()
+        raise DatasetNotFound(name=short_name)
 
     try:
         provider = ProviderFactory.from_id(provider_id)
@@ -473,7 +473,7 @@ def export_dataset(
     with client.with_commit(selected_commit):
         dataset_ = client.load_dataset(short_name)
         if not dataset_:
-            raise DatasetNotFound()
+            raise DatasetNotFound(name=short_name)
 
         access_token = client.get_value(provider_id, config_key_secret)
         exporter = provider.get_exporter(dataset_, access_token=access_token)

--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -335,9 +335,11 @@ class InvalidSuccessCode(RenkuException):
 class DatasetNotFound(RenkuException):
     """Raise when dataset is not found."""
 
-    def __init__(self, name=None):
+    def __init__(self, *, name=None, message=None):
         """Build a custom message."""
-        if name:
+        if message:
+            msg = message
+        elif name:
             msg = f'Dataset "{name}" is not found.'
         else:
             msg = 'Dataset is not found.'

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -21,7 +21,6 @@ import concurrent.futures
 import os
 import re
 import shutil
-import stat
 import tempfile
 import time
 import uuid
@@ -64,6 +63,10 @@ class DatasetsApiMixin(object):
     """Directory for storing dataset metadata in Renku."""
 
     POINTERS = 'pointers'
+    """Directory for storing external pointer files."""
+
+    CACHE = 'cache'
+    """Directory to cache transient data."""
 
     @property
     def renku_datasets_path(self):
@@ -225,6 +228,7 @@ class DatasetsApiMixin(object):
         dataset,
         urls,
         force=False,
+        overwrite=False,
         sources=(),
         destination='',
         ref=None,
@@ -235,15 +239,20 @@ class DatasetsApiMixin(object):
         progress=None
     ):
         """Import the data into the data directory."""
-        warning_message = ''
-        dataset_path = self.path / self.datadir / dataset.short_name
+        warning_messages = []
+        dataset_datadir = self.path / dataset.datadir
 
         destination = destination or Path('.')
-        destination = self._resolve_path(dataset_path, destination)
-        destination = self.path / dataset_path / destination
+        destination = self._resolve_path(dataset_datadir, destination)
+        destination = self.path / dataset_datadir / destination
+
+        if destination.exists() and not destination.is_dir():
+            raise errors.ParameterError(
+                f'Destination is not a directory: "{destination}"'
+            )
 
         files = []
-        if all_at_once:  # only for URLs
+        if all_at_once:  # Importing a dataset
             files = self._add_from_urls(
                 dataset=dataset,
                 urls=urls,
@@ -259,7 +268,11 @@ class DatasetsApiMixin(object):
                 if is_git and is_remote:  # Remote git repo
                     sources = sources or ()
                     new_files = self._add_from_git(
-                        dataset, url, sources, destination, ref
+                        dataset=dataset,
+                        url=url,
+                        sources=sources,
+                        destination=destination,
+                        ref=ref
                     )
                 else:
                     if sources:
@@ -269,9 +282,11 @@ class DatasetsApiMixin(object):
 
                     if not is_remote:  # Local path, might be git
                         if is_git:
-                            warning_message = 'Adding data from local Git ' \
-                                'repository. Use remote\'s Git URL instead ' \
-                                'to enable lineage information and updates.'
+                            warning_messages.append(
+                                'Adding data from local Git repository: ' +
+                                'Use remote\'s Git URL instead to enable ' +
+                                'lineage information and updates.'
+                            )
                         u = parse.urlparse(url)
                         new_files = self._add_from_local(
                             dataset=dataset,
@@ -281,25 +296,46 @@ class DatasetsApiMixin(object):
                         )
                     else:  # Remote URL
                         new_files = self._add_from_url(
-                            dataset,
-                            url,
-                            destination,
-                            extract,
+                            dataset=dataset,
+                            url=url,
+                            destination=destination,
+                            extract=extract,
                             progress=progress
                         )
 
                 files.extend(new_files)
 
-        files_to_commit = {f['path'] for f in files if f['path']}
+        # Remove all files that are under a .git directory
+        paths_to_avoid = [
+            d['path']
+            for d in files if '.git' in str(d['path']).split(os.path.sep)
+        ]
+        if paths_to_avoid:
+            files = [d for d in files if d['path'] not in paths_to_avoid]
+            warning_messages.append(
+                'Ignored adding paths under a .git directory:\n  ' +
+                '\n  '.join(str(p) for p in paths_to_avoid)
+            )
+
+        files_to_commit = {f['path'] for f in files}
         ignored = self.find_ignored_paths(*files_to_commit)
 
         if not force:
             if ignored:
                 raise errors.IgnoredFiles(ignored)
-            if dataset.contains_any(files):
-                raise errors.DatasetFileExists()
 
-        # all files at this point can be force-added and overwritten
+        # all files at this point can be force-added
+
+        if not overwrite:
+            existing_files = dataset.find_files(files_to_commit)
+            if existing_files:
+                files_to_commit = files_to_commit.difference(existing_files)
+                files = [f for f in files if f['path'] in files_to_commit]
+                warning_messages.append(
+                    'These existing files were not overwritten ' +
+                    '(use "--overwrite" flag to overwrite them):\n  ' +
+                    '\n  '.join([str(p) for p in existing_files])
+                )
 
         for data in files:
             operation = data.pop('operation', None)
@@ -314,6 +350,8 @@ class DatasetsApiMixin(object):
 
             if action == 'copy':
                 shutil.copy(src, dst)
+            elif action == 'move':
+                shutil.move(src, dst, copy_function=shutil.copy)
             elif action == 'symlink':
                 self._create_external_file(src, dst)
                 data['external'] = True
@@ -333,13 +371,12 @@ class DatasetsApiMixin(object):
                 len(files_to_commit)
             )
             self.repo.index.commit(msg)
+        else:
+            warning_messages.append('No file was added to project')
 
         # Generate the DatasetFiles
         dataset_files = []
         for data in files:
-            if os.path.basename(str(data['path'])) == '.git':
-                continue
-
             dataset_file = DatasetFile.from_revision(self, **data)
 
             # Set dataset file path relative to root for submodules.
@@ -348,18 +385,7 @@ class DatasetsApiMixin(object):
             dataset_files.append(dataset_file)
 
         dataset.update_files(dataset_files)
-        return warning_message
-
-    @staticmethod
-    def calculate_metadata(filepath):
-        """Calculate checksum and size of the file."""
-        try:
-            checksum = Repo().git.hash_object(str(filepath))
-        except GitCommandError:
-            checksum = None
-        filesize = os.path.getsize(filepath)
-
-        return checksum, filesize
+        return warning_messages
 
     def _check_protected_path(self, path):
         """Checks if a path is a protected path."""
@@ -377,41 +403,35 @@ class DatasetsApiMixin(object):
 
     def _add_from_local(self, dataset, path, external, destination):
         """Add a file or directory from a local filesystem."""
-        src = Path(path).resolve()
+        src = Path(os.path.abspath(path))
 
         if not src.exists():
-            raise errors.ParameterError(
-                'Cannot find file/directory: {}'.format(path)
-            )
+            raise errors.ParameterError(f'Cannot find file/directory: {path}')
 
-        if destination.exists() and destination.is_dir():
-            destination = destination / src.name
+        dst = destination / src.name
 
         # if we have a directory, recurse
         if src.is_dir():
-            if destination.exists() and not destination.is_dir():
-                raise errors.ParameterError('Cannot copy directory to a file')
+            if dst.exists() and not dst.is_dir():
+                raise errors.ParameterError(
+                    f'Cannot copy directory to a file: "{dst}"'
+                )
             if src == (self.path / dataset.datadir).resolve():
                 raise errors.ParameterError(
                     f'Cannot add dataset\'s data directory recursively: {path}'
                 )
 
-            if src.name == '.git':
-                # Cannot have a '.git' directory inside a Git repo
-                return []
-
             if self._check_protected_path(src):
                 raise errors.ProtectedFiles([src])
 
             files = []
-            destination.mkdir(parents=True, exist_ok=True)
             for f in src.iterdir():
                 files.extend(
                     self._add_from_local(
                         dataset=dataset,
                         path=os.path.abspath(f),
                         external=external,
-                        destination=destination
+                        destination=dst
                     )
                 )
             return files
@@ -437,31 +457,31 @@ class DatasetsApiMixin(object):
                     'parent': self
                 }]
 
-        # Make sure the parent directory exists.
-        destination.parent.mkdir(parents=True, exist_ok=True)
-
         action = 'symlink' if external else 'copy'
 
         return [{
-            'path': destination.relative_to(self.path),
+            'path': dst.relative_to(self.path),
             'url': 'file://' + os.path.relpath(str(src), str(self.path)),
             'creator': dataset.creator,
             'parent': self,
-            'operation': (src, destination, action)
+            'operation': (src, dst, action)
         }]
 
     def _add_from_urls(
         self, dataset, urls, destination, destination_names, extract, progress
     ):
-        destination.mkdir(parents=True, exist_ok=True)
-
         files = []
         max_workers = min(os.cpu_count() - 1, 4) or 1
         with concurrent.futures.ThreadPoolExecutor(max_workers) as executor:
             futures = {
                 executor.submit(
-                    self._add_from_url, dataset, url, destination / name,
-                    extract, progress
+                    self._add_from_url,
+                    dataset=dataset,
+                    url=url,
+                    destination=destination,
+                    extract=extract,
+                    filename=name,
+                    progress=progress
                 )
                 for url, name in zip(urls, destination_names)
             }
@@ -471,45 +491,17 @@ class DatasetsApiMixin(object):
 
         return files
 
-    @staticmethod
-    def _ensure_dropbox(url):
-        """Ensure dropbox url is set for file download."""
-        if not isinstance(url, ParseResult):
-            url = parse.urlparse(url)
-
-        query = url.query or ''
-        if 'dl=0' in url.query:
-            query = query.replace('dl=0', 'dl=1')
-        else:
-            query += 'dl=1'
-
-        url = url._replace(query=query)
-        return url
-
-    def provider_check(self, url):
-        """Check additional provider related operations."""
-        url = parse.urlparse(url)
-
-        if 'dropbox.com' in url.netloc:
-            url = self._ensure_dropbox(url)
-
-        return parse.urlunparse(url)
-
-    def _add_from_url(self, dataset, url, destination, extract, progress=None):
+    def _add_from_url(
+        self, dataset, url, destination, extract, filename=None, progress=None
+    ):
         """Process adding from url and return the location on disk."""
-        if destination.exists() and destination.is_dir():
-            u = parse.urlparse(url)
-            destination = destination / Path(u.path).name
-        else:
-            destination.parent.mkdir(parents=True, exist_ok=True)
-
-        url = self.provider_check(url)
+        url = self._provider_check(url)
 
         try:
             start = time.time() * 1e+3
-            paths = _download(
+            tmp_root, paths = self._download(
                 url=url,
-                download_to=destination,
+                filename=filename,
                 extract=extract,
                 progress_class=progress
             )
@@ -527,17 +519,15 @@ class DatasetsApiMixin(object):
                 'Cannot download from {}'.format(url)
             ) from e
 
-        # make the added file read-only
-        for path in paths:
-            mode = path.stat().st_mode & 0o777
-            path.chmod(mode & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
-
+        paths = [(src, destination / src.relative_to(tmp_root))
+                 for src in paths if not src.is_dir()]
         return [{
-            'path': path.relative_to(self.path),
+            'operation': (src, dst, 'move'),
+            'path': dst.relative_to(self.path),
             'url': remove_credentials(url),
             'creator': dataset.creator,
             'parent': self
-        } for path in paths]
+        } for src, dst in paths]
 
     def _add_from_git(self, dataset, url, sources, destination, ref):
         """Process adding resources from another git repository."""
@@ -566,12 +556,6 @@ class DatasetsApiMixin(object):
             raise errors.ParameterError(
                 'No such file or directory', param_hint=unused_sources
             )
-
-        if destination.exists() and not destination.is_dir():
-            if len(files) > 1:
-                raise errors.ParameterError(
-                    'Cannot copy multiple files or directories to a file'
-                )
 
         # Create metadata and move files to dataset
         results = []
@@ -632,9 +616,29 @@ class DatasetsApiMixin(object):
 
         return results
 
-    def _check_overwrite(self, files, force):
-        if force:
-            return
+    @staticmethod
+    def _ensure_dropbox(url):
+        """Ensure dropbox url is set for file download."""
+        if not isinstance(url, ParseResult):
+            url = parse.urlparse(url)
+
+        query = url.query or ''
+        if 'dl=0' in url.query:
+            query = query.replace('dl=0', 'dl=1')
+        else:
+            query += 'dl=1'
+
+        url = url._replace(query=query)
+        return url
+
+    def _provider_check(self, url):
+        """Check additional provider related operations."""
+        url = parse.urlparse(url)
+
+        if 'dropbox.com' in url.netloc:
+            url = self._ensure_dropbox(url)
+
+        return parse.urlunparse(url)
 
     def _resolve_paths(self, root_path, paths):
         """Check if paths are within a root path and resolve them."""
@@ -689,20 +693,7 @@ class DatasetsApiMixin(object):
             sources[source] = None
             used_sources.add(source)
 
-        if not dst_root.exists():  # Destination will be a file or directory
-            if len(sources) == 1 and not is_wildcard:
-                dst = dst_root / relative_path
-            else:  # Treat destination as a directory
-                dst = dst_root / source_name / relative_path
-        elif dst_root.is_dir():
-            dst = dst_root / source_name / relative_path
-        else:  # Destination is an existing file
-            if src.is_dir():
-                raise errors.ParameterError(
-                    'Cannot copy multiple files or directories to a file'
-                )
-            # Later we need to check if we are copying multiple files
-            dst = dst_root
+        dst = dst_root / source_name / relative_path
 
         return (path, src, dst)
 
@@ -1124,7 +1115,9 @@ class DatasetsApiMixin(object):
             url = path
         repo_name = os.path.splitext(os.path.basename(path))[0]
         path = os.path.dirname(path).lstrip('/')
-        repo_path = self.renku_path / 'cache' / u.hostname / path / repo_name
+        repo_path = (
+            self.renku_path / self.CACHE / u.hostname / path / repo_name
+        )
 
         if repo_path.exists():
             repo = Repo(str(repo_path))
@@ -1184,6 +1177,57 @@ class DatasetsApiMixin(object):
             return label.split('@')[1]
         return label
 
+    def _download(
+        self, url, filename, extract, progress_class=None, chunk_size=16384
+    ):
+        def extract_dataset(filepath):
+            """Extract downloaded file."""
+            try:
+                tmp = tempfile.mkdtemp()
+                patoolib.extract_archive(
+                    str(filepath), outdir=tmp, verbosity=-1
+                )
+            except patoolib.util.PatoolError:
+                return filepath.parent, [filepath]
+            else:
+                filepath.unlink()
+                return Path(tmp), [p for p in Path(tmp).rglob('*')]
+
+        tmp_root = self.renku_path / self.CACHE
+        tmp_root.mkdir(parents=True, exist_ok=True)
+        tmp = tempfile.mkdtemp(dir=tmp_root)
+
+        with requests.get(url, stream=True) as request:
+            request.raise_for_status()
+
+            if not filename:
+                u = parse.urlparse(url)
+                filename = Path(u.path).name
+                if not filename:
+                    raise errors.ParameterError(
+                        f'URL Cannot find a file to download from {url}'
+                    )
+
+            download_to = Path(tmp) / filename
+            with open(str(download_to), 'wb') as file_:
+                total_size = int(request.headers.get('content-length', 0))
+                progress_class = progress_class or DownloadProgressCallback
+                progress = progress_class(
+                    description=filename, total_size=total_size
+                )
+
+                try:
+                    for chunk in request.iter_content(chunk_size=chunk_size):
+                        if chunk:  # ignore keep-alive chunks
+                            file_.write(chunk)
+                            progress.update(size=len(chunk))
+                finally:
+                    progress.finalize()
+        if extract:
+            return extract_dataset(download_to)
+
+        return download_to.parent, [download_to]
+
 
 class DownloadProgressCallback:
     """Interface to report various stages of a download."""
@@ -1196,53 +1240,6 @@ class DownloadProgressCallback:
 
     def finalize(self):
         """Called once when the download is finished."""
-
-
-def _download(
-    url, download_to, extract, progress_class=None, chunk_size=16384
-):
-    def extract_dataset(filepath):
-        """Extract downloaded file."""
-        try:
-            tmp = tempfile.mkdtemp()
-            patoolib.extract_archive(str(filepath), outdir=tmp, verbosity=-1)
-        except patoolib.util.PatoolError:
-            return [filepath]
-        else:
-            filepath.unlink()
-            parent = filepath.parent
-            paths = [
-                parent / p.relative_to(tmp)
-                for p in Path(tmp).rglob('*') if not p.is_dir()
-            ]
-
-            for path in Path(tmp).glob('*'):
-                dst = parent / path.relative_to(tmp)
-                shutil.move(str(path), str(dst))
-
-            return paths
-
-    with requests.get(url, stream=True) as request:
-        request.raise_for_status()
-
-        with open(str(download_to), 'wb') as file_:
-            total_size = int(request.headers.get('content-length', 0))
-            progress_class = progress_class or DownloadProgressCallback
-            progress = progress_class(
-                description=download_to.name, total_size=total_size
-            )
-
-            try:
-                for chunk in request.iter_content(chunk_size=chunk_size):
-                    if chunk:  # ignore keep-alive chunks
-                        file_.write(chunk)
-                        progress.update(size=len(chunk))
-            finally:
-                progress.finalize()
-    if extract:
-        return extract_dataset(download_to)
-
-    return [download_to]
 
 
 def _check_url(url):

--- a/renku/core/models/datasets.py
+++ b/renku/core/models/datasets.py
@@ -471,6 +471,11 @@ class Dataset(Entity, CreatorMixin):
                 return True
         return False
 
+    def find_files(self, relative_paths):
+        """Return all paths that are in files container."""
+        files_paths = {str(f.path) for f in self.files}
+        return {p for p in relative_paths if str(p) in files_paths}
+
     def find_file(self, filename, return_index=False):
         """Find a file in files container."""
         for index, file_ in enumerate(self.files):

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -387,7 +387,6 @@ def test_add_to_dirty_repo(directory_tree, runner, project, client):
         catch_exceptions=False
     )
     assert 1 == result.exit_code
-    assert 'Error: File already exists in dataset' in result.output
 
     assert client.repo.is_dirty()
     assert ['untracked'] == client.repo.untracked_files
@@ -468,7 +467,6 @@ def test_relative_import_to_dataset(tmpdir, runner, client):
 
     paths = [str(zero_data), str(first_level), str(second_level)]
 
-    # add data in subdirectory
     result = runner.invoke(
         cli,
         ['dataset', 'add', 'dataset'] + paths,
@@ -480,6 +478,24 @@ def test_relative_import_to_dataset(tmpdir, runner, client):
     assert os.stat(os.path.join('data', 'dataset', 'first', 'first.txt'))
     assert os.stat(
         os.path.join('data', 'dataset', 'first', 'second', 'second.txt')
+    )
+
+    # add data in subdirectory
+    result = runner.invoke(
+        cli,
+        ['dataset', 'add', 'dataset', '-d', 'subdir'] + paths,
+        catch_exceptions=False,
+    )
+    assert 0 == result.exit_code
+
+    assert os.stat(os.path.join('data', 'dataset', 'subdir', 'zero.txt'))
+    assert os.stat(
+        os.path.join('data', 'dataset', 'subdir', 'first', 'first.txt')
+    )
+    assert os.stat(
+        os.path.join(
+            'data', 'dataset', 'subdir', 'first', 'second', 'second.txt'
+        )
     )
 
 
@@ -1397,10 +1413,10 @@ def test_avoid_empty_commits(runner, client, directory_tree):
         cli, ['dataset', 'add', 'my-dataset', directory_tree.strpath]
     )
     assert 1 == result.exit_code
+    assert 'Error: There is nothing to commit.' in result.output
 
     commit_sha_after = client.repo.head.object.hexsha
     assert commit_sha_before == commit_sha_after
-    assert 'Error: File already exists in dataset.' in result.output
 
 
 def test_multiple_dataset_commits(runner, client, directory_tree):
@@ -1423,36 +1439,6 @@ def test_multiple_dataset_commits(runner, client, directory_tree):
 
     commit_sha_after = client.repo.head.object.hexsha
     assert commit_sha_before != commit_sha_after
-
-
-def test_add_same_filename_multiple(runner, client, directory_tree):
-    """Check adding same filename multiple times."""
-    result = runner.invoke(
-        cli, ['dataset', 'add', '-c', 'my-dataset1', directory_tree.strpath]
-    )
-
-    assert 0 == result.exit_code
-
-    result = runner.invoke(
-        cli, ['dataset', 'add', 'my-dataset1', directory_tree.strpath]
-    )
-    assert 1 == result.exit_code
-    assert 'Error: File already exists in dataset.' in result.output
-
-    result = runner.invoke(
-        cli,
-        ['dataset', 'add', '--force', 'my-dataset1', directory_tree.strpath]
-    )
-    assert 1 == result.exit_code
-    assert 'Error: There is nothing to commit.' in result.output
-
-    result = runner.invoke(
-        cli, [
-            'dataset', 'add', '--force', 'my-dataset1', directory_tree.strpath,
-            'README.md'
-        ]
-    )
-    assert 0 == result.exit_code
 
 
 @pytest.mark.parametrize('filename', ['.renku', '.renku/', 'Dockerfile'])
@@ -1549,50 +1535,71 @@ def test_dataset_cmd_subdirectory(runner, project):
         assert 0 == result.exit_code
 
 
+@pytest.mark.parametrize('external', [False, True])
+def test_add_same_filename_multiple(runner, client, directory_tree, external):
+    """Check adding same filename multiple times."""
+    param = ['-e'] if external else []
+
+    result = runner.invoke(
+        cli,
+        ['dataset', 'add', '-c', 'my-dataset', directory_tree.strpath] + param
+    )
+
+    assert 0 == result.exit_code
+
+    path = Path('data') / 'my-dataset' / directory_tree.basename / 'file'
+
+    result = runner.invoke(
+        cli, ['dataset', 'add', 'my-dataset', directory_tree.strpath] + param
+    )
+    assert 1 == result.exit_code
+    assert 'These existing files were not overwritten' in result.output
+    assert str(path) in result.output
+    assert 'Warning: No file was added to project' in result.output
+    assert 'Error: There is nothing to commit.' in result.output
+
+    result = runner.invoke(
+        cli, [
+            'dataset', 'add', '--overwrite', 'my-dataset',
+            directory_tree.strpath
+        ] + param
+    )
+    exit_code = 0 if external else 1
+    assert exit_code == result.exit_code
+    assert 'These existing files were not overwritten' not in result.output
+    assert str(path) not in result.output
+    assert external or 'Warning: No file was added to project' in result.output
+    assert external or 'Error: There is nothing to commit.' in result.output
+
+    result = runner.invoke(
+        cli,
+        ['dataset', 'add', 'my-dataset', directory_tree.strpath, 'README.md'] +
+        param
+    )
+    assert 0 == result.exit_code
+    assert 'These existing files were not overwritten' in result.output
+    assert str(path) in result.output
+    assert 'Warning: No file was added to project' not in result.output
+
+
 def test_add_external_files(runner, client, directory_tree):
     """Check adding external files."""
     result = runner.invoke(
         cli, [
-            'dataset', 'add', '-c', '--external', 'my-data', '-d', 'files',
+            'dataset', 'add', '-c', '--external', 'my-data',
             directory_tree.strpath
         ]
     )
     assert 0 == result.exit_code
 
-    path = client.path / 'data' / 'my-data' / 'files' / 'file'
+    path = client.path / 'data' / 'my-data' / directory_tree.basename / 'file'
     assert path.exists()
     assert path.is_symlink()
     external_path = Path(directory_tree.strpath) / 'file'
     assert path.resolve() == external_path
 
     with client.with_dataset('my-data') as dataset:
-        assert dataset.find_file('data/my-data/files/file') is not None
-
-
-def test_add_external_file_multiple(runner, client, directory_tree):
-    """Check adding external files multiple times."""
-    result = runner.invoke(
-        cli, [
-            'dataset', 'add', '--create', '--external', 'my-data',
-            directory_tree.strpath
-        ]
-    )
-    assert 0 == result.exit_code
-
-    result = runner.invoke(
-        cli,
-        ['dataset', 'add', '--external', 'my-data', directory_tree.strpath]
-    )
-    assert 1 == result.exit_code
-    assert 'File already exists in dataset.' in result.output
-
-    result = runner.invoke(
-        cli, [
-            'dataset', 'add', '--external', 'my-data', '--force',
-            directory_tree.strpath
-        ]
-    )
-    assert 0 == result.exit_code
+        assert dataset.find_file(path.relative_to(client.path)) is not None
 
 
 def test_overwrite_external_file(runner, client, directory_tree):
@@ -1611,31 +1618,35 @@ def test_overwrite_external_file(runner, client, directory_tree):
         cli, ['dataset', 'add', 'my-data', directory_tree.strpath]
     )
     assert 1 == result.exit_code
-    assert 'File already exists in dataset.' in result.output
+    assert 'Warning: No file was added to project' in result.output
 
-    # Can add the same file with --force
+    # Can add the same file with --overwrite
     result = runner.invoke(
-        cli, ['dataset', 'add', 'my-data', '--force', directory_tree.strpath]
+        cli,
+        ['dataset', 'add', 'my-data', '--overwrite', directory_tree.strpath]
     )
     assert 0 == result.exit_code
-    assert [] == list(client.renku_pointers_path.rglob('*'))
+    pointer_files_deleted = list(client.renku_pointers_path.rglob('*')) == []
+    assert pointer_files_deleted
 
     # Can add the same external file
     result = runner.invoke(
         cli, [
-            'dataset', 'add', '--external', 'my-data', '--force',
+            'dataset', 'add', '--external', 'my-data', '--overwrite',
             directory_tree.strpath
         ]
     )
     assert 0 == result.exit_code
+    pointer_files_exist = len(list(client.renku_pointers_path.rglob('*'))) > 0
+    assert pointer_files_exist
 
 
 def test_remove_external_file(runner, client, directory_tree):
     """Test removal of external files."""
     result = runner.invoke(
         cli, [
-            'dataset', 'add', '--create', '--external', 'my-data', '-d',
-            'files', directory_tree.strpath
+            'dataset', 'add', '--create', '--external', 'my-data',
+            directory_tree.strpath
         ]
     )
     assert 0 == result.exit_code
@@ -1644,7 +1655,7 @@ def test_remove_external_file(runner, client, directory_tree):
         str(p.resolve())
         for p in client.renku_pointers_path.rglob('*')
     }
-    path = str(Path('data') / 'my-data' / 'files' / 'file')
+    path = str(Path('data') / 'my-data' / directory_tree.basename / 'file')
 
     result = runner.invoke(cli, ['rm', str(path)])
     assert 0 == result.exit_code
@@ -1663,13 +1674,13 @@ def test_unavailable_external_files(runner, client, directory_tree):
     """Check for external files that are not available."""
     result = runner.invoke(
         cli, [
-            'dataset', 'add', '-c', '--external', 'my-data', '-d', 'files',
+            'dataset', 'add', '-c', '--external', 'my-data',
             directory_tree.strpath
         ]
     )
     assert 0 == result.exit_code
 
-    path = Path('data') / 'my-data' / 'files' / 'file'
+    path = Path('data') / 'my-data' / directory_tree.basename / 'file'
     target = path.resolve()
 
     directory_tree.join('file').remove()
@@ -1692,7 +1703,7 @@ def test_external_file_update(runner, client, directory_tree, project):
     """Check updating external files."""
     result = runner.invoke(
         cli, [
-            'dataset', 'add', '-c', '--external', 'my-data', '-d', 'files',
+            'dataset', 'add', '-c', '--external', 'my-data',
             directory_tree.strpath
         ]
     )
@@ -1700,7 +1711,7 @@ def test_external_file_update(runner, client, directory_tree, project):
 
     directory_tree.join('file').write('some updates')
 
-    path = str(Path('data') / 'my-data' / 'files' / 'file')
+    path = str(Path('data') / 'my-data' / directory_tree.basename / 'file')
     previous_commit = client.find_previous_commit(path)
 
     result = runner.invoke(cli, ['dataset', 'update', '--external', 'my-data'])
@@ -1716,13 +1727,15 @@ def test_workflow_with_external_file(
     """Check using external files in workflows."""
     result = runner.invoke(
         cli, [
-            'dataset', 'add', '-c', '--external', 'my-data', '-d', 'files',
+            'dataset', 'add', '-c', '--external', 'my-data',
             directory_tree.strpath
         ]
     )
     assert 0 == result.exit_code
 
-    source = Path(project) / 'data' / 'my-data' / 'files' / 'file'
+    source = (
+        Path(project) / 'data' / 'my-data' / directory_tree.basename / 'file'
+    )
     output = Path(project) / 'data' / 'output.txt'
 
     assert 0 == run(args=('run', 'wc', '-c'), stdin=source, stdout=output)

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -662,7 +662,7 @@ def test_dataset_export(runner, client, project):
     )
 
     assert 2 == result.exit_code, result.output + str(result.stderr_bytes)
-    assert 'Dataset is not found.' in result.output
+    assert 'Dataset "doesnotexists" is not found.' in result.output
 
 
 @pytest.mark.integration

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -724,7 +724,9 @@ def test_export_dataverse_no_dataverse_name(
 
 
 @pytest.mark.integration
-def test_export_dataverse_no_dataverse_url(runner, client, dataverse_demo):
+def test_export_dataverse_no_dataverse_url(
+    runner, client, dataverse_demo, global_config_dir
+):
     """Test export without providing a dataverse server url."""
     client.remove_value('dataverse', 'server_url')
     client.repo.git.add('.renku/renku.ini')
@@ -736,7 +738,7 @@ def test_export_dataverse_no_dataverse_url(runner, client, dataverse_demo):
     result = runner.invoke(
         cli, [
             'dataset', 'export', 'my-dataset', 'dataverse', '--dataverse-name',
-            'name'
+            'sdsc-test-dataverse'
         ]
     )
 
@@ -752,9 +754,10 @@ def test_export_dataverse_no_dataverse_url(runner, client, dataverse_demo):
         (['-s', 'docker'], 'data/remote/docker/r/Dockerfile'),
         (['-s', 'docker/r/Dockerfile'], 'data/remote/Dockerfile'),
         # add data to a non-existing destination
-        (['-s', 'docker', '-d', 'new'], 'data/remote/new/r/Dockerfile'),
-        (['-s', 'docker/r', '-d', 'new'], 'data/remote/new/Dockerfile'),
-        (['-s', 'docker/r/Dockerfile', '-d', 'new'], 'data/remote/new'),
+        (['-s', 'docker', '-d', 'new'], 'data/remote/new/docker/r/Dockerfile'),
+        (['-s', 'docker/r', '-d', 'new'], 'data/remote/new/r/Dockerfile'),
+        (['-s', 'docker/r/Dockerfile', '-d', 'new'
+          ], 'data/remote/new/Dockerfile'),
         # add data to an existing destination
         (['-s', 'docker', '-d', 'existing'
           ], 'data/remote/existing/docker/r/Dockerfile'),
@@ -855,16 +858,14 @@ def test_add_from_git_copies_metadata(runner, client):
     'params,n_urls,message', [
         ([], 0, 'No URL is specified'),
         (['-s', 'file', '-d', 'new-file'], 0, 'No URL is specified'),
-        (['-s', 'file'], 2, 'Cannot add multiple URLs'),
-        (['-d', 'file'], 2, 'Cannot add multiple URLs'),
+        (['-s', 'file'], 2, 'Cannot use "--source" with multiple URLs.'),
         (['-s', 'non-existing'], 1, 'No such file or directory'),
         (['-s', 'docker/*Dockerfile'], 1, 'No such file or directory'),
         (['-s', 'docker', '-d', 'LICENSE'
-          ], 1, 'Cannot copy multiple files or directories to a file'),
+          ], 1, 'Destination is not a directory'),
         (['-s', 'LICENSE', '-s', 'Makefile', '-d', 'LICENSE'
-          ], 1, 'Cannot copy multiple files or directories to a file'),
-        (['-d', 'LICENSE'
-          ], 1, 'Cannot copy multiple files or directories to a file'),
+          ], 1, 'Destination is not a directory'),
+        (['-d', 'LICENSE'], 1, 'Destination is not a directory'),
     ]
 )
 @flaky(max_runs=10, min_passes=1)
@@ -1091,13 +1092,14 @@ def test_import_from_renku_project(tmpdir, client, runner):
         [
             'dataset', 'add', '--create', 'remote-dataset', '-s',
             'data/zhbikes/2019_verkehrszaehlungen_werte_fussgaenger_velo.csv',
-            '-d', 'file', '--ref', 'b973db5', remote
+            '-d', 'new-directory', '--ref', 'b973db5', remote
         ],
         catch_exceptions=False,
     )
     assert 0 == result.exit_code, result.output + str(result.stderr_bytes)
 
-    metadata = read_dataset_file_metadata(client, 'remote-dataset', 'file')
+    path = 'new-directory/2019_verkehrszaehlungen_werte_fussgaenger_velo.csv'
+    metadata = read_dataset_file_metadata(client, 'remote-dataset', path)
     assert metadata.creator[0].name == file_.creator[0].name
     assert metadata.based_on._id == file_._id
     assert metadata.based_on._label == file_._label

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -33,7 +33,7 @@ from renku.core.models.provenance.agents import Person
 
 
 @pytest.mark.parametrize(
-    'scheme, path, force, error',
+    'scheme, path, overwrite, error',
     [('', 'temp', False, None), ('file://', 'temp', True, None),
      ('', 'tempp', False, errors.ParameterError),
      ('http://', 'example.com/file', False, None),
@@ -41,7 +41,7 @@ from renku.core.models.provenance.agents import Person
      ('bla://', 'file', False, errors.UrlSchemeNotSupported)]
 )
 def test_data_add(
-    scheme, path, force, error, client, data_file, directory_tree,
+    scheme, path, overwrite, error, client, data_file, directory_tree,
     dataset_responses
 ):
     """Test data import."""
@@ -59,7 +59,7 @@ def test_data_add(
             }]
 
             client.add_data_to_dataset(
-                d, ['{}{}'.format(scheme, path)], force=force
+                d, ['{}{}'.format(scheme, path)], overwrite=overwrite
             )
 
         with open('data/dataset/file') as f:
@@ -82,7 +82,7 @@ def test_data_add(
                     'identifier': 'me_id'
                 }]
                 client.add_data_to_dataset(
-                    d, ['{}{}'.format(scheme, path)], force=True
+                    d, ['{}{}'.format(scheme, path)], overwrite=True
                 )
             assert os.path.exists('data/dataset/file')
 


### PR DESCRIPTION
# Description

Adding existing data to a dataset will fail the whole operation. This PR changes this behavior by adding only non-existing files instead of failing. You can overwrite existing files by passing a `--overwrite` flag.

Moreover, the `-d` flag is refactored to always be used as a directory instead of depending on the input type.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/1149
