### PR TITLE
feat(dataset): move/rename files between datasets

### DIFF
--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -34,6 +34,7 @@ from renku.core.compat import contextlib
 from renku.core.errors import DatasetNotFound, InvalidAccessToken, \
     OperationError, ParameterError, UsageError
 from renku.core.management.datasets import DATASET_METADATA_PATHS
+from renku.core.management.repository import WORKFLOW_METADATA_PATHS
 from renku.core.models.datasets import Url, generate_default_short_name
 from renku.core.models.provenance.agents import Person
 from renku.core.models.refs import LinkReference
@@ -404,7 +405,7 @@ def file_unlink(
 @pass_local_client(
     commit=True,
     commit_empty=False,
-    commit_only=DATASET_METADATA_PATHS,
+    commit_only=DATASET_METADATA_PATHS + WORKFLOW_METADATA_PATHS,
     raise_if_empty=True
 )
 def move_files(
@@ -437,12 +438,12 @@ def move_files(
     if source.short_name == target.short_name:
         target = source
 
-    # Make sure that target's datadir exists
-    (client.path / target.datadir).mkdir(parents=True, exist_ok=True)
+    # Make sure that target's data_dir exists
+    (client.path / target.data_dir).mkdir(parents=True, exist_ok=True)
 
     destination = destination or '.'
     dst_root = Path(
-        os.path.abspath(client.path / target.datadir / destination)
+        os.path.abspath(client.path / target.data_dir / destination)
     )
 
     move_single_file = len(files) == 1

--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -216,6 +216,14 @@ class DatasetFileExists(RenkuException):
         ).__init__('File already exists in dataset. Use --force to add.')
 
 
+class DatasetFileNotFound(RenkuException):
+    """Raise when a file is not in dataset."""
+
+    def __init__(self):
+        """Build a custom message."""
+        super().__init__('File is not in the dataset.')
+
+
 class CommitMessageEmpty(RenkuException):
     """Raise invalid commit message."""
 

--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -212,9 +212,16 @@ class StorageApiMixin(RepositoryApiMixin):
     @check_external_storage_wrapper
     def untrack_paths_from_storage(self, *paths):
         """Untrack paths from the external storage."""
+        relative_paths = []
+        for path in paths:
+            path = Path(path)
+            if path.is_absolute():
+                path = path.relative_to(self.path)
+            relative_paths.append(str(path))
+
         try:
             call(
-                self._CMD_STORAGE_UNTRACK + list(paths),
+                self._CMD_STORAGE_UNTRACK + relative_paths,
                 stdout=PIPE,
                 stderr=STDOUT,
                 cwd=self.path,

--- a/renku/core/models/entities.py
+++ b/renku/core/models/entities.py
@@ -104,6 +104,13 @@ class CommitMixin:
             return '{path}@{hexsha}'.format(hexsha=hexsha, path=path)
         return '{hexsha}'.format(hexsha=hexsha, self=self)
 
+    def replace_path(self, path, commit=None):
+        """Replace path and commit (if provided) and update _id and _label."""
+        self.path = path
+        self.commit = commit or self.commit
+        self._id = self.default_id()
+        self._label = self.default_label()
+
     def __attrs_post_init__(self):
         """Post-init hook."""
         if self.path and self.client:

--- a/renku/core/models/jsonld.py
+++ b/renku/core/models/jsonld.py
@@ -641,10 +641,11 @@ class JSONLDMixin(ReferenceMixin):
         source.update(asjsonld(self))
         return source
 
-    def to_yaml(self):
+    def to_yaml(self, path=None):
         """Store an instance to the referenced YAML file."""
         jsonld_ = self.asjsonld()
-        write_yaml(path=self.__reference__, data=jsonld_)
+        path = path or self.__reference__
+        write_yaml(path=path, data=jsonld_)
 
 
 def read_yaml(path):

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -2162,14 +2162,14 @@ def test_dataset_move_and_workflows(runner, client, directory_tree, run):
     base_src_path = os.path.join('data', 'src', directory_tree.basename)
     file1 = os.path.join(base_src_path, 'file')
     file2 = os.path.join(base_src_path, 'dir2', 'file2')
-    file3 = os.path.join('data', 'src', 'output.txt')
+    output = os.path.join('data', 'src', 'output.txt')
 
-    assert 0 == run(args=['run', 'cat', file1, file2], stdout=file3)
-    assert 0 == runner.invoke(cli, ['dataset', 'add', 'src', file3]).exit_code
+    assert 0 == run(args=['run', 'cat', file1, file2], stdout=output)
+    assert 0 == runner.invoke(cli, ['dataset', 'add', 'src', output]).exit_code
     assert 0 == runner.invoke(cli, ['dataset', 'mv', 'src', 'dst']).exit_code
 
     file1 = os.path.join('data', 'dst', 'file')
-    file3 = os.path.join('data', 'dst', 'output.txt')
+    new_output = os.path.join('data', 'dst', 'output.txt')
 
     # Update inputs and check workflow can be updated
     Path(file1).write_text('Some new changes')
@@ -2178,4 +2178,8 @@ def test_dataset_move_and_workflows(runner, client, directory_tree, run):
 
     assert 0 == run(args=['update'])
 
-    assert 'Some new changes' in Path(file3).read_text()
+    assert 'Some new changes' in Path(new_output).read_text()
+
+    # Check activity cache is updated
+    assert output not in client.activity_index_path.read_text()
+    assert new_output in client.activity_index_path.read_text()

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -2150,3 +2150,32 @@ def test_dataset_move_shared_files(
     attributes = (client.path / '.gitattributes').read_text()
     assert src_path in attributes
     assert dst_path in attributes
+
+
+def test_dataset_move_and_workflows(runner, client, directory_tree, run):
+    """Check moving files will update workflows."""
+    assert 0 == runner.invoke(
+        cli, ['dataset', 'add', '-c', 'src', directory_tree.strpath]
+    ).exit_code
+    assert 0 == runner.invoke(cli, ['dataset', 'create', 'dst']).exit_code
+
+    base_src_path = os.path.join('data', 'src', directory_tree.basename)
+    file1 = os.path.join(base_src_path, 'file')
+    file2 = os.path.join(base_src_path, 'dir2', 'file2')
+    file3 = os.path.join('data', 'src', 'output.txt')
+
+    assert 0 == run(args=['run', 'cat', file1, file2], stdout=file3)
+    assert 0 == runner.invoke(cli, ['dataset', 'add', 'src', file3]).exit_code
+    assert 0 == runner.invoke(cli, ['dataset', 'mv', 'src', 'dst']).exit_code
+
+    file1 = os.path.join('data', 'dst', 'file')
+    file3 = os.path.join('data', 'dst', 'output.txt')
+
+    # Update inputs and check workflow can be updated
+    Path(file1).write_text('Some new changes')
+    client.repo.git.add('*')
+    client.repo.index.commit('some changes')
+
+    assert 0 == run(args=['update'])
+
+    assert 'Some new changes' in Path(file3).read_text()


### PR DESCRIPTION
# Description

`renku dataset mv` command to move files between datasets or rename a single file. To choose which files to move we can use `-I` or `-X` to define a pattern similar to what other `renku dataset` commands accept.

Fixes https://github.com/SwissDataScienceCenter/renku-python/issues/1159