### PR TITLE
test: core IT migrated & performance improvements

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -160,10 +160,10 @@ jobs:
   test-macos-integration:
     runs-on: macos-latest
     strategy:
-      max-parallel: 1
+      max-parallel: 3
       matrix:
         python-version: [3.6, 3.7, 3.8]
-    needs: [test-linux-integration]
+    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -372,7 +372,7 @@ jobs:
 
   push-image:
     runs-on: ubuntu-latest
-    needs: [docs-linux, test-linux, test-macos]
+    needs: [docs-linux, test-linux-cli, test-linux-core, test-linux-service, test-macos-cli, test-macos-core, test-macos-service]
     if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2
@@ -387,7 +387,7 @@ jobs:
 
   publish-chart:
     runs-on: ubuntu-latest
-    needs: [docs-linux, test-linux, test-macos, test-linux-integration, test-macos-integration]
+    needs: [docs-linux, test-linux-cli, test-linux-core, test-linux-service, test-macos-cli, test-macos-core, test-macos-service, test-linux-integration, test-macos-integration]
     if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -130,8 +130,6 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8]
-    needs: [test-linux]
-    #if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -165,8 +163,6 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8]
-    needs: [test-macos]
-    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -131,7 +131,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
     needs: [test-linux]
-    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
+    #if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -157,7 +157,7 @@ jobs:
         IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
         ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
         RENKU_REQUESTS_TIMEOUT_SECONDS: 120
-      run: pytest -m integration -v --timeout=600
+      run: pytest -m integration -v --timeout=600 -n auto
 
   test-macos-integration:
     runs-on: macos-latest

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -322,7 +322,7 @@ jobs:
 
   publish-pypi:
     runs-on: ubuntu-latest
-    needs: [docs-linux, test-linux, test-macos, test-linux-integration, test-macos-integration]
+    needs: [docs-linux, test-linux-cli, test-linux-core, test-linux-service, test-macos-cli, test-macos-core, test-macos-service, test-linux-integration, test-macos-integration]
     if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -19,7 +19,7 @@ jobs:
   docs-linux:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 3
       matrix:
         python-version: [3.6, 3.7, 3.8]
     steps:
@@ -62,7 +62,7 @@ jobs:
   test-linux:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 3
       matrix:
         python-version: [3.6, 3.7, 3.8]
     steps:
@@ -98,7 +98,7 @@ jobs:
   test-macos:
     runs-on: macos-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 3
       matrix:
         python-version: [3.6, 3.7, 3.8]
     steps:
@@ -127,7 +127,7 @@ jobs:
   test-linux-integration:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 3
       matrix:
         python-version: [3.6, 3.7, 3.8]
     steps:
@@ -160,9 +160,10 @@ jobs:
   test-macos-integration:
     runs-on: macos-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 1
       matrix:
         python-version: [3.6, 3.7, 3.8]
