### PR TITLE
feat(core): Adds renku storage clean command

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -218,6 +218,21 @@ def client(project):
     LocalClient.get_value = original_get_value
 
 
+@pytest.fixture(scope='function')
+def client_with_remote(client, tmpdir_factory):
+    """Return a client with a (local) remote set."""
+    # create remote
+    path = str(tmpdir_factory.mktemp('remote'))
+    Repo().init(path, bare=True)
+
+    origin = client.repo.create_remote('origin', path)
+    client.repo.git.push('--set-upstream', 'origin', 'master')
+    yield {'client': client, 'origin': origin}
+    client.repo.git.branch('--unset-upstream')
+    client.repo.delete_remote(origin)
+    shutil.rmtree(path)
+
+
 @pytest.fixture
 def no_lfs_warning(client):
     """Sets show_lfs_message to False.

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,3 +22,10 @@ doctest_optionflags = ALLOW_UNICODE ALLOW_BYTES DONT_ACCEPT_TRUE_FOR_1 ELLIPSIS 
 pep8ignore = docs/conf.py ALL
 flake8-ignore = docs/conf.py ALL
 testpaths = docs tests renku conftest.py
+markers =
+    integration: mark a test as a integration.
+    service: mark a test as service test.
+    jobs: mark a test as a job test.
+    migration: mark a test as a migration test.
+    shelled: mark a test as a shelled test.
+    pep8: mark a test as a pep8 format test.

--- a/renku/cli/storage.py
+++ b/renku/cli/storage.py
@@ -15,11 +15,46 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Manage an external storage."""
+"""Manage git LFS external storage.
+
+Pulling files from git LFS
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+LFS works by checking small pointer files into git and saving the actual
+contents of a file in LFS. If instead of your file content, you see
+something like this, it means the file is stored in git LFS and its
+contents are not currently available locally (they are not pulled):
+
+.. code-block:: console
+
+    version https://git-lfs.github.com/spec/v1
+    oid sha256:42b5c7fb2acd54f6d3cd930f18fee3bdcb20598764ca93bdfb38d7989c054bcf
+    size 12
+
+You can manually pull contents of file(s) you want with:
+
+.. code-block:: console
+
+    $ renku storage pull file1 file2
+
+Removing local content of files stored in git LFS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to restore a file back to its pointer file state, for instance
+to free up space locally, you can run:
+
+.. code-block:: console
+
+    $ renku storage clean file1 file2
+
+This removes any data cached locally for files tracked in in git LFS.
+
+"""
 
 import click
 
 from renku.core.commands.client import pass_local_client
+from renku.core.errors import ParameterError
 
 
 @click.group()
@@ -38,3 +73,21 @@ def storage():
 def pull(client, paths):
     """Pull the specified paths from external storage."""
     client.pull_paths_from_storage(*paths)
+
+
+@storage.command()
+@click.argument(
+    'paths',
+    type=click.Path(exists=True, dir_okay=True),
+    nargs=-1,
+    required=True,
+)
+@pass_local_client
+def clean(client, paths):
+    """Remove files from lfs cache/turn them back into pointer files."""
+    try:
+        client.clean_storage_cache(*paths)
+    except (ParameterError) as e:
+        raise click.BadParameter(e)
+
+    click.secho('OK', fg='green')

--- a/renku/cli/storage.py
+++ b/renku/cli/storage.py
@@ -54,7 +54,7 @@ This removes any data cached locally for files tracked in in git LFS.
 import click
 
 from renku.core.commands.client import pass_local_client
-from renku.core.errors import ParameterError
+from renku.core.commands.echo import WARNING
 
 
 @click.group()
@@ -85,9 +85,11 @@ def pull(client, paths):
 @pass_local_client
 def clean(client, paths):
     """Remove files from lfs cache/turn them back into pointer files."""
-    try:
-        client.clean_storage_cache(*paths)
-    except (ParameterError) as e:
-        raise click.BadParameter(e)
+    untracked_paths = client.clean_storage_cache(*paths)
 
