### PR TITLE
fix(cli): Remove --datadir and --renku-home

### DIFF
--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -37,8 +37,6 @@ execute ``renku help``:
       --install-completion            Install completion for the current shell.
       --path <path>                   Location of a Renku repository.
                                       [default: (dynamic)]
-      --renku-home <path>             Location of the Renku directory.
-                                      [default: .renku]
       --external-storage / -S, --no-external-storage
                                       Use an external file storage service.
       -h, --help                      Show this message and exit.
@@ -167,14 +165,6 @@ def is_allowed_command(ctx):
     default=default_path,
     help='Location of a Renku repository.'
 )
-@click.option(
-    '--renku-home',
-    envvar='RENKU_HOME',
-    show_default=True,
-    metavar='<path>',
-    default=RENKU_HOME,
-    help='Location of the Renku directory.'
-)
 @option_external_storage_requested
 @click.option(
     '--disable-version-check',
@@ -186,9 +176,9 @@ def is_allowed_command(ctx):
     help='Do not periodically check PyPI for a new version of renku.',
 )
 @click.pass_context
-def cli(ctx, path, renku_home, external_storage_requested):
+def cli(ctx, path, external_storage_requested):
     """Check common Renku commands used in various situations."""
-    renku_path = Path(path) / renku_home
+    renku_path = Path(path) / RENKU_HOME
     if not renku_path.exists() and not is_allowed_command(ctx):
         raise UsageError((
             '`{0}` is not a renku repository.\n'
@@ -198,7 +188,6 @@ def cli(ctx, path, renku_home, external_storage_requested):
 
     ctx.obj = LocalClient(
         path=path,
-        renku_home=renku_home,
         external_storage_requested=external_storage_requested,
     )
 

--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -419,7 +419,6 @@ def prompt_tag_selection(tags):
 
 @click.group(invoke_without_command=True)
 @click.option('--revision', default=None)
-@click.option('--datadir', default='data', type=click.Path(dir_okay=True))
 @click.option(
     '--format',
     type=click.Choice(DATASETS_FORMATS),
@@ -438,20 +437,15 @@ def prompt_tag_selection(tags):
     show_default=True
 )
 @click.pass_context
-def dataset(ctx, revision, datadir, format, columns):
+def dataset(ctx, revision, format, columns):
     """Handle datasets."""
-    if isinstance(ctx, click.Context):
-        ctx.meta['renku.datasets.datadir'] = datadir
-
     check_for_migration()
 
     if ctx.invoked_subcommand is not None:
         return
 
     click.echo(
-        list_datasets(
-            revision=revision, datadir=datadir, format=format, columns=columns
-        )
+        list_datasets(revision=revision, format=format, columns=columns)
     )
 
 

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -47,17 +47,12 @@ from .format.datasets import DATASETS_FORMATS
 
 
 @pass_local_client(clean=False, commit=False)
-def list_datasets(
-    client, revision=None, datadir=None, format=None, columns=None
-):
+def list_datasets(client, revision=None, format=None, columns=None):
     """Handle datasets sub commands."""
     if revision is None:
         datasets = client.datasets.values()
     else:
         datasets = client.datasets_from_commit(client.repo.commit(revision))
-
-    if datadir:
-        client.datadir = datadir
 
     if format is None:
         return list(datasets)


### PR DESCRIPTION
Removes `--datadir` flag since it's not working/implemented, to be picked up again in #1284 
Removes `--renku-home` flag, we don't want it to be set to something other than `.renku`, there's really no reason to, and in most places in the code it's hardcoded anyways

Not removing `--path`, since that seems to work fine in my tests (But it has to be specified in the beginning, `renku --path . dataset`, not `renku dataset --path .`). Not sure how useful that is, but it works and there might be cases where it's useful.

Closes #1197 