### PR TITLE
refactor: replaces dataset_name with short_name & title support

### DIFF
--- a/renku/service/jobs/datasets.py
+++ b/renku/service/jobs/datasets.py
@@ -102,7 +102,7 @@ def dataset_import(
 @requires_cache
 def dataset_add_remote_file(
     cache, user, user_job_id, project_id, create_dataset, commit_message,
-    dataset_name, url
+    short_name, url
 ):
     """Add a remote file to a specified dataset."""
     user = cache.ensure_user(user)
@@ -116,7 +116,7 @@ def dataset_add_remote_file(
             urls = url if isinstance(url, list) else [url]
             add_file(
                 urls,
-                dataset_name,
+                short_name,
                 create=create_dataset,
                 commit_message=commit_message
             )

--- a/renku/service/serializers/datasets.py
+++ b/renku/service/serializers/datasets.py
@@ -138,28 +138,6 @@ class DatasetListRequest(Schema):
     project_id = fields.String(required=True)
 
 
-class CreatorDetails(Schema):
-    """Serialize a creator of a dataset to a response object."""
-
-    name = fields.String()
-    email = fields.String()
-    label = fields.String()
-    affiliation = fields.String()
-    alternate_name = fields.String()
-
-
-class DatasetDetails(Schema):
-    """Serialize a dataset to a response object."""
-
-    title = fields.String(required=True, attribute='name')
-    creator = fields.List(fields.Nested(CreatorDetails), required=True)
-    description = fields.String()
-
-    short_name = fields.String(required=True)
-    version = fields.String(allow_none=True)
-    created_at = fields.String(allow_none=True, attribute='created')
-
-
 class DatasetListResponse(Schema):
     """Response schema for dataset list view."""
 
@@ -228,7 +206,7 @@ class DatasetEditRequest(Schema):
 
     title = fields.String(default=None)
     description = fields.String(default=None)
-    creators = fields.List(fields.Nested(CreatorDetails))
+    creators = fields.List(fields.Nested(DatasetCreators))
     commit_message = fields.String()
 
 

--- a/renku/service/views/datasets.py
+++ b/renku/service/views/datasets.py
@@ -105,7 +105,7 @@ def list_dataset_files_view(user, cache):
         )
 
     with chdir(project.abs_path):
-        ctx['files'] = list_files(datasets=[ctx['dataset_name']])
+        ctx['files'] = list_files(datasets=[ctx['short_name']])
 
     return result_response(DatasetFilesListResponseRPC(), ctx)
 
@@ -142,7 +142,7 @@ def add_file_to_dataset_view(user_data, cache):
 
     if not ctx['commit_message']:
         ctx['commit_message'] = 'service: dataset add {0}'.format(
-            ctx['dataset_name']
+            ctx['short_name']
         )
 
     local_paths = []
@@ -161,7 +161,7 @@ def add_file_to_dataset_view(user_data, cache):
                 queue.enqueue(
                     dataset_add_remote_file, user_data, job.job_id,
                     project.project_id, ctx['create_dataset'], commit_message,
-                    ctx['dataset_name'], _file['file_url']
+                    ctx['short_name'], _file['file_url']
                 )
             continue
 
@@ -185,7 +185,7 @@ def add_file_to_dataset_view(user_data, cache):
         with chdir(project.abs_path):
             add_file(
                 local_paths,
-                ctx['dataset_name'],
+                ctx['short_name'],
                 create=ctx['create_dataset'],
                 force=ctx['force'],
                 commit_message=ctx['commit_message']
@@ -218,6 +218,7 @@ def add_file_to_dataset_view(user_data, cache):
 @requires_identity
 def create_dataset_view(user, cache):
     """Create a new dataset in a project."""
+    breakpoint()
     ctx = DatasetCreateRequest().load(request.json)
     project = cache.get_project(cache.ensure_user(user), ctx['project_id'])
 
@@ -228,7 +229,7 @@ def create_dataset_view(user, cache):
 
     with chdir(project.abs_path):
         create_dataset(
-            ctx['dataset_name'],
+            ctx['short_name'],
             commit_message=ctx['commit_message'],
             creators=ctx.get('creators'),
             description=ctx.get('description'),

--- a/renku/service/views/datasets.py
+++ b/renku/service/views/datasets.py
@@ -218,7 +218,6 @@ def add_file_to_dataset_view(user_data, cache):
 @requires_identity
 def create_dataset_view(user, cache):
     """Create a new dataset in a project."""
-    breakpoint()
     ctx = DatasetCreateRequest().load(request.json)
     project = cache.get_project(cache.ensure_user(user), ctx['project_id'])
 

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -921,9 +921,9 @@ def test_usage_error_in_add_from_git(runner, client, params, n_urls, message):
     assert message in result.output
 
 
-def read_dataset_file_metadata(client, dataset_name, filename):
+def read_dataset_file_metadata(client, short_name, filename):
     """Return metadata from dataset's YAML file."""
-    with client.with_dataset(dataset_name) as dataset:
+    with client.with_dataset(short_name) as dataset:
         assert client.get_dataset_path(dataset.name).exists()
 
         for file_ in dataset.files:

--- a/tests/cli/test_move.py
+++ b/tests/cli/test_move.py
@@ -80,12 +80,12 @@ def test_move_dataset_file(tmpdir, runner, client):
 def test_move_symlinks(data_repository, runner, project, client, destination):
     """Test importing data into a dataset."""
     # create a dataset
-    dataset_name = 'dataset'
-    result = runner.invoke(cli, ['dataset', 'create', dataset_name])
+    short_name = 'dataset'
+    result = runner.invoke(cli, ['dataset', 'create', short_name])
     assert 0 == result.exit_code
     assert 'OK' in result.output
 
-    with client.with_dataset(dataset_name) as dataset:
+    with client.with_dataset(short_name) as dataset:
         assert dataset.name == 'dataset'
 
     # add data from local git repo

--- a/tests/service/jobs/test_datasets.py
+++ b/tests/service/jobs/test_datasets.py
@@ -292,7 +292,7 @@ def test_dataset_add_remote_file(url, svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': uuid.uuid4().hex,
+        'short_name': uuid.uuid4().hex,
         'create_dataset': True,
         'files': [{
             'file_url': url
@@ -306,7 +306,7 @@ def test_dataset_add_remote_file(url, svc_client_with_repo):
 
     assert response
     assert_rpc_response(response)
-    assert {'files', 'dataset_name',
+    assert {'files', 'short_name',
             'project_id'} == set(response.json['result'].keys())
 
     dest = make_project_path(
@@ -320,8 +320,8 @@ def test_dataset_add_remote_file(url, svc_client_with_repo):
     commit_message = 'service: dataset add remote file'
 
     dataset_add_remote_file(
-        user, job_id, project_id, True, commit_message,
-        payload['dataset_name'], url
+        user, job_id, project_id, True, commit_message, payload['short_name'],
+        url
     )
 
     new_commit = Repo(dest).head.commit

--- a/tests/service/views/test_dataset_views.py
+++ b/tests/service/views/test_dataset_views.py
@@ -53,7 +53,7 @@ def test_create_dataset_view(svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': '{0}'.format(uuid.uuid4().hex),
+        'short_name': '{0}'.format(uuid.uuid4().hex),
     }
 
     response = svc_client.post(
@@ -65,8 +65,8 @@ def test_create_dataset_view(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name'} == set(response.json['result'].keys())
-    assert payload['dataset_name'] == response.json['result']['dataset_name']
+    assert {'short_name'} == set(response.json['result'].keys())
+    assert payload['short_name'] == response.json['result']['short_name']
 
 
 @pytest.mark.service
@@ -78,7 +78,7 @@ def test_create_dataset_commit_msg(svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': '{0}'.format(uuid.uuid4().hex),
+        'short_name': '{0}'.format(uuid.uuid4().hex),
         'commit_message': 'my awesome dataset'
     }
 
@@ -91,8 +91,8 @@ def test_create_dataset_commit_msg(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name'} == set(response.json['result'].keys())
-    assert payload['dataset_name'] == response.json['result']['dataset_name']
+    assert {'short_name'} == set(response.json['result'].keys())
+    assert payload['short_name'] == response.json['result']['short_name']
 
 
 @pytest.mark.service
@@ -104,7 +104,7 @@ def test_create_dataset_view_dataset_exists(svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': 'mydataset',
+        'short_name': 'mydataset',
     }
 
     response = svc_client.post(
@@ -129,7 +129,7 @@ def test_create_dataset_view_unknown_param(svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': 'mydata',
+        'short_name': 'mydata',
         'remote_name': 'origin'
     }
 
@@ -155,7 +155,7 @@ def test_create_dataset_with_no_identity(svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': 'mydata',
+        'short_name': 'mydata',
         'remote_name': 'origin',
     }
 
@@ -183,7 +183,7 @@ def test_add_file_view_with_no_identity(svc_client_with_repo):
     svc_client, headers, project_id, _ = svc_client_with_repo
     payload = {
         'project_id': project_id,
-        'dataset_name': 'mydata',
+        'short_name': 'mydata',
         'remote_name': 'origin',
     }
 
@@ -228,7 +228,7 @@ def test_add_file_view(svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': '{0}'.format(uuid.uuid4().hex),
+        'short_name': '{0}'.format(uuid.uuid4().hex),
         'create_dataset': True,
         'files': [{
             'file_id': file_id,
@@ -245,7 +245,7 @@ def test_add_file_view(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name', 'project_id',
+    assert {'short_name', 'project_id',
             'files'} == set(response.json['result'].keys())
 
     assert 1 == len(response.json['result']['files'])
@@ -273,7 +273,7 @@ def test_add_file_commit_msg(svc_client_with_repo):
     payload = {
         'commit_message': 'my awesome data file',
         'project_id': project_id,
-        'dataset_name': '{0}'.format(uuid.uuid4().hex),
+        'short_name': '{0}'.format(uuid.uuid4().hex),
         'create_dataset': True,
         'files': [{
             'file_id': file_id,
@@ -289,7 +289,7 @@ def test_add_file_commit_msg(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name', 'project_id',
+    assert {'short_name', 'project_id',
             'files'} == set(response.json['result'].keys())
 
     assert 1 == len(response.json['result']['files'])
@@ -317,7 +317,7 @@ def test_add_file_failure(svc_client_with_repo):
     payload = {
         'commit_message': 'my awesome data file',
         'project_id': project_id,
-        'dataset_name': '{0}'.format(uuid.uuid4().hex),
+        'short_name': '{0}'.format(uuid.uuid4().hex),
         'create_dataset': True,
         'files': [{
             'file_id': file_id,
@@ -363,8 +363,8 @@ def test_list_datasets_view(svc_client_with_repo):
     assert 0 != len(response.json['result']['datasets'])
 
     assert {
-        'version', 'description', 'short_name', 'created_at', 'creator',
-        'title'
+        'version', 'description', 'created_at', 'short_name', 'title',
+        'creator'
     } == set(response.json['result']['datasets'][0].keys())
 
 
@@ -397,7 +397,7 @@ def test_create_and_list_datasets_view(svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': '{0}'.format(uuid.uuid4().hex),
+        'short_name': '{0}'.format(uuid.uuid4().hex),
     }
 
     response = svc_client.post(
@@ -409,8 +409,8 @@ def test_create_and_list_datasets_view(svc_client_with_repo):
     assert response
 
     assert_rpc_response(response)
-    assert {'dataset_name'} == set(response.json['result'].keys())
-    assert payload['dataset_name'] == response.json['result']['dataset_name']
+    assert {'short_name'} == set(response.json['result'].keys())
+    assert payload['short_name'] == response.json['result']['short_name']
 
     params_list = {
         'project_id': project_id,
@@ -428,11 +428,11 @@ def test_create_and_list_datasets_view(svc_client_with_repo):
     assert {'datasets'} == set(response.json['result'].keys())
     assert 0 != len(response.json['result']['datasets'])
     assert {
-        'version', 'description', 'short_name', 'created_at', 'creator',
-        'title'
+        'creator', 'short_name', 'version', 'title', 'description',
+        'created_at'
     } == set(response.json['result']['datasets'][0].keys())
 
-    assert payload['dataset_name'] in [
+    assert payload['short_name'] in [
         ds['short_name'] for ds in response.json['result']['datasets']
     ]
 
@@ -463,7 +463,7 @@ def test_list_dataset_files(svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': 'mydata',
+        'short_name': 'mydata',
         'files': [{
             'file_id': file_id
         }, ],
@@ -479,13 +479,13 @@ def test_list_dataset_files(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name', 'files',
+    assert {'short_name', 'files',
             'project_id'} == set(response.json['result'].keys())
     assert file_id == response.json['result']['files'][0]['file_id']
 
     params = {
         'project_id': project_id,
-        'dataset_name': 'mydata',
+        'short_name': 'mydata',
     }
 
     response = svc_client.get(
@@ -497,9 +497,9 @@ def test_list_dataset_files(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name', 'files'} == set(response.json['result'].keys())
+    assert {'short_name', 'files'} == set(response.json['result'].keys())
 
-    assert params['dataset_name'] == response.json['result']['dataset_name']
+    assert params['short_name'] == response.json['result']['short_name']
     assert file_name in [
         file['name'] for file in response.json['result']['files']
     ]
@@ -543,7 +543,7 @@ def test_add_with_unpacked_archive(datapack_zip, svc_client_with_repo):
     file_ = mm['file2']
     payload = {
         'project_id': project_id,
-        'dataset_name': '{0}'.format(uuid.uuid4().hex),
+        'short_name': '{0}'.format(uuid.uuid4().hex),
     }
 
     headers['Content-Type'] = content_type
@@ -556,12 +556,12 @@ def test_add_with_unpacked_archive(datapack_zip, svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name'} == set(response.json['result'].keys())
-    assert payload['dataset_name'] == response.json['result']['dataset_name']
+    assert {'short_name'} == set(response.json['result'].keys())
+    assert payload['short_name'] == response.json['result']['short_name']
 
     payload = {
         'project_id': project_id,
-        'dataset_name': payload['dataset_name'],
+        'short_name': payload['short_name'],
         'files': [{
             'file_id': file_['file_id']
         }, ]
@@ -576,13 +576,13 @@ def test_add_with_unpacked_archive(datapack_zip, svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name', 'files',
+    assert {'short_name', 'files',
             'project_id'} == set(response.json['result'].keys())
     assert file_['file_id'] == response.json['result']['files'][0]['file_id']
 
     params = {
         'project_id': project_id,
-        'dataset_name': payload['dataset_name'],
+        'short_name': payload['short_name'],
     }
 
     response = svc_client.get(
@@ -594,9 +594,9 @@ def test_add_with_unpacked_archive(datapack_zip, svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name', 'files'} == set(response.json['result'].keys())
+    assert {'short_name', 'files'} == set(response.json['result'].keys())
 
-    assert params['dataset_name'] == response.json['result']['dataset_name']
+    assert params['short_name'] == response.json['result']['short_name']
     assert file_['file_name'] in [
         file['name'] for file in response.json['result']['files']
     ]
@@ -645,7 +645,7 @@ def test_add_with_unpacked_archive_all(datapack_zip, svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': '{0}'.format(uuid.uuid4().hex),
+        'short_name': '{0}'.format(uuid.uuid4().hex),
     }
 
     headers['Content-Type'] = content_type
@@ -658,12 +658,12 @@ def test_add_with_unpacked_archive_all(datapack_zip, svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name'} == set(response.json['result'].keys())
-    assert payload['dataset_name'] == response.json['result']['dataset_name']
+    assert {'short_name'} == set(response.json['result'].keys())
+    assert payload['short_name'] == response.json['result']['short_name']
 
     payload = {
         'project_id': project_id,
-        'dataset_name': payload['dataset_name'],
+        'short_name': payload['short_name'],
         'files': files,
     }
 
@@ -676,13 +676,13 @@ def test_add_with_unpacked_archive_all(datapack_zip, svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name', 'files',
+    assert {'short_name', 'files',
             'project_id'} == set(response.json['result'].keys())
     assert files == response.json['result']['files']
 
     params = {
         'project_id': project_id,
-        'dataset_name': payload['dataset_name'],
+        'short_name': payload['short_name'],
     }
 
     response = svc_client.get(
@@ -694,9 +694,9 @@ def test_add_with_unpacked_archive_all(datapack_zip, svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name', 'files'} == set(response.json['result'].keys())
+    assert {'short_name', 'files'} == set(response.json['result'].keys())
 
-    assert params['dataset_name'] == response.json['result']['dataset_name']
+    assert params['short_name'] == response.json['result']['short_name']
     assert file_['file_name'] in [
         file['name'] for file in response.json['result']['files']
     ]
@@ -710,7 +710,7 @@ def test_add_existing_file(svc_client_with_repo):
     svc_client, headers, project_id, _ = svc_client_with_repo
     payload = {
         'project_id': project_id,
-        'dataset_name': '{0}'.format(uuid.uuid4().hex),
+        'short_name': '{0}'.format(uuid.uuid4().hex),
     }
 
     response = svc_client.post(
@@ -721,13 +721,13 @@ def test_add_existing_file(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name'} == set(response.json['result'].keys())
-    assert payload['dataset_name'] == response.json['result']['dataset_name']
+    assert {'short_name'} == set(response.json['result'].keys())
+    assert payload['short_name'] == response.json['result']['short_name']
 
     files = [{'file_path': 'README.md'}]
     payload = {
         'project_id': project_id,
-        'dataset_name': payload['dataset_name'],
+        'short_name': payload['short_name'],
         'files': files,
     }
 
@@ -740,7 +740,7 @@ def test_add_existing_file(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name', 'files',
+    assert {'short_name', 'files',
             'project_id'} == set(response.json['result'].keys())
 
     assert files == response.json['result']['files']
@@ -838,7 +838,7 @@ def test_dataset_add_remote(
     )
 
     assert_rpc_response(response)
-    assert {'files', 'dataset_name',
+    assert {'files', 'short_name',
             'project_id'} == set(response.json['result'])
     job_id = response.json['result']['files'][0]['job_id']
 
@@ -884,7 +884,7 @@ def test_dataset_add_multiple_remote(
     )
 
     assert_rpc_response(response)
-    assert {'files', 'dataset_name',
+    assert {'files', 'short_name',
             'project_id'} == set(response.json['result'])
 
     for file in response.json['result']['files']:
@@ -923,7 +923,7 @@ def test_add_remote_and_local_file(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'dataset_name', 'files',
+    assert {'short_name', 'files',
             'project_id'} == set(response.json['result'].keys())
 
     for pair in zip(response.json['result']['files'], payload['files']):

--- a/tests/service/views/test_dataset_views.py
+++ b/tests/service/views/test_dataset_views.py
@@ -943,7 +943,7 @@ def test_edit_datasets_view(svc_client_with_repo):
 
     payload = {
         'project_id': project_id,
-        'dataset_name': short_name,
+        'short_name': short_name,
     }
 
     response = svc_client.post(
@@ -955,8 +955,8 @@ def test_edit_datasets_view(svc_client_with_repo):
     assert response
 
     assert_rpc_response(response)
-    assert {'dataset_name'} == set(response.json['result'].keys())
-    assert payload['dataset_name'] == response.json['result']['dataset_name']
+    assert {'short_name'} == set(response.json['result'].keys())
+    assert payload['short_name'] == response.json['result']['short_name']
 
     params_list = {
         'project_id': project_id,

--- a/tests/service/views/test_utils.py
+++ b/tests/service/views/test_utils.py
@@ -45,7 +45,8 @@ def test_result_response(svc_client):
 
     expected = ctx['datasets'][0]
     received = response['result']['datasets'][0]
-    assert expected['name'] == received['title']
+
+    assert expected['short_name'] == received['short_name']
 
 
 def test_result_response_with_none(svc_client):

--- a/tests/service/views/test_utils.py
+++ b/tests/service/views/test_utils.py
@@ -36,7 +36,7 @@ def test_error_response(svc_client):
 
 def test_result_response(svc_client):
     """Test result response utility."""
-    ctx = {'datasets': [{'name': 'my-dataset'}]}
+    ctx = {'datasets': [{'short_name': 'my-dataset'}]}
     response = result_response(DatasetListResponseRPC(), ctx).json
 
     assert response

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,7 +38,7 @@ def raises(error):
         return not_raises()
 
 
-def make_dataset_add_payload(project_id, urls, dataset_name=None):
+def make_dataset_add_payload(project_id, urls, short_name=None):
     """Make dataset add request payload."""
     files = []
     for url in urls:
@@ -50,7 +50,7 @@ def make_dataset_add_payload(project_id, urls, dataset_name=None):
 
     return {
         'project_id': project_id,
-        'dataset_name': dataset_name or uuid.uuid4().hex,
+        'short_name': short_name or uuid.uuid4().hex,
         'create_dataset': True,
         'force': False,
         'files': files


### PR DESCRIPTION
This PR adds consistency between service and the core in regards with `dataset_name` => `short_name` and adds support for adding title on dataset creation. 

addresses: #1075 
addresses: #1148

Rebase for #1186 is needed after merging this PR.