+    if untracked_paths:
+        click.echo(
+            WARNING + 'These paths were ignored as they are not tracked' +
+            ' in git LFS:\n\t{}'.format('\n\t'.join(untracked_paths))
+        )
     click.secho('OK', fg='green')

--- a/renku/cli/storage.py
+++ b/renku/cli/storage.py
@@ -85,11 +85,19 @@ def pull(client, paths):
 @pass_local_client
 def clean(client, paths):
     """Remove files from lfs cache/turn them back into pointer files."""
-    untracked_paths = client.clean_storage_cache(*paths)
+    untracked_paths, local_only_paths = client.clean_storage_cache(*paths)
 
     if untracked_paths:
         click.echo(
             WARNING + 'These paths were ignored as they are not tracked' +
-            ' in git LFS:\n\t{}'.format('\n\t'.join(untracked_paths))
+            ' in git LFS:\n\t{}\n'.format('\n\t'.join(untracked_paths))
         )
+
+    if local_only_paths:
+        click.echo(
+            WARNING + 'These paths were ignored as they are not pushed to ' +
+            'a remote with git LFS:\n\t{}\n'.
+            format('\n\t'.join(local_only_paths))
+        )
+
     click.secho('OK', fg='green')

--- a/renku/core/management/git.py
+++ b/renku/core/management/git.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """Wrap Git client."""
 
+import glob
 import itertools
 import os
 import sys
@@ -83,13 +84,19 @@ def _clean_streams(repo, mapped_streams):
 
 def _expand_directories(paths):
     """Expand directory with all files it contains."""
+    processed_paths = set()
     for path in paths:
-        path_ = Path(path)
-        if path_.is_dir():
-            for expanded in path_.rglob('*'):
-                yield str(expanded)
-        else:
-            yield path
+        for matched_path in glob.glob(path, recursive=True):
+            if matched_path in processed_paths:
+                continue
+            path_ = Path(matched_path)
+            if path_.is_dir():
+                for expanded in path_.rglob('*'):
+                    processed_paths.add(str(expanded))
+                    yield str(expanded)
+            else:
+                processed_paths.add(matched_path)
+                yield matched_path
 
 
 @attr.s

--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -239,10 +239,13 @@ class StorageApiMixin(RepositoryApiMixin):
             len(client.repo.remotes) < 1 or
             not client.repo.active_branch.tracking_branch()
         ):
