### PR TITLE
chore: fix lfs doctor test

### DIFF
--- a/tests/core/commands/test_doctor.py
+++ b/tests/core/commands/test_doctor.py
@@ -67,7 +67,7 @@ def test_git_hooks_modified(runner, project):
 
 def test_lfs_broken_history(runner, client, tmp_path):
     """Test lfs migrate info check on a broken history."""
-    big_file = tmp_path / 'big-file.ipynb'
+    big_file = tmp_path / 'big-file.bin'
     with open(big_file, 'w') as file_:
         file_.seek(client.minimum_lfs_file_size)
         file_.write('some-data')
@@ -86,11 +86,11 @@ def test_lfs_broken_history(runner, client, tmp_path):
     result = runner.invoke(cli, ['doctor'])
     assert 1 == result.exit_code
     assert 'Git history contains large files' in result.output
-    assert '*.ipynb' in result.output
+    assert '*.bin' in result.output
 
     # Exclude *.ipynb files from LFS in .renkulfsignore
     (client.path / client.RENKU_LFS_IGNORE_PATH).write_text(
-        '\n'.join(['*swp', '*ipynb', '.DS_Store'])
+        '\n'.join(['*swp', '*.bin', '.DS_Store'])
     )
 
     result = runner.invoke(cli, ['doctor'])


### PR DESCRIPTION
Fixes a failing renku-doctor test by using non-conflicting extension for test file. 