### PR TITLE
feat(cli): Adds warning messages for LFS, fix output redirection

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -201,6 +201,28 @@ def client(project):
     """Return a Renku repository."""
     from renku.core.management import LocalClient
 
+    original_get_value = LocalClient.get_value
+
+    def mocked_get_value(
+        self, section, key, local_only=False, global_only=False
+    ):
+        """We don't want lfs warnings in tests."""
+        if key == 'show_lfs_warnings':
+            return 'False'
+        return original_get_value(self, section, key, local_only, global_only)
+
+    LocalClient.get_value = mocked_get_value
+
+    yield LocalClient(path=project)
+
+    LocalClient.get_value = original_get_value
+
+
+@pytest.fixture
+def client_with_lfs_warning(project):
+    """Return a Renku repository with lfs warnings active."""
+    from renku.core.management import LocalClient
+
     yield LocalClient(path=project)
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -230,12 +230,16 @@ def no_lfs_warning(client):
     yield client
 
 
-@pytest.fixture
+@pytest.fixture(scope='function')
 def client_with_lfs_warning(project):
     """Return a Renku repository with lfs warnings active."""
     from renku.core.management import LocalClient
 
-    yield LocalClient(path=project)
+    client = LocalClient(path=project)
+    client.set_value('renku', 'lfs_threshold', '0b')
+    client.repo.git.add('.renku/renku.ini')
+    client.repo.index.commit('update renku.ini')
+    yield client
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -207,7 +207,7 @@ def client(project):
         self, section, key, local_only=False, global_only=False
     ):
         """We don't want lfs warnings in tests."""
-        if key == 'show_lfs_warnings':
+        if key == 'show_lfs_message':
             return 'False'
         return original_get_value(self, section, key, local_only, global_only)
 
@@ -216,6 +216,18 @@ def client(project):
     yield LocalClient(path=project)
 
     LocalClient.get_value = original_get_value
+
+
+@pytest.fixture
+def no_lfs_warning(client):
+    """Sets show_lfs_message to False.
+
+    For those times in life when mocking just isn't enough.
+    """
+    with client.commit():
+        client.set_value('renku', 'show_lfs_message', 'False')
+
+    yield client
 
 
 @pytest.fixture

--- a/renku/cli/config.py
+++ b/renku/cli/config.py
@@ -81,6 +81,9 @@ The following values are available for the ``renku config`` command:
 | dataverse.server_url   | URL for the Dataverse API server    | ``None``  |
 |                        | to use                              |           |
 +------------------------+-------------------------------------+-----------+
+| show_lfs_message       | Whether to show messages about      | ``True``  |
+|                        | files being added to git LFS or not |           |
++------------------------+-------------------------------------+-----------+
 | lfs_threshold          | Threshold file size below which     | ``100kb`` |
 |                        | files are not added to git LFS      |           |
 +------------------------+-------------------------------------+-----------+

--- a/renku/cli/move.py
+++ b/renku/cli/move.py
@@ -112,9 +112,20 @@ def move(ctx, client, sources, destination):
                 click.edit(filename=str(client.path / '.gitattributes'))
 
     if tracked and client.has_external_storage:
