### PR TITLE
fix(core): Only update project metadata if any migrations were executed

### DIFF
--- a/renku/core/management/migrate.py
+++ b/renku/core/management/migrate.py
@@ -69,14 +69,14 @@ def migrate(client, progress_callback=None):
                 progress_callback(f'Applying migration {module_name}...')
             module.migrate(client)
             n_migrations_executed += 1
+    if n_migrations_executed > 0:
+        client.project.version = str(version)
+        client.project.to_yaml()
 
-    client.project.version = str(version)
-    client.project.to_yaml()
-
-    if progress_callback and n_migrations_executed > 0:
-        progress_callback(
-            f'Successfully applied {n_migrations_executed} migrations.'
-        )
+        if progress_callback:
+            progress_callback(
+                f'Successfully applied {n_migrations_executed} migrations.'
+            )
 
     return n_migrations_executed != 0
 


### PR DESCRIPTION
Makes it so `.renku/metadata,yaml` is only committed/updated if there were migrations to execute.

Closes #1296

Followup issue: https://github.com/SwissDataScienceCenter/renku-python/issues/1307