### PR TITLE
feat(dataset): doi variations for import

### DIFF
--- a/renku/core/commands/providers/doi.py
+++ b/renku/core/commands/providers/doi.py
@@ -21,7 +21,7 @@ import urllib
 import attr
 
 from renku.core.commands.providers.api import ProviderApi
-from renku.core.utils.doi import is_doi
+from renku.core.utils.doi import extract_doi, is_doi
 from renku.core.utils.requests import retry
 
 DOI_BASE_URL = 'https://dx.doi.org'
@@ -81,10 +81,7 @@ class DOIProvider(ProviderApi):
     @staticmethod
     def supports(uri):
         """Whether or not this provider supports a given uri."""
-        if is_doi(uri) is not None:
-            return True
-
-        return False
+        return bool(is_doi(uri))
 
     @staticmethod
     def _serialize(response):
@@ -98,9 +95,8 @@ class DOIProvider(ProviderApi):
 
     def _query(self, doi):
         """Retrieve metadata for given doi."""
-        url = doi
-        if doi.startswith('http') is False:
-            url = make_doi_url(doi)
+        doi = extract_doi(doi)
+        url = make_doi_url(doi)
 
         with retry() as session:
             response = session.get(url, headers=self.headers)

--- a/renku/core/utils/doi.py
+++ b/renku/core/utils/doi.py
@@ -19,7 +19,8 @@
 import re
 
 doi_regexp = re.compile(
-    r'(doi:\s*|(?:https?://)?(?:dx\.)?doi\.org/)?(10\.\d+(.\d+)*/.+)$',
+    r'(doi:\s*|(?:(?:https|http)://)?(?:(?:dx|www)\.)?doi\.org/)?' +
+    r'(10\.\d+(.\d+)*/.+)$',
     flags=re.I
 )
 """See http://en.wikipedia.org/wiki/Digital_object_identifier."""

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -56,7 +56,7 @@ from renku.core.utils.contexts import chdir
 )
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_dataset_import_real_doi(runner, project, doi, prefix, sleep_after):
+def test_dataset_import_real_doi(runner, client, doi, prefix, sleep_after):
     """Test dataset import for existing DOI."""
     uri = prefix + doi['doi']
     result = runner.invoke(cli, ['dataset', 'import', uri], input='y')

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -36,7 +36,6 @@ from renku.core.utils.contexts import chdir
 @pytest.mark.parametrize(
     'doi', [{
         'doi': '10.5281/zenodo.2658634',
-        'input': 'y',
         'short_name': 'pyndl_naive_discriminat_v064',
         'creator':
             'Konstantin Sering, Marc Weitz, David-Elias Künstle, '
@@ -44,19 +43,23 @@ from renku.core.utils.contexts import chdir
         'version': 'v0.6.4'
     }, {
         'doi': '10.7910/DVN/F4NUMR',
-        'input': 'y',
         'short_name': 'replication_data_for_ca_2',
         'creator': 'James Druckman, Martin Kifer, Michael Parkin',
         'version': '2'
     }]
 )
+@pytest.mark.parametrize(
+    'prefix', [
+        '', 'doi:', 'doi.org/', 'www.doi.org/', 'dx.doi.org/',
+        'http://www.doi.org/', 'https://dx.doi.org/', 'https://doi.org/'
+    ]
+)
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_dataset_import_real_doi(runner, project, doi, sleep_after):
+def test_dataset_import_real_doi(runner, project, doi, prefix, sleep_after):
     """Test dataset import for existing DOI."""
-    result = runner.invoke(
-        cli, ['dataset', 'import', doi['doi']], input=doi['input']
-    )
+    uri = prefix + doi['doi']
+    result = runner.invoke(cli, ['dataset', 'import', uri], input='y')
     assert 0 == result.exit_code, result.output + str(result.stderr_bytes)
     assert 'OK' in result.output + str(result.stderr_bytes)
 


### PR DESCRIPTION
# Description

The following cases will work now:
```
renku dataset import www.doi.org/10.7910/DVN/WTZS4K
renku dataset import http://dx.doi.org/10.7910/DVN/WTZS4K
renku dataset import https://www.doi.org/10.7910/DVN/WTZS4K
...
```

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/1078