-        client.track_paths_in_storage(
+        lfs_paths = client.track_paths_in_storage(
             *(destinations[path] for path in tracked)
         )
+        if (
+            lfs_paths and
+            client.get_value('renku', 'show_lfs_warnings') is None or
+            client.get_value('renku', 'show_lfs_warnings') == 'True'
+        ):
+            click.echo(
+                WARNING + 'Adding files to Git LFS:\n' +
+                '\t{}'.format('\n\t'.join(lfs_paths)) +
+                '\nTo disable this warning in the future, run:' +
+                '\n\trenku config show_lfs_warnings False'
+            )
 
     # 4. Handle symlinks.
     dst.parent.mkdir(parents=True, exist_ok=True)

--- a/renku/cli/move.py
+++ b/renku/cli/move.py
@@ -30,7 +30,7 @@ from subprocess import run
 import click
 
 from renku.core.commands.client import pass_local_client
-from renku.core.commands.echo import WARNING, progressbar
+from renku.core.commands.echo import INFO, WARNING, progressbar
 
 
 @click.command(name='mv')
@@ -115,16 +115,13 @@ def move(ctx, client, sources, destination):
         lfs_paths = client.track_paths_in_storage(
             *(destinations[path] for path in tracked)
         )
-        if (
-            lfs_paths and
-            client.get_value('renku', 'show_lfs_warnings') is None or
-            client.get_value('renku', 'show_lfs_warnings') == 'True'
-        ):
+        show_message = client.get_value('renku', 'show_lfs_message')
+        if (lfs_paths and show_message is None or show_message == 'True'):
             click.echo(
-                WARNING + 'Adding files to Git LFS:\n' +
+                INFO + 'Adding these files to Git LFS:\n' +
                 '\t{}'.format('\n\t'.join(lfs_paths)) +
-                '\nTo disable this warning in the future, run:' +
-                '\n\trenku config show_lfs_warnings False'
+                '\nTo disable this message in the future, run:' +
+                '\n\trenku config show_lfs_message False'
             )
 
     # 4. Handle symlinks.

--- a/renku/cli/move.py
+++ b/renku/cli/move.py
@@ -116,7 +116,7 @@ def move(ctx, client, sources, destination):
             *(destinations[path] for path in tracked)
         )
         show_message = client.get_value('renku', 'show_lfs_message')
