### PR TITLE
fix(dataset): correct url in different domain

### DIFF
--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -602,7 +602,6 @@ def import_dataset(
     if not files:
         raise ParameterError('Dataset {} has no files.'.format(uri))
 
-    dataset.url = remove_credentials(uri)
     dataset.same_as = Url(url_id=remove_credentials(uri))
 
     if not provider.is_git_based:

--- a/renku/core/models/datasets.py
+++ b/renku/core/models/datasets.py
@@ -563,9 +563,7 @@ class Dataset(Entity, CreatorMixin):
             )
         )
 
-        if not self.url:
-            # set the url for non-imported datasets
-            self.url = self._id
+        self.url = self._id
 
         # if `date_published` is set, we are probably dealing with
         # an imported dataset so `created` is not needed

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -258,6 +258,25 @@ def test_dataset_creator_is_invalid(client, runner, creator, field):
     assert field + ' is invalid' in result.output
 
 
+def test_dataset_url_in_different_domain(runner, client):
+    """Test URL is set correctly in a different Renku domain."""
+    result = runner.invoke(cli, ['dataset', 'create', 'my-dataset'])
+    assert 0 == result.exit_code
+
+    try:
+        renku_domain = os.environ.get('RENKU_DOMAIN')
+        os.environ['RENKU_DOMAIN'] = 'alternative-domain'
+
+        with client.with_dataset('my-dataset') as dataset:
+            assert dataset.url.startswith('https://alternative-domain')
+            assert dataset.url == dataset._id
+    finally:
+        if renku_domain:
+            os.environ['RENKU_DOMAIN'] = renku_domain
+        else:
+            del os.environ['RENKU_DOMAIN']
+
+
 @pytest.mark.parametrize('output_format', DATASETS_FORMATS.keys())
 def test_datasets_list_empty(output_format, runner, project):
     """Test listing without datasets."""

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -52,7 +52,7 @@ from renku.core.utils.contexts import chdir
 )
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_dataset_import_real_doi(runner, project, doi, sleep_after):
+def test_dataset_import_real_doi(runner, project, doi, client, sleep_after):
     """Test dataset import for existing DOI."""
     result = runner.invoke(
         cli, ['dataset', 'import', doi['doi']], input=doi['input']
@@ -69,6 +69,11 @@ def test_dataset_import_real_doi(runner, project, doi, sleep_after):
     result = runner.invoke(cli, ['dataset', 'ls-tags', doi['short_name']])
     assert 0 == result.exit_code, result.output + str(result.stderr_bytes)
     assert doi['version'] in result.output
+
+    with client.with_dataset(doi['short_name']) as dataset:
+        assert doi['doi'] in dataset.same_as.url
+        assert dataset.identifier in dataset.url
+        assert dataset.url == dataset._id
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Set dataset's URL to be always equal to its `_id`.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/1057
