### PR TITLE
feat: add click plugin support

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -19,9 +19,12 @@
 Plugin Support
 ==============
 
-Plugins are supported using the `pluggy <https://pluggy.readthedocs.io/en/latest/>`_ library.
+Runtime Plugins
+---------------
 
-Plugins can be created as python packages that contain the respective entrypoint definition in their `setup.py` file, like so:
+Runtime plugins are supported using the `pluggy <https://pluggy.readthedocs.io/en/latest/>`_ library.
+
+Runtime plugins can be created as python packages that contain the respective entrypoint definition in their `setup.py` file, like so:
 
 .. code-block:: python
 
@@ -50,3 +53,32 @@ where `myproject.pluginmodule` points to a Renku `hookimpl` e.g.:
 
 .. automodule:: renku.core.plugins.run
    :members:
+
+
+CLI Plugins
+-----------
+
+Command-line interface plugins are supported using the `click-plugins <https://github.com/click-contrib/click-plugins>` library.
+
+As in case the runtime plugins, command-line plugins can be created as python packages that contain the respective entrypoint definition in their `setup.py` file, like so:
+
+.. code-block:: python
+
+    from setuptools import setup
+
+    setup(
+        ...
+        entry_points={"renku.cli_plugins": ["mycmd = myproject.pluginmodule:mycmd"]},
+        ...
+    )
+
+where `myproject.pluginmodule:mycmd` points to a click command e.g.:
+
+.. code-block:: python
+
+    import click
+
+    @click.command()
+    @pass_local_client()
+    def mycmd(client):
+        ...

--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -69,6 +69,9 @@ import click
 import click_completion
 import yaml
 
+from pkg_resources import iter_entry_points
+from click_plugins import with_plugins
+
 from renku.cli.clone import clone
 from renku.cli.config import config
 from renku.cli.dataset import dataset
@@ -122,7 +125,7 @@ def is_allowed_command(ctx):
     """Check if invoked command contains help command."""
     return ctx.invoked_subcommand in WARNING_UNPROTECTED_COMMANDS or "-h" in sys.argv or "--help" in sys.argv
 
-
+@with_plugins(iter_entry_points('renku.cli_plugins'))
 @click.group(
     cls=IssueFromTraceback, context_settings={"auto_envvar_prefix": "RENKU", "help_option_names": ["-h", "--help"],}
 )

--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ install_requires = [
     "calamus>=0.3.3,<0.3.4",
     "click-completion>=0.5.0,<=0.5.3",
     "click>=7.0,<=7.1.2",
+    "click-plugins==1.1.1",
     "cryptography>=2.7,<=2.9.2",
     "cwlgen>=0.4.0,<=0.4.2",
     "cwltool>=3.0.20200724003302,<=3.0.20200807132242",


### PR DESCRIPTION
As discussed this adds the option to add renku cli subcommands via click plugins.
required for new renku-mls features.

updating calamus version in order to support blank node id generation