### PR TITLE
fix(core): fix workflow migration triples

### DIFF
--- a/renku/core/management/migrations/m_0003__2_initial.py
+++ b/renku/core/management/migrations/m_0003__2_initial.py
@@ -129,6 +129,8 @@ def _fix_labels_and_ids(client):
         dataset._label = dataset.identifier
 
         for file_ in dataset.files:
+            if not Path(file_.path).exists():
+                continue
             _, commit, _ = client.resolve_in_submodules(
                 client.find_previous_commit(file_.path, revision="HEAD"), file_.path,
             )

--- a/renku/core/models/workflow/run.py
+++ b/renku/core/models/workflow/run.py
@@ -170,16 +170,19 @@ class Run(CommitMixin):
     _activity = attr.ib(kw_only=True, default=None)
 
     @staticmethod
-    def generate_id(client):
+    def generate_id(client, identifier=None):
         """Generate an id for an argument."""
         host = "localhost"
         if client:
             host = client.remote.get("host") or host
         host = os.environ.get("RENKU_DOMAIN") or host
 
+        if not identifier:
+            identifier = str(uuid.uuid4())
+
         return urllib.parse.urljoin(
             "https://{host}".format(host=host),
-            pathlib.posixpath.join("/runs", urllib.parse.quote(str(uuid.uuid4()), safe="")),
+            pathlib.posixpath.join("/runs", urllib.parse.quote(identifier, safe="")),
         )
 
     @classmethod


### PR DESCRIPTION
Adds deterministic id's for migrate `renku:Run`s. The id's are now based on the hash of the original `*.cwl` path and its commit.

Closes #1532 