### PR TITLE
fix(tests): integration tests

### DIFF
--- a/renku/service/config.py
+++ b/renku/service/config.py
@@ -44,7 +44,9 @@ TEMPLATE_CLONE_DEPTH_DEFAULT = int(
     os.getenv('TEMPLATE_CLONE_DEPTH_DEFAULT', 0)
 )
 
-CACHE_DIR = os.getenv('CACHE_DIR', tempfile.TemporaryDirectory().name)
+CACHE_DIR = os.getenv(
+    'CACHE_DIR', os.path.realpath(tempfile.TemporaryDirectory().name)
+)
 CACHE_UPLOADS_PATH = Path(CACHE_DIR) / Path('uploads')
 CACHE_UPLOADS_PATH.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
# Description

Fixes integration tests on macOS. On macOS `/var` is a symlink to `/private/var` which can cause issue if at some point we resolve a path.