### PR TITLE
chore: ignore eggs in shellcheck

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,7 +40,7 @@ check_styles(){
     isort -rc -c -df
     unify -c -r renku tests conftest.py docs
     check-manifest --ignore ".travis-*,renku/version.py,renku/templates,renku/templates/**"
-    find . -iname \*.sh -print0 | xargs -0 shellcheck
+    find . -path ./.eggs -prune -o -iname \*.sh -print0 | xargs -0 shellcheck
 }
 
 build_docs(){


### PR DESCRIPTION
Ignores eggs in shellcheck - we don't write those scripts so we shouldn't be checking them. 

This should allow #1251 to pass. 