+    needs: [test-linux-integration]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -59,7 +59,7 @@ jobs:
     - name: test with twine
       run: twine check dist/*
 
-  test-linux:
+  test-linux-cli:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 3
@@ -87,7 +87,7 @@ jobs:
         git config --global --add user.name "Renku @ SDSC"
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
-      run: ./run-tests.sh -s -t
+      run: pytest -v -m "not integration and not publish" tests/cli
     - name: Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
@@ -95,7 +95,79 @@ jobs:
       run: coveralls
       continue-on-error: true
 
-  test-macos:
+  test-linux-core:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install system packages
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libyaml-0-2 libyaml-dev
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[nodocs]
+          python -m pip install coveralls
+          python setup.py --version
+          git config --global --add user.name "Renku @ SDSC"
+          git config --global --add user.email "renku@datascience.ch"
+      - name: Test with pytest
+        run: pytest -v -m "not integration and not publish" tests/core
+      - name: Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          RENKU_REQUESTS_TIMEOUT_SECONDS: 120
+        run: coveralls
+        continue-on-error: true
+
+  test-linux-service:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install system packages
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libyaml-0-2 libyaml-dev
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[nodocs]
+          python -m pip install coveralls
+          python setup.py --version
+          git config --global --add user.name "Renku @ SDSC"
+          git config --global --add user.email "renku@datascience.ch"
+      - name: Test with pytest
+        run: pytest -v -m "not integration and not publish" tests/service
+      - name: Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          RENKU_REQUESTS_TIMEOUT_SECONDS: 120
+        run: coveralls
+        continue-on-error: true
+
+  test-macos-cli:
     runs-on: macos-latest
     strategy:
       max-parallel: 3
@@ -122,7 +194,65 @@ jobs:
     - name: Test with pytest
       env:
         RENKU_REQUESTS_TIMEOUT_SECONDS: 120
-      run: ./run-tests.sh
+      run: pytest -v -m "not integration and not publish" tests/cli
+
+  test-macos-core:
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install git-lfs shellcheck node || brew link --overwrite node
+          python -m pip install --upgrade pip
+          python -m pip install setuptools wheel twine
+          python -m pip install -e .[all]
+          git config --global --add user.name "Renku @ SDSC"
+          git config --global --add user.email "renku@datascience.ch"
+      - name: Test with pytest
+        env:
+          RENKU_REQUESTS_TIMEOUT_SECONDS: 120
+        run: pytest -v -m "not integration and not publish" tests/core
+
+  test-macos-service:
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install git-lfs shellcheck node || brew link --overwrite node
+          python -m pip install --upgrade pip
+          python -m pip install setuptools wheel twine
+          python -m pip install -e .[all]
+          git config --global --add user.name "Renku @ SDSC"
+          git config --global --add user.email "renku@datascience.ch"
+      - name: Test with pytest
+        env:
+          RENKU_REQUESTS_TIMEOUT_SECONDS: 120
+        run: pytest -v -m "not integration and not publish" tests/service
 
   test-linux-integration:
     runs-on: ubuntu-latest

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -327,27 +327,31 @@
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:0aef3fa29f7d1194d6f8a99382b1b844e5a14d3bc1ef82c3b1c4fb7e7e2019bc",
-                "sha256:159ae2bbb4dc3ba506aeba868d14e56a754c0be402d1f0d7fdb264e0bdf2b095",
-                "sha256:161a68a427022bf13e249458be2cb8da56b055988c584d372a917c665825ae9a",
-                "sha256:2d58f0e6395bf41087a383a48b06b42165f3b699f1aa41ba201db84ab77be63d",
-                "sha256:311c9d1840042fc8e2dd80fc80272a7ea73e7646745556153c9cda85a4628b18",
-                "sha256:35c3ad7b7f7d5d4a54a80f0ff5a41ab186237d6486843f8dde00c42cfab33905",
-                "sha256:459ef557e669d0046fe2b92eb4822c097c00b5ef9d11df0f9bd7d4267acdfc52",
-                "sha256:4a50513b6be001b9b7be2c435478fe9669249c77c241813907a44cda1fcd03f4",
-                "sha256:51035b175740c44707694c521560b55b66da9d5a7c545cf22582bc02deb61664",
-                "sha256:96f2cdb35bdfda10e075f12892a42cff5179bbda698992b845f36c5e92755d33",
-                "sha256:a0aed261060cd0372abf08d16399b1224dbb5b400312e6b00f2b23eabe1d4e96",
-                "sha256:a6052c4c7d95de2345d9c58fc0fe34fff6c27a8ed8550dafeb18ada84406cc99",
-                "sha256:cbf1354292a4f7abb6a0188f74f5e902e4510ebad105be1dbc4809d1ed92f77e",
-                "sha256:da82b2372f5ded8806eaac95b19af89a7174efdb418d4e7beb0c6ab09cee7d95",
-                "sha256:dd89f466c930d7cfe84c94b5cbe862867c88b269f23e5aa61d40945e0d746f54",
-                "sha256:e3183fbeb452ec11670c2d9bfd08a57bc87e46856b24d1c335f995239bedd0e1",
-                "sha256:e9a571e7168076a0d5ecaabd91e9032e86d815cca3a4bf0dafead539ef071aa5",
-                "sha256:ec6aba217d0c4f71cbe48aea962a382dedcd111f47b55e8b58d4aaca519bd360"
+                "sha256:00b78a97a79d0dfefa584d44dd1aba9668d3de7ec82335ba0ff51d53ef107143",
+                "sha256:042b54fd71c2092e6d10e5e66fa60f65c5954f8145e809f5d9f394c9b13d32ee",
+                "sha256:11f87dc06eb5f376cc6d5f0c19a1b4dca202035622777c4ce8e5b72c87b035d6",
+                "sha256:19ae6f6511a02008ef3554e158c41bb2a8e5c8455935b98d6da076d9f152fd7c",
+                "sha256:22c1935c6f8e3d6ea2e169eb03928adbdb8a2251d2890f8689368d65e70aa176",
+                "sha256:30ef2068f4f94660144515380ef04b93d15add2214eab8be4cd46ebc900d681c",
+                "sha256:33da47ba3a581860ddd3d38c950a5fe950ca389f7123edd0d6ab0bc473499fe7",
+                "sha256:3e8698dc384857413580012f4ca322d89e63ef20fc3d4635a5b606d6d4b61f6a",
+                "sha256:4fdd7113fc5143c72dacf415079eec42fcbe69cc9d3d291b4ca742e3a9455807",
+                "sha256:63b6d9a5077d54db271fcc6772440f7380ec3fa559d0e2497dbfae2f47c2c814",
+                "sha256:8133b63b05f12751cddd8e3e7f02ba39dc7cfa7d2ba99d80d7436f0ba26d6b75",
+                "sha256:89b8e5780e49753e2b4cd5aab45d3df092ddcbba3de2c4d4492a029588fe1758",
+                "sha256:8d82e27cbbea6edb8821751806f39f5dcfd7b46a5e23d27b98d6d8c8ec751df8",
+                "sha256:92cedd6e26712505adb1c17fab64651a498cc0102a80ba562ff4a2451088f57a",
+                "sha256:9723364577b79ad9958a68851fe2acb94da6fd25170c595516a8289e6a129043",
+                "sha256:c484020ad26973a14a7cb1e1d2e0bfe97cf6803273ae9bd154e0213cc74bad49",
+                "sha256:c697bd1b333b3e6abdff04ef9f5fb4b1936633d9cc4e28d90606705c9083254c",
+                "sha256:d0f7e14ff3424639d33e6bc449e77e4b345e52c21bbd6f6004a1d219196e2664",
+                "sha256:db2df3eff7ed3e6813638686f1bb5934d1a0662d9d3b4196b5164a86be3a1e8f",
+                "sha256:edbcb4c5efabd93ede05b272296a5a78a67e9b6e82ba7f51a07b8103db06ce01",
+                "sha256:ef355fb3802e0fc5a71dadb65a3c317bfc9bdf567d357f8e0b1900b432ffe486",
+                "sha256:fe2f61fed5817bf8db01d9a72309ed5990c478a077e9585b58740c26774bce39"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.5.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.5.1"
         },
         "lockfile": {
             "hashes": [
@@ -787,11 +791,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
-                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
+                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.25.9"
+            "version": "==1.25.10"
         },
         "walrus": {
             "hashes": [

--- a/conftest.py
+++ b/conftest.py
@@ -56,7 +56,7 @@ IT_REMOTE_REPO_URL = os.getenv(
 IT_GIT_ACCESS_TOKEN = os.getenv('IT_OAUTH_GIT_TOKEN')
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def renku_path(tmpdir_factory):
     """Temporary instance path."""
     path = str(tmpdir_factory.mktemp('renku'))
@@ -64,7 +64,7 @@ def renku_path(tmpdir_factory):
     shutil.rmtree(path)
 
 
-@pytest.fixture()
+@pytest.fixture
 def instance_path(renku_path, monkeypatch):
     """Temporary instance path."""
     with monkeypatch.context() as m:
@@ -72,7 +72,7 @@ def instance_path(renku_path, monkeypatch):
         yield renku_path
 
 
-@pytest.fixture()
+@pytest.fixture
 def runner():
     """Create a runner on isolated filesystem."""
     return CliRunner()
@@ -90,7 +90,7 @@ def global_config_dir(monkeypatch, tmpdir_factory):
         yield m
 
 
-@pytest.fixture()
+@pytest.fixture
 def run_shell():
     """Create a shell cmd runner."""
     import subprocess
@@ -123,7 +123,7 @@ def run_shell():
     return run_
 
 
-@pytest.fixture()
+@pytest.fixture
 def run(runner, capsys):
     """Return a callable runner."""
     from renku.cli import cli
@@ -145,7 +145,7 @@ def run(runner, capsys):
     return generate
 
 
-@pytest.fixture()
+@pytest.fixture
 def isolated_runner():
     """Create a runner on isolated filesystem."""
     runner_ = CliRunner()
@@ -153,7 +153,7 @@ def isolated_runner():
         yield runner_
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_file(tmpdir):
     """Create a sample data file."""
     p = tmpdir.mkdir('data').join('file')
@@ -161,7 +161,7 @@ def data_file(tmpdir):
     return p
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def repository():
     """Yield a Renku repository."""
     from renku.cli import cli
@@ -240,7 +240,7 @@ def client(project):
     LocalClient.get_value = original_get_value
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def client_with_remote(client, tmpdir_factory):
     """Return a client with a (local) remote set."""
     # create remote
@@ -267,7 +267,7 @@ def no_lfs_warning(client):
     yield client
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def client_with_lfs_warning(project):
     """Return a Renku repository with lfs warnings active."""
     from renku.core.management import LocalClient
@@ -298,7 +298,7 @@ def dataset(client):
     return dataset
 
 
-@pytest.fixture(scope='function', params=['.', 'some/sub/directory'])
+@pytest.fixture(params=['.', 'some/sub/directory'])
 def subdirectory(request):
     """Runs tests in root directory and a subdirectory."""
     from renku.core.utils.contexts import chdir
@@ -340,7 +340,7 @@ def dataset_responses():
         yield rsps
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def directory_tree(tmpdir_factory):
     """Create a test directory tree."""
     # initialize
@@ -351,7 +351,7 @@ def directory_tree(tmpdir_factory):
     return p
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def data_repository(directory_tree):
     """Create a test repo."""
     from git import Actor, Repo
@@ -534,7 +534,7 @@ def old_repository_with_submodules(request, tmpdir_factory):
     shutil.rmtree(repo_path.strpath)
 
 
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture(autouse=True)
 def add_client(doctest_namespace):
     """Add Renku client to doctest namespace."""
     from renku.core.management import LocalClient
@@ -748,7 +748,7 @@ def dataset_metadata_before_calamus():
     yield yaml.load(path.read_text(), Loader=NoDatesSafeLoader)
 
 
-@pytest.fixture()
+@pytest.fixture
 def sleep_after():
     """Fixture that causes a delay after executing a test.
 
@@ -788,7 +788,7 @@ def remote_project(data_repository, directory_tree):
         yield runner, project_path
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def datapack_zip(directory_tree):
     """Returns dummy data folder as a zip archive."""
     from renku.core.utils.contexts import chdir
@@ -799,7 +799,7 @@ def datapack_zip(directory_tree):
     yield Path(workspace_dir.name) / 'datapack.zip'
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def datapack_tar(directory_tree):
     """Returns dummy data folder as a tar archive."""
     from renku.core.utils.contexts import chdir
@@ -857,7 +857,7 @@ def svc_client(mock_redis):
     ctx.pop()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def svc_client_cache(mock_redis):
     """Service jobs fixture."""
     from renku.service.entrypoint import create_app

--- a/conftest.py
+++ b/conftest.py
@@ -39,7 +39,6 @@ import responses
 import yaml
 from _pytest.monkeypatch import MonkeyPatch
 from click.testing import CliRunner
-from flaky import flaky
 from git import Repo
 from walrus import Database
 
@@ -163,7 +162,6 @@ def data_file(tmpdir):
 
 
 @pytest.fixture(scope='module')
-@flaky(max_runs=5)
 def repository():
     """Yield a Renku repository."""
     from renku.cli import cli

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -45,11 +45,11 @@ check_styles(){
 
 build_docs(){
     sphinx-build -qnNW docs docs/_build/html
-    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py"
+    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py" -n auto
 }
 
 run_tests(){
-    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py"
+    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n auto
 }
 
 usage(){

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -45,11 +45,11 @@ check_styles(){
 
 build_docs(){
     sphinx-build -qnNW docs docs/_build/html
-    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py" -n 4
+    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py" -n 4 --reruns 5 --reruns-delay 1
 }
 
 run_tests(){
-    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n 4
+    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n 4 --reruns 5 --reruns-delay 1
 }
 
 usage(){

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -49,7 +49,7 @@ build_docs(){
 }
 
 run_tests(){
-    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" --dist=each --tx 4*popen//python=python --boxed
+    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" --dist=each -n 4 --boxed
 }
 
 usage(){

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -49,7 +49,7 @@ build_docs(){
 }
 
 run_tests(){
-    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" --dist=each -n 4 --boxed
+    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n 4 --boxed
 }
 
 usage(){

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -45,11 +45,11 @@ check_styles(){
 
 build_docs(){
     sphinx-build -qnNW docs docs/_build/html
-    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py" -n auto
+    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py" -n 4
 }
 
 run_tests(){
-    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n auto
+    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n 4
 }
 
 usage(){

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -45,11 +45,11 @@ check_styles(){
 
 build_docs(){
     sphinx-build -qnNW docs docs/_build/html
-    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py" -n 4 --reruns 30 --reruns-delay 3
+    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py"
 }
 
 run_tests(){
-    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n 4 --reruns 30 --reruns-delay 3
+    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" --dist=each --tx 4*popen//python=python --boxed
 }
 
 usage(){

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -45,11 +45,11 @@ check_styles(){
 
 build_docs(){
     sphinx-build -qnNW docs docs/_build/html
-    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py" -n 4 --reruns 30 --reruns-delay 1
+    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py" -n 4 --reruns 30 --reruns-delay 3
 }
 
 run_tests(){
-    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n 4 --reruns 30 --reruns-delay 1
+    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n 4 --reruns 30 --reruns-delay 3
 }
 
 usage(){

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -45,11 +45,11 @@ check_styles(){
 
 build_docs(){
     sphinx-build -qnNW docs docs/_build/html
-    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py" -n 4 --reruns 5 --reruns-delay 1
+    pytest -v -m "not integration and not publish" -o testpaths="docs conftest.py" -n 4 --reruns 30 --reruns-delay 1
 }
 
 run_tests(){
-    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n 4 --reruns 5 --reruns-delay 1
+    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n 4 --reruns 30 --reruns-delay 1
 }
 
 usage(){

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -49,7 +49,7 @@ build_docs(){
 }
 
 run_tests(){
-    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py" -n 4 --boxed
+    pytest -v -m "not integration and not publish" -o testpaths="tests renku conftest.py"
 }
 
 usage(){

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ tests_require = [
     'pytest-timeout>=1.3.4',
     'pytest-pep8>=1.0.6',
     'pytest-yapf>=0.1.1',
+    'pytest-rerunfailures>=9.0',
     'pytest>=4.0.0',
     'responses>=0.7.0',
     'unify>=0.4',

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ tests_require = [
     'pytest-timeout>=1.3.4',
     'pytest-pep8>=1.0.6',
     'pytest-yapf>=0.1.1',
-    'pytest-rerunfailures>=9.0',
     'pytest>=4.0.0',
     'responses>=0.7.0',
     'unify>=0.4',

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ tests_require = [
     'isort==5.1.4',
     'six>=1.13.0',
     'pydocstyle>=3.0.0',
+    'pytest-xdist>=1.33.0',
     'pytest-cache>=1.0',
     'pytest-cov>=2.5.1',
     'pytest-flake8>=1.0.4',

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ tests_require = [
     'isort==5.1.4',
     'six>=1.13.0',
     'pydocstyle>=3.0.0',
-    'pytest-xdist>=1.33.0',
+    'pytest-xdist==1.33.0',
     'pytest-cache>=1.0',
     'pytest-cov>=2.5.1',
     'pytest-flake8>=1.0.4',

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -27,7 +27,6 @@ from pathlib import Path
 import pytest
 import requests
 import yaml
-from flaky import flaky
 
 from renku.cli import cli
 from renku.core.commands.format.dataset_files import DATASET_FILES_COLUMNS, \
@@ -544,7 +543,6 @@ def test_usage_error_in_add_from_url(runner, client, params, message):
     assert message in result.output
 
 
-@flaky(max_runs=5, min_passes=1)
 def test_add_from_local_repo_warning(
     runner, client, data_repository, directory_tree
 ):
@@ -611,7 +609,6 @@ def test_dataset_add_with_copy(tmpdir, runner, project, client):
         assert inode not in original_inodes
 
 
-@flaky(max_runs=5, min_passes=1)
 def test_dataset_file_path_from_subdirectory(runner, client, subdirectory):
     """Test adding a file into a dataset and check path independent
     of the CWD """

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1503,7 +1503,6 @@ def test_add_protected_file(runner, client, filename, subdirectory):
 )
 def test_add_nonprotected_file(runner, client, tmpdir, filename, subdirectory):
     """Check adding an 'almost' protected file."""
-
     new_file = tmpdir.join(filename)
     new_file.write(str('test'))
 

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pytest
 import requests
 import yaml
+from flaky import flaky
 
 from renku.cli import cli
 from renku.core.commands.format.dataset_files import DATASET_FILES_COLUMNS, \
@@ -543,6 +544,7 @@ def test_usage_error_in_add_from_url(runner, client, params, message):
     assert message in result.output
 
 
+@flaky(max_runs=5, min_passes=1)
 def test_add_from_local_repo_warning(
     runner, client, data_repository, directory_tree
 ):
@@ -609,6 +611,7 @@ def test_dataset_add_with_copy(tmpdir, runner, project, client):
         assert inode not in original_inodes
 
 
+@flaky(max_runs=5, min_passes=1)
 def test_dataset_file_path_from_subdirectory(runner, client, subdirectory):
     """Test adding a file into a dataset and check path independent
     of the CWD """
@@ -804,7 +807,6 @@ def test_datasets_ls_files_tabular_creators(tmpdir, runner, project, client):
     )
     assert 0 == result.exit_code
 
-    creator = None
     with client.with_dataset('my-dataset') as dataset:
         creator = dataset.creators[0].name
 

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -289,7 +289,7 @@ def test_dataset_reimport_removed_dataset(runner, project, sleep_after):
 
 
 @pytest.mark.integration
-@flaky(max_runs=10, min_passes=1)
+@flaky(max_runs=30, min_passes=1)
 def test_dataset_import_preserve_names(runner, project, sleep_after):
     """Test import keeps original file names."""
     doi = '10.7910/DVN/F4NUMR'

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -34,6 +34,8 @@ from renku.core.management.repository import DEFAULT_DATA_DIR as DATA_DIR
 from renku.core.utils.contexts import chdir
 
 
+@pytest.mark.integration
+@flaky(max_runs=10, min_passes=1)
 @pytest.mark.parametrize(
     'doi', [{
         'doi': '10.5281/zenodo.2658634',
@@ -55,8 +57,6 @@ from renku.core.utils.contexts import chdir
         'http://www.doi.org/', 'https://dx.doi.org/', 'https://doi.org/'
     ]
 )
-@pytest.mark.integration
-@flaky(max_runs=10, min_passes=1)
 def test_dataset_import_real_doi(runner, client, doi, prefix, sleep_after):
     """Test dataset import for existing DOI."""
     uri = prefix + doi['doi']
@@ -289,7 +289,7 @@ def test_dataset_reimport_removed_dataset(runner, project, sleep_after):
 
 
 @pytest.mark.integration
-@flaky(max_runs=30, min_passes=1)
+@flaky(max_runs=10, min_passes=1)
 def test_dataset_import_preserve_names(runner, project, sleep_after):
     """Test import keeps original file names."""
     doi = '10.7910/DVN/F4NUMR'
@@ -305,25 +305,26 @@ def test_dataset_import_preserve_names(runner, project, sleep_after):
 @flaky(max_runs=10, min_passes=1)
 @pytest.mark.parametrize(
     'url', [
-        'https://dev.renku.ch/datasets/48299db3-8870-4cbe-a480-f75985c42a62/',
-        'https://dev.renku.ch/projects/virginiafriedrich/datasets-test/'
-        'datasets/48299db3-8870-4cbe-a480-f75985c42a62'
+        'https://dev.renku.ch/datasets/e3e1beba-0559-4fdd-8e46-82963cec9fe2',
+        (
+            'https://dev.renku.ch/projects/'
+            'renku-testing/project-9/'
+            'datasets/e3e1beba-0559-4fdd-8e46-82963cec9fe2/'
+        ),
     ]
 )
-def test_dataset_import_renku(runner, project, client, url):
-    """Test dataset import from Renku projects."""
+def test_dataset_import_renkulab_dataset(runner, project, client, url):
+    """Test dataset import from Renkulab projects."""
     result = runner.invoke(cli, ['dataset', 'import', url], input='y')
     assert 0 == result.exit_code
-    checksum = '54751585bb81a0bff32727e46e2aabaa0c8d19f8'
-    assert checksum in result.output
-    size = '66.00'
-    assert size in result.output
+    assert '47316f93d5381e69c0b2ee0e28576e0b38a1f218' in result.output
+
+    assert '1.10' in result.output
     assert 'OK' in result.output
 
     result = runner.invoke(cli, ['dataset', 'ls-files'])
     assert 0 == result.exit_code
-    path = 'zhbikes/2019_verkehrszaehlungen_werte_fussgaenger_velo.csv'
-    assert path in result.output
+    assert 'ie_data_with_TRCAPE.xls' in result.output
 
     dataset = [d for d in client.datasets.values()][0]
     assert dataset.same_as.url['@id'] == url
@@ -331,10 +332,14 @@ def test_dataset_import_renku(runner, project, client, url):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_dataset_import_renku_fail(runner, client, monkeypatch):
+@pytest.mark.parametrize(
+    'url', [
+        'https://dev.renku.ch/datasets/e3e1beba-0559-4fdd-8e46-82963cec9fe2',
+    ]
+)
+def test_dataset_import_renku_fail(runner, client, monkeypatch, url):
     """Test dataset import fails if cannot clone repo."""
     from renku.core.management import LocalClient
-    url = 'https://dev.renku.ch/datasets/48299db3-8870-4cbe-a480-f75985c42a62'
 
     def prepare_git_repo(*_):
         raise errors.GitError
@@ -352,13 +357,13 @@ def test_dataset_import_renku_fail(runner, client, monkeypatch):
 @flaky(max_runs=10, min_passes=1)
 @pytest.mark.parametrize(
     'url,exit_code',
-    [('https://dev.renku.ch/projects/virginiafriedrich/datasets-test/', 2),
+    [('https://dev.renku.ch/projects/renku-testing/project-9/', 2),
      (
-         'https://dev.renku.ch/projects/virginiafriedrich/datasets-test/'
+         'https://dev.renku.ch/projects/renku-testing/project-9/'
          'datasets/b9f7b21b-8b00-42a2-976a-invalid', 2
      ), ('https://dev.renku.ch/datasets/10.5281%2Fzenodo.666', 1)]
 )
-def test_dataset_import_renku_errors(runner, project, url, exit_code):
+def test_dataset_import_renkulab_errors(runner, project, url, exit_code):
     """Test usage errors in Renku dataset import."""
     result = runner.invoke(cli, ['dataset', 'import', url], input='y')
     assert exit_code == result.exit_code
@@ -369,18 +374,19 @@ def test_dataset_import_renku_errors(runner, project, url, exit_code):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_dataset_reimport_renku_dataset(runner, project):
+@pytest.mark.parametrize(
+    'url',
+    ['https://dev.renku.ch/datasets/e3e1beba-0559-4fdd-8e46-82963cec9fe2']
+)
+def test_dataset_reimport_renkulab_dataset(runner, project, url):
     """Test dataset import for existing dataset"""
-    URL = 'https://dev.renku.ch/projects/virginiafriedrich/datasets-test/' \
-        'datasets/48299db3-8870-4cbe-a480-f75985c42a62'
-
-    result = runner.invoke(cli, ['dataset', 'import', URL], input='y')
+    result = runner.invoke(cli, ['dataset', 'import', url], input='y')
     assert 'OK' in result.output
     assert 0 == result.exit_code
 
-    result = runner.invoke(cli, ['dataset', 'import', URL], input='y')
+    result = runner.invoke(cli, ['dataset', 'import', url], input='y')
     assert 1 == result.exit_code
-    assert 'Dataset exists: "zhbikes"' in result.output
+    assert 'Dataset exists' in result.output
 
 
 @pytest.mark.integration
@@ -560,7 +566,7 @@ def test_dataset_export_upload_multiple(
 
 
 @pytest.mark.integration
-@flaky(max_runs=10, min_passes=1)
+@flaky(max_runs=30, min_passes=1)
 def test_dataset_export_upload_failure(runner, tmpdir, client, zenodo_sandbox):
     """Test failed uploading of a file to Zenodo deposit."""
     result = runner.invoke(cli, ['dataset', 'create', 'my-dataset'])
@@ -758,7 +764,7 @@ def test_export_dataverse_no_dataverse_url(
 
 
 @pytest.mark.integration
-@flaky(max_runs=10, min_passes=1)
+@flaky(max_runs=30, min_passes=1)
 def test_export_imported_dataset_to_dataverse(
     runner, client, dataverse_demo, zenodo_sandbox
 ):
@@ -1105,42 +1111,43 @@ def test_empty_update(client, runner, data_repository, directory_tree):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_import_from_renku_project(tmpdir, client, runner):
-    """Test an imported dataset from other renku repos will have metadata."""
+@pytest.mark.parametrize(
+    'url', ['https://dev.renku.ch/gitlab/renku-testing/project-9.git']
+)
+def test_import_from_renku_project(tmpdir, client, runner, url):
+    """Check metadata for an imported dataset from other renkulab repo."""
     from renku.core.management import LocalClient
-
-    remote = 'https://dev.renku.ch/gitlab/virginiafriedrich/datasets-test.git'
 
     path = tmpdir.strpath
     os.environ['GIT_LFS_SKIP_SMUDGE'] = '1'
-    git.Repo.clone_from(remote, path, recursive=True)
+    git.Repo.clone_from(url, path, recursive=True)
 
     remote_client = LocalClient(path)
     with chdir(remote_client.path):
         runner.invoke(cli, ['migrate'])
+
     file_ = read_dataset_file_metadata(
-        remote_client, 'zhbikes',
-        '2019_verkehrszaehlungen_werte_fussgaenger_velo.csv'
+        remote_client, 'testing-create-04', 'ie_data_with_TRCAPE.xls'
     )
 
     result = runner.invoke(
         cli,
         [
             'dataset', 'add', '--create', 'remote-dataset', '-s',
-            'data/zhbikes/2019_verkehrszaehlungen_werte_fussgaenger_velo.csv',
-            '-d', 'new-directory', '--ref', 'b973db5', remote
+            'data/testing-create-04/ie_data_with_TRCAPE.xls', '-d',
+            'new-directory', '--ref', '97f907e', url
         ],
         catch_exceptions=False,
     )
     assert 0 == result.exit_code, result.output + str(result.stderr_bytes)
 
-    path = 'new-directory/2019_verkehrszaehlungen_werte_fussgaenger_velo.csv'
+    path = 'new-directory/ie_data_with_TRCAPE.xls'
     metadata = read_dataset_file_metadata(client, 'remote-dataset', path)
     assert metadata.based_on._id == file_._id
     assert metadata.based_on._label == file_._label
     assert metadata.based_on.path == file_.path
     assert metadata.based_on.based_on is None
-    assert metadata.based_on.url == remote
+    assert metadata.based_on.url == url
 
 
 @pytest.mark.integration
@@ -1150,7 +1157,8 @@ def test_import_from_renku_project(tmpdir, client, runner):
 @flaky(max_runs=10, min_passes=1)
 def test_add_specific_refs(ref, runner, client):
     """Test adding a specific version of files."""
-    FILENAME = 'CHANGES.rst'
+    filename = 'CHANGES.rst'
+
     # create a dataset
     result = runner.invoke(cli, ['dataset', 'create', 'dataset'])
     assert 0 == result.exit_code, result.output + str(result.stderr_bytes)
@@ -1158,12 +1166,12 @@ def test_add_specific_refs(ref, runner, client):
     # add data from a git repo
     result = runner.invoke(
         cli, [
-            'dataset', 'add', 'dataset', '-s', FILENAME, '--ref', ref,
+            'dataset', 'add', 'dataset', '-s', filename, '--ref', ref,
             'https://github.com/SwissDataScienceCenter/renku-python.git'
         ]
     )
     assert 0 == result.exit_code
-    content = (client.path / DATA_DIR / 'dataset' / FILENAME).read_text()
+    content = (client.path / DATA_DIR / 'dataset' / filename).read_text()
     assert 'v0.3.0' in content
     assert 'v0.3.1' not in content
 
@@ -1254,14 +1262,15 @@ def test_files_are_tracked_in_lfs(runner, client, no_lfs_size_limit):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_renku_clone(runner, monkeypatch):
+@pytest.mark.parametrize(
+    'url', ['https://dev.renku.ch/gitlab/renku-testing/project-9']
+)
+def test_renkulab_clone(runner, monkeypatch, url):
     """Test cloning of a Renku repo and existence of required settings."""
     from renku.core.management.storage import StorageApiMixin
 
-    remote = 'https://dev.renku.ch/gitlab/virginiafriedrich/datasets-test.git'
-
     with runner.isolated_filesystem() as project_path:
-        result = runner.invoke(cli, ['clone', remote, project_path])
+        result = runner.invoke(cli, ['clone', url, project_path])
         assert 0 == result.exit_code, result.output + str(result.stderr_bytes)
         assert (Path(project_path) / 'Dockerfile').exists()
 
@@ -1288,13 +1297,14 @@ def test_renku_clone(runner, monkeypatch):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_renku_clone_with_config(tmpdir):
+@pytest.mark.parametrize(
+    'url', ['https://dev.renku.ch/gitlab/renku-testing/project-9']
+)
+def test_renkulab_clone_with_config(tmpdir, url):
     """Test cloning of a Renku repo and existence of required settings."""
-    remote = 'https://dev.renku.ch/gitlab/virginiafriedrich/datasets-test.git'
-
     with chdir(str(tmpdir)):
         repo = project_clone(
-            remote,
+            url,
             config={
                 'user.name': 'sam',
                 'user.email': 's@m.i',
@@ -1312,22 +1322,23 @@ def test_renku_clone_with_config(tmpdir):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_renku_clone_checkout_rev(tmpdir):
-    """Test cloning of a Renku repo checking out a rev with static config."""
-    remote = 'https://dev.renku.ch/gitlab/virginiafriedrich/datasets-test.git'
-
+@pytest.mark.parametrize(
+    'url', ['https://dev.renku.ch/gitlab/renku-testing/project-9']
+)
+def test_renkulab_clone_checkout_rev(tmpdir, url):
+    """Test cloning of a repo checking out a rev with static config."""
     with chdir(str(tmpdir)):
         repo = project_clone(
-            remote,
+            url,
             config={
                 'user.name': 'sam',
                 'user.email': 's@m.i',
                 'filter.lfs.custom': '0'
             },
-            checkout_rev='3d387e64ea25079df8dd43b8875058cf9f4b0315',
+            checkout_rev='97f907e1a3f992d4acdc97a35df73b8affc917a6',
         )
 
-        assert '3d387e64ea25079df8dd43b8875058cf9f4b0315' == str(
+        assert '97f907e1a3f992d4acdc97a35df73b8affc917a6' == str(
             repo.active_branch
         )
         reader = repo.config_reader()
@@ -1345,11 +1356,9 @@ def test_renku_clone_checkout_rev(tmpdir):
 ])
 def test_renku_clone_checkout_revs(tmpdir, rev):
     """Test cloning of a Renku repo checking out a rev."""
-    remote = 'https://dev.renku.ch/gitlab/contact/no-renku.git'
-
     with chdir(str(tmpdir)):
         repo = project_clone(
-            remote,
+            'https://dev.renku.ch/gitlab/contact/no-renku.git',
             checkout_rev=rev,
         )
 
@@ -1358,7 +1367,7 @@ def test_renku_clone_checkout_revs(tmpdir, rev):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    'path,expected_path', [('', 'datasets-test'), ('.', '.'),
+    'path,expected_path', [('', 'project-9'), ('.', '.'),
                            ('new-name', 'new-name')]
 )
 @flaky(max_runs=10, min_passes=1)
@@ -1366,7 +1375,7 @@ def test_renku_clone_uses_project_name(
     runner, monkeypatch, path, expected_path
 ):
     """Test renku clone uses project name as target-path by default."""
-    remote = 'https://dev.renku.ch/gitlab/virginiafriedrich/datasets-test.git'
+    remote = 'https://dev.renku.ch/gitlab/renku-testing/project-9'
 
     with runner.isolated_filesystem() as project_path:
         result = runner.invoke(cli, ['clone', remote, path])
@@ -1376,22 +1385,34 @@ def test_renku_clone_uses_project_name(
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_add_removes_credentials(runner, client):
+@pytest.mark.parametrize(
+    'url', [(
+        'https://username:password@raw.githubusercontent.com/'
+        'SwissDataScienceCenter/renku-python/master/docs/Makefile'
+    )]
+)
+def test_add_removes_credentials(runner, client, url):
     """Check removal of credentials during adding of remote data files."""
-    url = 'https://username:password@example.com/index.html'
+    from urllib.parse import urlparse
     result = runner.invoke(cli, ['dataset', 'add', '-c', 'my-dataset', url])
     assert 0 == result.exit_code, result.output + str(result.stderr_bytes)
 
     with client.with_dataset('my-dataset') as dataset:
         file_ = dataset.files[0]
-        assert file_.url == 'https://example.com/index.html'
+        url_obj = urlparse(url)
+        assert file_.url == url_obj._replace(netloc=url_obj.hostname).geturl()
 
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_check_disk_space(runner, client, monkeypatch):
+@pytest.mark.parametrize(
+    'url', [(
+        'https://raw.githubusercontent.com/SwissDataScienceCenter/'
+        'renku-python/master/docs/Makefile'
+    )]
+)
+def test_check_disk_space(runner, client, monkeypatch, url):
     """Check adding to dataset prompts if disk space is not enough."""
-    url = 'https://example.com/index.html'
 
     def disk_usage(_):
         """Mocked response."""

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -45,10 +45,9 @@ def test_run_simple(runner, project):
 
 def test_run_many_args(client, run):
     """Test a renku run command which implicitly relies on many inputs."""
-
     os.mkdir('files')
     output = 'output.txt'
-    for i in range(5003):
+    for i in range(103):
         os.system('touch files/{}.txt'.format(i))
     client.repo.index.add(['files/'])
     client.repo.index.commit('add many files')


### PR DESCRIPTION
This PR makes a few improvements on our testing setup:

* import datasets tests use 60x times smaller datasets for importing
* `integration` marked tests now run in parallel using `pytest-xdist` ( normal unit tests are still running sequentially due to flakiness, but by component)
* local execution of `pytest -m integration -n auto` leads to the execution time of <5 minutes (depends on the CPU/Threads count)
* speeds up CI execution (4 workers only, expandable with our infrastructure if we want faster):
    * `test-macos` & `test-linux`: ~20min (was ~40min)
    * `test-linux-integration`: ~15min (was 45min)
    * `test-macos-integration`: ~20min (was ~55min+) 
    * overall: ~25min (was ~55+min with collect & provisioning)
* unit tests are decoupled on the CI level so testing happens for each module individually (tried to used xdist on them but `cli` tests are really flaky, so such parallelization does not benefit us much)
  * `test-linux` are now run in parallel for each component: `test-linux-cli`, `test-linux-core`, `test-linux-service`
  * `test-macos` are now run in parallel for each component: `test-macos-cli`, `test-macos-core`, `test-macos-service`

Due to the big wait times during work hours for macos machines, I've disabled the `test-macos-integration`  to run only on post-merge. I've tried to run a test suite on my threadripper machine with 48 threads and the entire suite ran blazingly fast due to the parallelization introduced in this PR (to avoid `cli` flakiness locally I used `pytest-rerunfailures`). 

We could speed up this run even further by provisioning Github runners on our infrastructure to expand the computing power.
