### PR TITLE
build(deps): Fix failing CI due to new flake8 version 3.8

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -39,10 +39,10 @@
         },
         "appdirs": {
             "hashes": [
-                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
-                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
             ],
-            "version": "==1.4.3"
+            "version": "==1.4.4"
         },
         "attrs": {
             "hashes": [
@@ -698,10 +698,10 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+                "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3",
+                "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"
             ],
-            "version": "==5.4.1"
+            "version": "==5.4.2"
         },
         "pytest-cache": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ tests_require = [
     'check-manifest>=0.37',
     'coverage>=4.5.3',
     'fakeredis==1.4.1',
-    'flake8>=3.5',
+    'flake8>=3.5,<3.8',
     'flaky==3.6.1',
     'freezegun>=0.3.12',
     'isort==4.3.21',


### PR DESCRIPTION
Pins flake8 to <3.8