-            raise errors.ParameterError(
-                'No git remote is configured for {} branch {}. Cleaning lfs'.
+            raise errors.ConfigurationError(
+                'No git remote is configured for {} branch {}.'.
                 format(client.path, client.repo.active_branch.name) +
-                ' would lead to a loss of data as it is not on a' + ' server.'
+                'Cleaning the storage cache would lead to a loss of data as ' +
+                'it is not on a server. Please see ' +
+                'https://www.atlassian.com/git/tutorials/syncing for ' +
+                'information on how to sync with a remote.'
             )
         try:
             status = check_output(

--- a/tests/cli/test_move.py
+++ b/tests/cli/test_move.py
@@ -52,6 +52,7 @@ def test_move_dataset_file(tmpdir, runner, client):
     assert (client.path / 'files' / 'testing' / 'source').exists()
 
     result = runner.invoke(cli, ['doctor'], catch_exceptions=False)
+
     assert 0 == result.exit_code
 
     src = os.path.join('files', 'testing', 'source')

--- a/tests/core/commands/test_storage.py
+++ b/tests/core/commands/test_storage.py
@@ -34,7 +34,8 @@ def test_lfs_storage_clean_no_remote(runner, project, client):
     result = runner.invoke(
         cli, ['storage', 'clean', 'tracked'], catch_exceptions=False
     )
-    assert 2 == result.exit_code
+    assert 1 == result.exit_code
+    assert 'No git remote is configured for' in result.output
 
 
 def test_lfs_storage_clean(runner, project, client_with_remote):
@@ -96,11 +97,9 @@ def test_lfs_storage_unpushed_clean(runner, project, client_with_remote):
 
     with (client.path / 'tracked').open('w') as fp:
         fp.write('tracked file')
-    client.repo.git.add('*')
-    client.repo.index.commit('tracked file')
     subprocess.call(['git', 'lfs', 'track', 'tracked'])
     client.repo.git.add('*')
-    client.repo.index.commit('Tracked in lfs')
+    client.repo.index.commit('tracked file')
 
     result = runner.invoke(
         cli, ['storage', 'clean', 'tracked'], catch_exceptions=False

--- a/tests/core/commands/test_storage.py
+++ b/tests/core/commands/test_storage.py
@@ -17,8 +17,6 @@
 # limitations under the License.
 """Storage command tests."""
 
-from __future__ import absolute_import, print_function
-
 import os
 import subprocess
 from pathlib import Path
@@ -36,8 +34,8 @@ def test_lfs_storage_clean(runner, project, client):
     result = runner.invoke(
         cli, ['storage', 'clean', 'tracked'], catch_exceptions=False
     )
-    assert 2 == result.exit_code
-    assert 'These paths are not in git lfs' in result.output
+    assert 0 == result.exit_code
+    assert 'These paths were ignored as they are not tracked' in result.output
 
     subprocess.call(['git', 'lfs', 'track', 'tracked'])
     client.repo.git.add('*')
@@ -59,8 +57,9 @@ def test_lfs_storage_clean(runner, project, client):
     )
     assert 0 == result.exit_code
 
-    with (client.path / 'tracked').open('r') as fp:
-        assert 'version https://git-lfs.github.com/spec/v1' in fp.read()
+    assert 'version https://git-lfs.github.com/spec/v1' in (
+        client.path / 'tracked'
+    ).read_text()
 
     lfs_objects = []
     for _, _, files in os.walk(str(client.path / '.git' / 'lfs' / 'objects')):

--- a/tests/core/commands/test_storage.py
+++ b/tests/core/commands/test_storage.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2020 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Storage command tests."""
+
+from __future__ import absolute_import, print_function
+
+import os
+import subprocess
+from pathlib import Path
+
+from renku.cli import cli
+
+
+def test_lfs_storage_clean(runner, project, client):
+    """Test ``renku storage clean`` command."""
+    with (client.path / 'tracked').open('w') as fp:
+        fp.write('tracked file')
+    client.repo.git.add('*')
+    client.repo.index.commit('tracked file')
+
+    result = runner.invoke(
+        cli, ['storage', 'clean', 'tracked'], catch_exceptions=False
+    )
+    assert 2 == result.exit_code
+    assert 'These paths are not in git lfs' in result.output
+
+    subprocess.call(['git', 'lfs', 'track', 'tracked'])
+    client.repo.git.add('*')
+    client.repo.index.commit('Tracked in lfs')
+
+    with (client.path / 'tracked').open('r') as fp:
+        assert 'tracked file' in fp.read()
+
+    assert 'tracked' in Path('.gitattributes').read_text()
+
+    lfs_objects = []
+    for _, _, files in os.walk(str(client.path / '.git' / 'lfs' / 'objects')):
+        lfs_objects.extend(files)
+
+    assert 1 == len(lfs_objects)
+
+    result = runner.invoke(
+        cli, ['storage', 'clean', 'tracked'], catch_exceptions=False
+    )
+    assert 0 == result.exit_code
+
+    with (client.path / 'tracked').open('r') as fp:
+        assert 'version https://git-lfs.github.com/spec/v1' in fp.read()
+
+    lfs_objects = []
+    for _, _, files in os.walk(str(client.path / '.git' / 'lfs' / 'objects')):
+        lfs_objects.extend(files)
+
+    assert 0 == len(lfs_objects)
+
+    # already clean file should be ignored on clean
+    result = runner.invoke(
+        cli, ['storage', 'clean', 'tracked'], catch_exceptions=False
+    )
+    assert 0 == result.exit_code


### PR DESCRIPTION
Adds a new `renku storage clean <files>` command that removes locally cached LFS content (replaces it with pointer file content).

Closes #1147 