### PR TITLE
feat: protected branches support

### DIFF
--- a/renku/service/cache/models/job.py
+++ b/renku/service/cache/models/job.py
@@ -62,3 +62,10 @@ class Job(Model):
 
         self.extras['error'] = error
         self.save()
+
+    def update_extras(self, key, value):
+        """Update extras field."""
+        if not self.extras:
+            self.extras = {key: value}
+        else:
+            self.extras[key] = value

--- a/renku/service/jobs/datasets.py
+++ b/renku/service/jobs/datasets.py
@@ -89,7 +89,7 @@ def dataset_import(
             )
 
             remote_branch = repo_sync(project.abs_path)
-            user_job.update_extras = remote_branch
+            user_job.update_extras('remote_branch', remote_branch.name)
 
             user_job.complete()
         except (
@@ -124,7 +124,7 @@ def dataset_add_remote_file(
             )
 
             remote_branch = repo_sync(project.abs_path)
-            user_job.update_extras('remote_branch', remote_branch)
+            user_job.update_extras('remote_branch', remote_branch.name)
 
             user_job.complete()
     except (HTTPError, BaseException, GitCommandError) as e:

--- a/renku/service/jobs/datasets.py
+++ b/renku/service/jobs/datasets.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Dataset jobs."""
+from git import GitCommandError
 from urllib3.exceptions import HTTPError
 
 from renku.core.commands.dataset import add_file, import_dataset
@@ -78,6 +79,7 @@ def dataset_import(
     with chdir(project.abs_path):
         try:
             user_job.in_progress()
+
             import_dataset(
                 dataset_uri,
                 short_name,
@@ -85,18 +87,18 @@ def dataset_import(
                 commit_message=f'service: dataset import {dataset_uri}',
                 progress=DatasetImportJobProcess(cache, user_job)
             )
+
+            remote_branch = repo_sync(project.abs_path)
+            user_job.update_extras = remote_branch
+
             user_job.complete()
-        except (HTTPError, ParameterError, DatasetExistsError) as exp:
+        except (
+            HTTPError, ParameterError, DatasetExistsError, GitCommandError
+        ) as exp:
             user_job.fail_job(str(exp))
 
             # Reraise exception, so we see trace in job metadata.
             raise exp
-
-    if not repo_sync(project.abs_path):
-        error = 'failed to push refs'
-        user_job.fail_job(error)
-
-        raise RuntimeError(error)
 
 
 @requires_cache
@@ -121,9 +123,9 @@ def dataset_add_remote_file(
                 commit_message=commit_message
             )
 
-            if not repo_sync(project.abs_path):
-                user_job.fail_job('repo sync failed')
+            remote_branch = repo_sync(project.abs_path)
+            user_job.update_extras('remote_branch', remote_branch)
 
             user_job.complete()
-    except (HTTPError, BaseException) as e:
+    except (HTTPError, BaseException, GitCommandError) as e:
         user_job.fail_job(str(e))

--- a/renku/service/serializers/datasets.py
+++ b/renku/service/serializers/datasets.py
@@ -65,6 +65,7 @@ class DatasetCreateResponse(Schema):
     """Response schema for a dataset create view."""
 
     short_name = fields.String(required=True)
+    remote_branch = fields.String()
 
 
 class DatasetCreateResponseRPC(JsonRPCResponse):
@@ -124,6 +125,7 @@ class DatasetAddResponse(Schema):
     short_name = fields.String(required=True)
 
     files = fields.List(fields.Nested(DatasetAddFile), required=True)
+    remote_branch = fields.String()
 
 
 class DatasetAddResponseRPC(JsonRPCResponse):

--- a/renku/service/utils/__init__.py
+++ b/renku/service/utils/__init__.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Renku service utility functions."""
-from git import Repo
+from git import Repo, GitCommandError
 
 from renku.service.config import CACHE_PROJECTS_PATH, CACHE_UPLOADS_PATH
 
@@ -60,7 +60,13 @@ def repo_sync(repo_path, remote_names=('origin', )):
 
     for remote in repo.remotes:
         if remote.name in remote_names:
-            repo.git.push(remote.name, repo.active_branch)
+            try:
+                repo.git.push(remote.name, repo.active_branch)
+            except GitCommandError as e:
+                if 'Locking support detected' in e.stderr:
+                    repo.git.checkout()
+                    # TODO: checkout new branch
             is_pushed = True
 
+    # TODO: return branch name if true
     return is_pushed

--- a/renku/service/utils/__init__.py
+++ b/renku/service/utils/__init__.py
@@ -16,7 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Renku service utility functions."""
-from git import Repo, GitCommandError
+import uuid
+
+from git import GitCommandError, Repo
 
 from renku.service.config import CACHE_PROJECTS_PATH, CACHE_UPLOADS_PATH
 
@@ -56,17 +58,19 @@ def valid_file(user, cached_file):
 def repo_sync(repo_path, remote_names=('origin', )):
     """Sync the repo with the remotes."""
     repo = Repo(repo_path)
-    is_pushed = False
+    pushed_branch = None
 
     for remote in repo.remotes:
         if remote.name in remote_names:
             try:
                 repo.git.push(remote.name, repo.active_branch)
+                pushed_branch = repo.active_branch
             except GitCommandError as e:
-                if 'Locking support detected' in e.stderr:
-                    repo.git.checkout()
-                    # TODO: checkout new branch
-            is_pushed = True
+                if 'protected branches' not in e.stderr:
+                    raise e
 
-    # TODO: return branch name if true
-    return is_pushed
+                pushed_branch = uuid.uuid4().hex
+                repo.git.checkout(b=pushed_branch)
+                repo.git.push(remote.name, repo.active_branch)
+
+    return pushed_branch

--- a/renku/service/views/datasets.py
+++ b/renku/service/views/datasets.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from flask import Blueprint, request
 from flask_apispec import marshal_with, use_kwargs
+from git import GitCommandError
 
 from renku.core.commands.dataset import add_file, create_dataset, \
     edit_dataset, list_datasets, list_files
@@ -191,7 +192,9 @@ def add_file_to_dataset_view(user_data, cache):
                 commit_message=ctx['commit_message']
             )
 
-            if not repo_sync(project.abs_path):
+            try:
+                ctx['remote_branch'] = repo_sync(project.abs_path)
+            except GitCommandError:
                 return error_response(
                     INTERNAL_FAILURE_ERROR_CODE, 'repo sync failed'
                 )
@@ -235,7 +238,9 @@ def create_dataset_view(user, cache):
             commit_message=ctx['commit_message']
         )
 
-    if not repo_sync(project.abs_path):
+    try:
+        ctx['remote_branch'] = repo_sync(project.abs_path)
+    except GitCommandError:
         return error_response(
             INTERNAL_FAILURE_ERROR_CODE,
             'push to remote failed silently - try again'

--- a/tests/service/views/test_dataset_views.py
+++ b/tests/service/views/test_dataset_views.py
@@ -26,7 +26,6 @@ from pathlib import Path
 
 import pytest
 from flaky import flaky
-
 from tests.service.views.test_cache_views import IT_GIT_ACCESS_TOKEN
 from tests.utils import make_dataset_add_payload
 
@@ -67,7 +66,8 @@ def test_create_dataset_view(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name'} == set(response.json['result'].keys())
+    assert {'short_name',
+            'remote_branch'} == set(response.json['result'].keys())
     assert payload['short_name'] == response.json['result']['short_name']
 
 
@@ -99,7 +99,8 @@ def test_create_dataset_with_metadata(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name'} == set(response.json['result'].keys())
+    assert {'short_name',
+            'remote_branch'} == set(response.json['result'].keys())
     assert payload['short_name'] == response.json['result']['short_name']
 
     params = {
@@ -178,7 +179,8 @@ def test_create_dataset_commit_msg(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name'} == set(response.json['result'].keys())
+    assert {'short_name',
+            'remote_branch'} == set(response.json['result'].keys())
     assert payload['short_name'] == response.json['result']['short_name']
 
 
@@ -332,8 +334,8 @@ def test_add_file_view(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name', 'project_id',
-            'files'} == set(response.json['result'].keys())
+    assert {'short_name', 'project_id', 'files',
+            'remote_branch'} == set(response.json['result'].keys())
 
     assert 1 == len(response.json['result']['files'])
     assert file_id == response.json['result']['files'][0]['file_id']
@@ -376,8 +378,8 @@ def test_add_file_commit_msg(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name', 'project_id',
-            'files'} == set(response.json['result'].keys())
+    assert {'short_name', 'project_id', 'files',
+            'remote_branch'} == set(response.json['result'].keys())
 
     assert 1 == len(response.json['result']['files'])
     assert file_id == response.json['result']['files'][0]['file_id']
@@ -496,7 +498,8 @@ def test_create_and_list_datasets_view(svc_client_with_repo):
     assert response
 
     assert_rpc_response(response)
-    assert {'short_name'} == set(response.json['result'].keys())
+    assert {'short_name',
+            'remote_branch'} == set(response.json['result'].keys())
     assert payload['short_name'] == response.json['result']['short_name']
 
     params_list = {
@@ -566,8 +569,8 @@ def test_list_dataset_files(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name', 'files',
-            'project_id'} == set(response.json['result'].keys())
+    assert {'short_name', 'files', 'project_id',
+            'remote_branch'} == set(response.json['result'].keys())
     assert file_id == response.json['result']['files'][0]['file_id']
 
     params = {
@@ -643,7 +646,8 @@ def test_add_with_unpacked_archive(datapack_zip, svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name'} == set(response.json['result'].keys())
+    assert {'short_name',
+            'remote_branch'} == set(response.json['result'].keys())
     assert payload['short_name'] == response.json['result']['short_name']
 
     payload = {
@@ -663,8 +667,8 @@ def test_add_with_unpacked_archive(datapack_zip, svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name', 'files',
-            'project_id'} == set(response.json['result'].keys())
+    assert {'short_name', 'files', 'project_id',
+            'remote_branch'} == set(response.json['result'].keys())
     assert file_['file_id'] == response.json['result']['files'][0]['file_id']
 
     params = {
@@ -745,7 +749,8 @@ def test_add_with_unpacked_archive_all(datapack_zip, svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name'} == set(response.json['result'].keys())
+    assert {'short_name',
+            'remote_branch'} == set(response.json['result'].keys())
     assert payload['short_name'] == response.json['result']['short_name']
 
     payload = {
@@ -763,8 +768,8 @@ def test_add_with_unpacked_archive_all(datapack_zip, svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name', 'files',
-            'project_id'} == set(response.json['result'].keys())
+    assert {'short_name', 'files', 'project_id',
+            'remote_branch'} == set(response.json['result'].keys())
     assert files == response.json['result']['files']
 
     params = {
@@ -808,7 +813,8 @@ def test_add_existing_file(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name'} == set(response.json['result'].keys())
+    assert {'short_name',
+            'remote_branch'} == set(response.json['result'].keys())
     assert payload['short_name'] == response.json['result']['short_name']
 
     files = [{'file_path': 'README.md'}]
@@ -827,8 +833,8 @@ def test_add_existing_file(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name', 'files',
-            'project_id'} == set(response.json['result'].keys())
+    assert {'short_name', 'files', 'project_id',
+            'remote_branch'} == set(response.json['result'].keys())
 
     assert files == response.json['result']['files']
 
@@ -1010,8 +1016,8 @@ def test_add_remote_and_local_file(svc_client_with_repo):
     assert response
     assert_rpc_response(response)
 
-    assert {'short_name', 'files',
-            'project_id'} == set(response.json['result'].keys())
+    assert {'short_name', 'files', 'project_id',
+            'remote_branch'} == set(response.json['result'].keys())
 
     for pair in zip(response.json['result']['files'], payload['files']):
         if 'job_id' in pair[0]:
@@ -1040,9 +1046,10 @@ def test_edit_datasets_view(svc_client_with_repo):
     )
 
     assert response
-
     assert_rpc_response(response)
-    assert {'short_name'} == set(response.json['result'].keys())
+
+    assert {'short_name',
+            'remote_branch'} == set(response.json['result'].keys())
     assert payload['short_name'] == response.json['result']['short_name']
 
     params_list = {
@@ -1109,4 +1116,6 @@ def test_protected_branch(svc_client):
     )
 
     assert response
+
     assert {'result'} == set(response.json.keys())
+    assert 'master' != response.json['result']['remote_branch']


### PR DESCRIPTION
closes: #1190 

This PR adds a feature for handling failures to sync with remote repositories. In case of such failures, it will create a new branch (named by generating `uuid4()` ) and push it to a remote. Because of this behaviour, we add to responses of `datasets.add` and `datasets.create`. In cases where we sync with remote within jobs, this `remote_branch` key will be written inside of job details which can be accessed via `/jobs`.

Additional key in HTTP responses can be found in:

```
{
  ...
  "remote_branch": "d059c132512846e88aa642e88a1bf6e2"
  ...
}
```

or in case of a job details:

```
{
  ...
  "extras": {
      "remote_branch": "d059c132512846e88aa642e88a1bf6e2"
  }
  ...
}
```