### PR TITLE
fix(core): fixes git encoding of paths with unicode characters

### DIFF
--- a/renku/core/commands/graph.py
+++ b/renku/core/commands/graph.py
@@ -31,6 +31,7 @@ from renku.core.models.git import Range
 from renku.core.models.provenance.activities import Activity, ProcessRun, Usage, WorkflowRun
 from renku.core.models.provenance.qualified import Generation
 from renku.core.models.workflow.run import Run
+from renku.core.utils.scm import git_unicode_unescape
 
 
 def _safe_path(filepath, can_be_cwl=False):
@@ -527,7 +528,7 @@ def build_graph(client, revision, no_output, paths):
 
         commit = client.repo.rev_parse(stop)
         paths = (
-            str(client.path / item.a_path)
+            str(client.path / git_unicode_unescape(item.a_path))
             for item in commit.diff(commit.parents or NULL_TREE)
             # if not item.deleted_file
         )

--- a/renku/core/management/migrations/m_0005__2_cwl.py
+++ b/renku/core/management/migrations/m_0005__2_cwl.py
@@ -36,6 +36,7 @@ from renku.core.models.provenance.activities import ProcessRun, WorkflowRun
 from renku.core.models.provenance.agents import Person, SoftwareAgent
 from renku.core.models.workflow.parameters import CommandArgument, CommandInput, CommandOutput, MappedIOStream
 from renku.core.models.workflow.run import Run
