### PR TITLE
docs: update readme instructions for installing in editable mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,13 +173,20 @@ Developing Renku
 ================
 
 For development it's convenient to install ``renku`` in editable mode. This is
-still possible with ``pipx``. First clone the repository and then do:
+still possible with ``pipx``. First clone the repository and run the setup:
+
+::
+
+    $ python setup.py bdist_wheel
+
+Then install with ``pipx`` in editable mode:
 
 ::
 
     $ pipx install \
         --editable \
-        <path-to-renku-python>[all] \
+        --force \
+        --spec <path-to-renku-python> \
         renku
 
 This will install all the extras for testing and debugging.


### PR DESCRIPTION
# Description

Update the instructions included in the `README` file for installing `renku` locally in editable mode with `pipx`.

Not sure if `python setup.py bdist_wheel` is mandatory but I couldn't install without manually building first.