-        if (lfs_paths and show_message is None or show_message == 'True'):
+        if (lfs_paths and (show_message is None or show_message == 'True')):
             click.echo(
                 INFO + 'Adding these files to Git LFS:\n' +
                 '\t{}'.format('\n\t'.join(lfs_paths)) +

--- a/renku/cli/run.py
+++ b/renku/cli/run.py
@@ -239,10 +239,15 @@ def run(
     system_stdout = None
     system_stderr = None
 
+    # /dev/tty is a virtual device that points to the terminal
+    # of the currently executed process
     try:
-        # /dev/tty is a virtual device that points to the terminal
-        # of the currently executed process
-        tty_exists = os.path.exists('/dev/tty')
+        with open('/dev/tty', 'w'):
+            tty_exists = True
+    except OSError:
+        tty_exists = False
+
+    try:
         stdout_redirected = 'stdout' in mapped_std
         stderr_redirected = 'stderr' in mapped_std
 
@@ -314,13 +319,16 @@ def run(
 
                 wf.add_step(run=tool)
 
-        if factory.warning:
-            click.echo(factory.warning)
+        if factory.messages:
+            click.echo(factory.messages)
+
+        if factory.warnings:
+            click.echo(factory.warnings)
 
     finally:
         if system_stdout:
-            system_stdout.close()
             sys.stdout = old_stdout
+            system_stdout.close()
         if system_stderr:
-            system_stderr.close()
             sys.stderr = old_stderr
+            system_stderr.close()

--- a/renku/cli/run.py
+++ b/renku/cli/run.py
@@ -37,6 +37,13 @@ Tracking execution of your command line script is done by simply adding the
 .. warning:: Circular dependencies are not supported for ``renku run``. See
    :ref:`circular-dependencies` for more details.
 
+.. warning:: When using output redirection in ``renku run`` on Windows (with
+   `` > file`` or `` 2> file``), all Renku errors and messages are redirected
+   as well and ``renku run`` produces no output on the terminal. On Linux,
+   this is detected by renku and only the output of the command to be run is
+   actually redirected. Renku specific messages such as errors get printed to
+   the terminal as usual and don't get redirected.
+
 Detecting input paths
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -228,44 +235,92 @@ def run(
     client, inputs, outputs, no_output, success_codes, isolation, command_line
 ):
     """Tracking work on a specific problem."""
-    working_dir = client.repo.working_dir
     mapped_std = _mapped_std_streams(client.candidate_paths)
-    factory = CommandLineToolFactory(
-        command_line=command_line,
-        explicit_inputs=inputs,
-        explicit_outputs=outputs,
-        directory=os.getcwd(),
-        working_dir=working_dir,
-        successCodes=success_codes,
-        **{
-            name: os.path.relpath(path, working_dir)
-            for name, path in mapped_std.items()
-        }
-    )
-    with client.with_workflow_storage() as wf:
-        with factory.watch(client, no_output=no_output) as tool:
-            # Don't compute paths if storage is disabled.
-            if client.has_external_storage:
-                # Make sure all inputs are pulled from a storage.
-                paths_ = (
-                    path
-                    for _, path in tool.iter_input_files(client.workflow_path)
+    system_stdout = None
+    system_stderr = None
+
+    try:
+        # /dev/tty is a virtual device that points to the terminal
+        # of the currently executed process
+        tty_exists = os.path.exists('/dev/tty')
+        stdout_redirected = 'stdout' in mapped_std
+        stderr_redirected = 'stderr' in mapped_std
+
+        if tty_exists:
+            # if renku was called with redirected stdout/stderr, undo the
+            # redirection here so error messages can be printed normally
+            if stdout_redirected:
+                system_stdout = open('/dev/tty', 'w')
+                old_stdout = sys.stdout
+                sys.stdout = system_stdout
+
+            if stderr_redirected:
+                system_stderr = open('/dev/tty', 'w')
+                old_stderr = sys.stderr
+                sys.stderr = system_stderr
+
+        working_dir = client.repo.working_dir
+        factory = CommandLineToolFactory(
+            command_line=command_line,
+            explicit_inputs=inputs,
+            explicit_outputs=outputs,
+            directory=os.getcwd(),
+            working_dir=working_dir,
+            successCodes=success_codes,
+            **{
+                name: os.path.relpath(path, working_dir)
+                for name, path in mapped_std.items()
+            }
+        )
+        with client.with_workflow_storage() as wf:
+            with factory.watch(client, no_output=no_output) as tool:
+                # Don't compute paths if storage is disabled.
+                if client.has_external_storage:
+                    # Make sure all inputs are pulled from a storage.
+                    paths_ = (
+                        path for _, path in
+                        tool.iter_input_files(client.workflow_path)
+                    )
+                    client.pull_paths_from_storage(*paths_)
+
+                if tty_exists:
+                    # apply original output redirection
+                    if stdout_redirected:
+                        sys.stdout = old_stdout
+                    if stderr_redirected:
+                        sys.stderr = old_stderr
+
+                return_code = call(
+                    factory.command_line,
+                    cwd=os.getcwd(),
+                    **{key: getattr(sys, key)
+                       for key in mapped_std.keys()},
                 )
-                client.pull_paths_from_storage(*paths_)
 
-            return_code = call(
-                factory.command_line,
-                cwd=os.getcwd(),
-                **{key: getattr(sys, key)
-                   for key in mapped_std.keys()},
-            )
+                sys.stdout.flush()
+                sys.stderr.flush()
 
-            if return_code not in (success_codes or {0}):
-                raise errors.InvalidSuccessCode(
-                    return_code, success_codes=success_codes
-                )
+                if tty_exists:
+                    # change back to /dev/tty redirection
+                    if stdout_redirected:
+                        sys.stdout = system_stdout
+                    if stderr_redirected:
+                        sys.stderr = system_stderr
 
-            sys.stdout.flush()
-            sys.stderr.flush()
+                if return_code not in (success_codes or {0}):
+                    raise errors.InvalidSuccessCode(
+                        return_code, success_codes=success_codes
+                    )
 
-            wf.add_step(run=tool)
+                wf.add_step(run=tool)
+
+        if factory.warning:
+            click.echo(factory.warning)
+
+    finally:
+        if system_stdout:
+            system_stdout.close()
+            sys.stdout = old_stdout
+        if system_stderr:
+            system_stderr.close()
+            sys.stderr = old_stderr

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -41,7 +41,7 @@ from renku.core.utils.doi import is_doi
 from renku.core.utils.urls import remove_credentials
 
 from .client import pass_local_client
-from .echo import WARNING
+from .echo import INFO, WARNING
 from .format.dataset_files import DATASET_FILES_FORMATS
 from .format.datasets import DATASETS_FORMATS
 
@@ -272,7 +272,7 @@ def add_to_dataset(
             short_name=short_name, create=create
         ) as dataset:
             with urlscontext(urls) as bar:
-                warning_messages = client.add_data_to_dataset(
+                warning_messages, messages = client.add_data_to_dataset(
                     dataset,
                     bar,
                     external=external,
@@ -286,6 +286,10 @@ def add_to_dataset(
                     destination_names=destination_names,
                     progress=progress,
                 )
+
+            if messages:
+                for msg in messages:
+                    click.echo(INFO + msg)
 
             if warning_messages:
                 for msg in warning_messages:

--- a/renku/core/commands/echo.py
+++ b/renku/core/commands/echo.py
@@ -23,6 +23,7 @@ import os
 import click
 from git.remote import RemoteProgress
 
+INFO = click.style('Info: ', bold=True, fg='blue')
 WARNING = click.style('Warning: ', bold=True, fg='yellow')
 ERROR = click.style('Error: ', bold=True, fg='red')
 

--- a/renku/core/commands/providers/dataverse.py
+++ b/renku/core/commands/providers/dataverse.py
@@ -140,7 +140,11 @@ class DataverseProvider(ProviderApi):
         with retry() as session:
             response = session.get(uri, headers={'Accept': self._accept})
             if response.status_code != 200:
-                raise LookupError('record not found')
+                raise LookupError(
+                    'record not found. Status: {}'.format(
+                        response.status_code
+                    )
+                )
             return response
 
     def find_record(self, uri, client=None):

--- a/renku/core/commands/providers/doi.py
+++ b/renku/core/commands/providers/doi.py
@@ -101,7 +101,11 @@ class DOIProvider(ProviderApi):
         with retry() as session:
             response = session.get(url, headers=self.headers)
             if response.status_code != 200:
-                raise LookupError('record not found')
+                raise LookupError(
+                    'record not found. Status: {}'.format(
+                        response.status_code
+                    )
+                )
 
             return response
 

--- a/renku/core/commands/providers/zenodo.py
+++ b/renku/core/commands/providers/zenodo.py
@@ -517,7 +517,11 @@ class ZenodoProvider(ProviderApi):
                 make_records_url(record_id), headers={'Accept': self._accept}
             )
             if response.status_code != 200:
-                raise LookupError('record not found')
+                raise LookupError(
+                    'record not found. Status: {}'.format(
+                        response.status_code
+                    )
+                )
             return response
 
     def find_record(self, uri, client=None):

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -396,7 +396,9 @@ class DatasetsApiMixin(object):
         if self.has_external_storage:
             lfs_paths = self.track_paths_in_storage(*files_to_commit)
             show_message = self.get_value('renku', 'show_lfs_message')
-            if (lfs_paths and show_message is None or show_message == 'True'):
+            if (
+                lfs_paths and (show_message is None or show_message == 'True')
+            ):
                 messages.append((
                     'Adding these files to Git LFS:\n' +
                     '\t{}'.format('\n\t'.join(lfs_paths)) +

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -248,6 +248,7 @@ class DatasetsApiMixin(object):
         progress=None
     ):
         """Import the data into the data directory."""
+        messages = []
         warning_messages = []
         dataset_datadir = self.path / dataset.datadir
 
@@ -394,15 +395,13 @@ class DatasetsApiMixin(object):
         # Track non-symlinks in LFS
         if self.has_external_storage:
             lfs_paths = self.track_paths_in_storage(*files_to_commit)
-            show_warnings = self.get_value('renku', 'show_lfs_warnings')
-            if (
-                lfs_paths and show_warnings is None or show_warnings == 'True'
-            ):
-                warning_messages.append((
-                    'Adding files to Git LFS:\n' +
+            show_message = self.get_value('renku', 'show_lfs_message')
+            if (lfs_paths and show_message is None or show_message == 'True'):
+                messages.append((
+                    'Adding these files to Git LFS:\n' +
                     '\t{}'.format('\n\t'.join(lfs_paths)) +
-                    '\nTo disable this warning in the future, run:' +
-                    '\n\trenku config show_lfs_warnings False'
+                    '\nTo disable this message in the future, run:' +
+                    '\n\trenku config show_lfs_message False'
                 ))
 
         # Force-add to include possible ignored files
@@ -429,7 +428,7 @@ class DatasetsApiMixin(object):
             dataset_files.append(dataset_file)
 
         dataset.update_files(dataset_files)
-        return warning_messages
+        return warning_messages, messages
 
     def _check_protected_path(self, path):
         """Checks if a path is a protected path."""

--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -188,6 +188,8 @@ class StorageApiMixin(RepositoryApiMixin):
                 raise errors.ParameterError(
                     'Couldn\'t run \'git lfs\':\n{0}'.format(e)
                 )
+            return track_paths
+        return []
 
     @ensure_external_storage
     def untrack_paths_from_storage(self, *paths):

--- a/renku/core/models/cwl/command_line_tool.py
+++ b/renku/core/models/cwl/command_line_tool.py
@@ -364,8 +364,8 @@ class CommandLineToolFactory(object):
 
                 show_message = client.get_value('renku', 'show_lfs_message')
                 if (
-                    lfs_paths and show_message is None or
-                    show_message == 'True'
+                    lfs_paths and
+                    (show_message is None or show_message == 'True')
                 ):
                     self.messages = (
                         INFO + 'Adding these files to Git LFS:\n' +

--- a/renku/core/models/cwl/command_line_tool.py
+++ b/renku/core/models/cwl/command_line_tool.py
@@ -29,7 +29,7 @@ import attr
 import click
 
 from renku.core import errors
-from renku.core.commands.echo import WARNING
+from renku.core.commands.echo import INFO
 
 from ...management.config import RENKU_HOME
 from ..datastructures import DirectoryTree
@@ -212,7 +212,8 @@ class CommandLineToolFactory(object):
 
     successCodes = attr.ib(default=attr.Factory(list))  # list(int)
 
-    warning = attr.ib(default=None)
+    messages = attr.ib(default=None)
+    warnings = attr.ib(default=None)
 
     def __attrs_post_init__(self):
         """Derive basic information."""
@@ -361,16 +362,16 @@ class CommandLineToolFactory(object):
             if client.has_external_storage:
                 lfs_paths = client.track_paths_in_storage(*paths)
 
-                show_warnings = client.get_value('renku', 'show_lfs_warnings')
+                show_message = client.get_value('renku', 'show_lfs_message')
                 if (
-                    lfs_paths and show_warnings is None or
-                    show_warnings == 'True'
+                    lfs_paths and show_message is None or
+                    show_message == 'True'
                 ):
-                    self.warning = (
-                        WARNING + 'Adding files to Git LFS:\n' +
+                    self.messages = (
+                        INFO + 'Adding these files to Git LFS:\n' +
                         '\t{}'.format('\n\t'.join(lfs_paths)) +
-                        '\nTo disable this warning in the future, run:' +
-                        '\n\trenku config show_lfs_warnings False'
+                        '\nTo disable this message in the future, run:' +
+                        '\n\trenku config show_lfs_message False'
                     )
 
             tool.inputs = list(inputs.values())

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -392,7 +392,7 @@ def test_add_and_create_dataset_with_lfs_warning(
         catch_exceptions=False
     )
     assert 0 == result.exit_code
-    assert 'Adding files to Git LFS' in result.output
+    assert 'Adding these files to Git LFS' in result.output
     assert 'dir2/file2' in result.output
     assert 'file' in result.output
 

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -379,6 +379,24 @@ def test_add_and_create_dataset(
     assert 1 == result.exit_code
 
 
+def test_add_and_create_dataset_with_lfs_warning(
+    directory_tree, runner, project, client_with_lfs_warning
+):
+    """Test add data with lfs warning."""
+
+    # Add succeeds with --create
+    result = runner.invoke(
+        cli,
+        ['dataset', 'add', '--create', 'new-dataset',
+         str(directory_tree)],
+        catch_exceptions=False
+    )
+    assert 0 == result.exit_code
+    assert 'Adding files to Git LFS' in result.output
+    assert 'dir2/file2' in result.output
+    assert 'file' in result.output
+
+
 def test_add_to_dirty_repo(directory_tree, runner, project, client):
     """Test adding to a dataset in a dirty repo commits only added files."""
     with (client.path / 'tracked').open('w') as fp:

--- a/tests/cli/test_isolation.py
+++ b/tests/cli/test_isolation.py
@@ -53,7 +53,8 @@ def test_run_in_isolation(runner, project, client, run, subdirectory):
 
 
 def test_file_modification_during_run(
-    tmpdir, runner, project, client, run, subdirectory, no_lfs_size_limit
+    tmpdir, runner, project, client, run, subdirectory, no_lfs_size_limit, 
+    no_lfs_warning
 ):
     """Test run in isolation."""
     script = client.path / 'script.py'
@@ -86,8 +87,10 @@ def test_file_modification_during_run(
             prefix + cmd, stdin=subprocess.PIPE, stdout=stdout
         )
 
-        while not lock.exists():
+        while not lock.exists() and process.poll() is None:
             time.sleep(1)
+
+        assert process.poll() is None, 'Subprocess exited prematurely'
 
         with script.open('w') as fp:
             fp.write('print("edited")')

--- a/tests/cli/test_isolation.py
+++ b/tests/cli/test_isolation.py
@@ -53,7 +53,7 @@ def test_run_in_isolation(runner, project, client, run, subdirectory):
 
 
 def test_file_modification_during_run(
-    tmpdir, runner, project, client, run, subdirectory, no_lfs_size_limit, 
+    tmpdir, runner, project, client, run, subdirectory, no_lfs_size_limit,
     no_lfs_warning
 ):
     """Test run in isolation."""

--- a/tests/cli/test_rerun.py
+++ b/tests/cli/test_rerun.py
@@ -30,7 +30,7 @@ from click.testing import CliRunner
 from renku.cli import cli
 
 
-def test_simple_rerun(runner, project, run):
+def test_simple_rerun(runner, project, run, no_lfs_warning):
     """Test simple file recreation."""
     greetings = {'hello', 'hola', 'ahoj'}
 
@@ -117,7 +117,7 @@ def test_rerun_with_inputs(runner, project, run):
         assert f.read().startswith(first_data)
 
 
-def test_rerun_with_edited_inputs(project, run):
+def test_rerun_with_edited_inputs(project, run, no_lfs_warning):
     """Test input modification."""
     runner = CliRunner(mix_stderr=False)
 

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -33,7 +33,7 @@ def update_and_commit(data, file_, repo):
     repo.index.commit('Updated source.txt')
 
 
-def test_update(runner, project, run):
+def test_update(runner, project, run, no_lfs_warning):
     """Test automatic file update."""
     from renku.core.utils.shacl import validate_graph
 
@@ -137,7 +137,7 @@ def test_workflow_without_outputs(runner, project, run):
     assert 0 == result.exit_code
 
 
-def test_siblings_update(runner, project, run):
+def test_siblings_update(runner, project, run, no_lfs_warning):
     """Test detection of siblings during update."""
     cwd = Path(project)
     parent = cwd / 'parent.txt'

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -172,7 +172,7 @@ def test_workflow(runner, project):
     assert result_default.output == result_arg.output
 
 
-def test_streams(runner, project, capsys):
+def test_streams(runner, project, capsys, no_lfs_warning):
     """Test redirection of std streams."""
     repo = git.Repo('.')
 
@@ -266,7 +266,7 @@ def test_streams_cleanup(runner, project, run):
         assert fp.read() == '1'
 
 
-def test_streams_and_args_names(runner, project, capsys):
+def test_streams_and_args_names(runner, project, capsys, no_lfs_warning):
     """Test streams and conflicting argument names."""
     with capsys.disabled():
         with open('lalala', 'wb') as stdout:
@@ -528,7 +528,7 @@ def test_unchanged_output(runner, project):
     assert 1 == result.exit_code
 
 
-def test_unchanged_stdout(runner, project, capsys):
+def test_unchanged_stdout(runner, project, capsys, no_lfs_warning):
     """Test detection of unchanged stdout."""
     with capsys.disabled():
         with open('output.txt', 'wb') as stdout:
@@ -760,7 +760,7 @@ def test_deleted_input(runner, project, capsys):
     assert Path('input.mv').exists()
 
 
-def test_input_directory(runner, project, run):
+def test_input_directory(runner, project, run, no_lfs_warning):
     """Test detection of input directory."""
     repo = git.Repo(project)
     cwd = Path(project)


### PR DESCRIPTION
This adds warning messages when files get added to LFS like:
```
Warning: Adding files to Git LFS:
        file.txt
To disable this warning in the future, run:
        renku config show_lfs_warnings False
```

This PR also fixes output redirection in `renku run`. Before, when doing something like `renku run command >out.txt 2>err.txt`, not just the output of command would get passed into the files, but also any renku specific messages (like errors, warnings etc.). With this PR, the output redirection is only applied to the subprocess call, and renku itself can log to the terminal normally. Note: this doesn't work on windows, where the old behaviour is still in place.

This PR also fixes a bug where dataset files would always get added to LFS, even if the user didn't have/want LFS.

Closes #1099