### PR TITLE
chore: refactor renku_clone to project_clone

### DIFF
--- a/renku/cli/clone.py
+++ b/renku/cli/clone.py
@@ -32,7 +32,7 @@ To clone a Renku project and set up required Git hooks and Git LFS use
 
 import click
 
-from renku.core.commands.clone import renku_clone
+from renku.core.commands.clone import project_clone
 from renku.core.commands.echo import GitProgress
 
 
@@ -47,7 +47,7 @@ def clone(pull_data, url, path):
     click.echo('Cloning {} ...'.format(url))
 
     skip_smudge = not pull_data
-    renku_clone(
+    project_clone(
         url=url, path=path, skip_smudge=skip_smudge, progress=GitProgress()
     )
     click.secho('OK', fg='green')

--- a/renku/core/commands/clone.py
+++ b/renku/core/commands/clone.py
@@ -23,7 +23,7 @@ from .client import pass_local_client
 
 
 @pass_local_client
-def renku_clone(
+def project_clone(
     client,
     url,
     path=None,

--- a/renku/service/entrypoint.py
+++ b/renku/service/entrypoint.py
@@ -33,7 +33,7 @@ from renku.service.config import API_SPEC_URL, API_VERSION, CACHE_DIR, \
 from renku.service.logger import service_log
 from renku.service.utils.json_encoder import SvcJSONEncoder
 from renku.service.views.cache import CACHE_BLUEPRINT_TAG, cache_blueprint, \
-    list_projects_view, list_uploaded_files_view, project_clone, \
+    list_projects_view, list_uploaded_files_view, project_clone_view, \
     upload_file_view
 from renku.service.views.datasets import DATASET_BLUEPRINT_TAG, \
     add_file_to_dataset_view, create_dataset_view, dataset_blueprint, \
@@ -94,7 +94,7 @@ def build_routes(app):
 
     docs.register(upload_file_view, blueprint=CACHE_BLUEPRINT_TAG)
     docs.register(list_uploaded_files_view, blueprint=CACHE_BLUEPRINT_TAG)
-    docs.register(project_clone, blueprint=CACHE_BLUEPRINT_TAG)
+    docs.register(project_clone_view, blueprint=CACHE_BLUEPRINT_TAG)
     docs.register(list_projects_view, blueprint=CACHE_BLUEPRINT_TAG)
 
     docs.register(create_dataset_view, blueprint=DATASET_BLUEPRINT_TAG)

--- a/renku/service/views/cache.py
+++ b/renku/service/views/cache.py
@@ -26,7 +26,7 @@ from flask_apispec import marshal_with, use_kwargs
 from marshmallow import EXCLUDE
 from patoolib.util import PatoolError
 
-from renku.core.commands.clone import renku_clone
+from renku.core.commands.clone import project_clone
 from renku.service.config import CACHE_UPLOADS_PATH, \
     INVALID_PARAMS_ERROR_CODE, SERVICE_PREFIX, SUPPORTED_ARCHIVES
 from renku.service.serializers.cache import FileListResponseRPC, \
@@ -177,7 +177,7 @@ def _project_clone(cache, user_data, project_data):
                 project.delete()
 
     local_path.mkdir(parents=True, exist_ok=True)
-    renku_clone(
+    project_clone(
         project_data['url_with_auth'],
         local_path,
         depth=project_data['depth'],
@@ -210,7 +210,7 @@ def _project_clone(cache, user_data, project_data):
 @handle_validation_except
 @requires_identity
 @accepts_json
-def project_clone(user_data):
+def project_clone_view(user_data):
     """Clone a remote repository."""
     project_data = ProjectCloneContext().load({
         **user_data,

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -29,7 +29,7 @@ from flaky import flaky
 
 from renku.cli import cli
 from renku.core import errors
-from renku.core.commands.clone import renku_clone
+from renku.core.commands.clone import project_clone
 from renku.core.utils.contexts import chdir
 
 
@@ -1284,7 +1284,7 @@ def test_renku_clone_with_config(tmpdir):
     remote = 'https://dev.renku.ch/gitlab/virginiafriedrich/datasets-test.git'
 
     with chdir(str(tmpdir)):
-        renku_clone(
+        project_clone(
             remote,
             config={
                 'user.name': 'sam',


### PR DESCRIPTION
This PR refactors core API `renku_clone` to more descriptive name `project_clone`.