+from renku.core.utils.scm import git_unicode_unescape
 from renku.version import __version__, version_url
 
 default_missing_software_agent = SoftwareAgent(
@@ -365,7 +366,7 @@ def _invalidations_from_commit(client, commit):
         # in this backwards diff
         if file_.change_type != "A":
             continue
-        path_ = Path(file_.a_path)
+        path_ = Path(git_unicode_unescape(file_.a_path))
         entity = _get_activity_entity(client, commit, path_, collections, deleted=True)
 
         results.append(entity)

--- a/renku/core/models/cwl/command_line_tool.py
+++ b/renku/core/models/cwl/command_line_tool.py
@@ -30,6 +30,7 @@ from git import Actor
 
 from renku.core import errors
 from renku.core.commands.echo import INFO
+from renku.core.utils.scm import git_unicode_unescape
 from renku.version import __version__, version_url
 
 from ...management.config import RENKU_HOME
@@ -182,7 +183,7 @@ class CommandLineToolFactory(object):
                 candidates |= {file_ for file_ in repo.untracked_files}
 
                 # Capture modified files through redirects.
-                candidates |= {o.a_path for o in repo.index.diff(None) if not o.deleted_file}
+                candidates |= {git_unicode_unescape(o.a_path) for o in repo.index.diff(None) if not o.deleted_file}
 
             # Include explicit outputs
             candidates |= {str(path.relative_to(self.working_dir)) for path in self.explicit_outputs}

--- a/renku/core/models/provenance/activities.py
+++ b/renku/core/models/provenance/activities.py
@@ -139,16 +139,23 @@ class Activity(CommitMixin, ReferenceMixin):
             # in this backwards diff
             if file_.change_type == "A":
                 continue
+
             path_ = Path(git_unicode_unescape(file_.a_path))
 
-            is_dataset = self.client.DATASETS in str(path_)
+            is_dataset = any(
+                [
+                    path_.resolve() == (self.client.path / f.path).resolve()
+                    for d in self.client.datasets.values()
+                    for f in d.files
+                ]
+            )
             not_refs = LinkReference.REFS not in str(path_)
             does_not_exists = not path_.exists()
 
             if all([is_dataset, not_refs, does_not_exists]):
                 dataset = next(
                     d
-                    for d in self.client.datasets
+                    for d in self.client.datasets.values()
                     for f in d.files
                     if path_.resolve() == (self.client.path / f.path).resolve()
                 )

--- a/renku/core/models/provenance/activities.py
+++ b/renku/core/models/provenance/activities.py
@@ -41,6 +41,7 @@ from renku.core.models.entities import (
 from renku.core.models.locals import ReferenceMixin
 from renku.core.models.refs import LinkReference
 from renku.core.models.workflow.run import Run
+from renku.core.utils.scm import git_unicode_unescape
 
 from .agents import Person, PersonSchema, SoftwareAgentSchema, renku_agent
 from .qualified import Association, AssociationSchema, Generation, GenerationSchema, Usage, UsageSchema
@@ -138,14 +139,9 @@ class Activity(CommitMixin, ReferenceMixin):
             # in this backwards diff
             if file_.change_type == "A":
                 continue
-            path_ = Path(file_.a_path)
-            is_dataset = any(
-                [
-                    path_.resolve() == (self.client.path / f.path).resolve()
-                    for d in self.client.datasets.values()
-                    for f in d.files
-                ]
-            )
+            path_ = Path(git_unicode_unescape(file_.a_path))
+
+            is_dataset = self.client.DATASETS in str(path_)
             not_refs = LinkReference.REFS not in str(path_)
             does_not_exists = not path_.exists()
 
@@ -243,7 +239,7 @@ class Activity(CommitMixin, ReferenceMixin):
             # in this backwards diff
             if file_.change_type == "A":
                 continue
-            path_ = Path(file_.a_path)
+            path_ = Path(git_unicode_unescape(file_.a_path))
 
             is_dataset = any(
                 [

--- a/renku/core/models/provenance/qualified.py
+++ b/renku/core/models/provenance/qualified.py
@@ -18,6 +18,7 @@
 """Represent elaborated information about relations."""
 
 import weakref
+from urllib.parse import quote
 
 import attr
 from marshmallow import EXCLUDE
@@ -134,8 +135,8 @@ class Generation(EntityProxyMixin):
     def default_id(self):
         """Configure calculated ID."""
         if self.role:
-            return "{self.activity._id}/{self.role}".format(self=self,)
-        return "{self.activity._id}/tree/{self.entity.path}".format(self=self,)
+            return f"{self.activity._id}/{self.role}"
+        return f"{self.activity._id}/tree/{quote(str(self.entity.path))}"
 
     @classmethod
     def from_jsonld(cls, data):

--- a/renku/core/utils/scm.py
+++ b/renku/core/utils/scm.py
@@ -22,3 +22,10 @@ import re
 def strip_and_lower(input):
     """Adjust chars to make the input compatible as scm source."""
     return re.sub(r"\s", r"-", input.strip()).lower()
+
+
+def git_unicode_unescape(s, encoding="utf-8"):
+    """Undoes git/gitpython unicode encoding."""
+    if s.startswith('"'):
+        return s.strip('"').encode("latin1").decode("unicode-escape").encode("latin1").decode(encoding)
+    return s

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -410,6 +410,26 @@ def test_add_to_dirty_repo(directory_tree, runner, project, client):
     assert ["untracked"] == client.repo.untracked_files
 
 
+def test_add_unicode_file(tmpdir, runner, project, client):
+    """Test adding files with unicode special characters in their names."""
+    # create a dataset
+    result = runner.invoke(cli, ["dataset", "create", "my-dataset"])
+    assert 0 == result.exit_code
+    assert "OK" in result.output
+
+    filename = "filéàèû爱ಠ_ಠ.txt"
+    new_file = tmpdir.join(filename)
+    new_file.write(str("test"))
+
+    # add data
+    result = runner.invoke(cli, ["dataset", "add", "my-dataset", str(new_file)],)
+    assert 0 == result.exit_code
+
+    result = runner.invoke(cli, ["log", "--format", "json-ld", "--strict", f"data/my-dataset/{filename}"])
+    assert 0 == result.exit_code
+    assert filename in result.output.encode("latin1").decode("unicode-escape")
+
+
 def test_multiple_file_to_dataset(tmpdir, runner, project, client):
     """Test importing multiple data into a dataset at once."""
     # create a dataset


### PR DESCRIPTION
Git encodes path with unicode characters, like `filé.txt` as `"fil\u00e9.txt"`. This undoes that encoding when loading file paths from gitpython.

Closes #1474 