### PR TITLE
fix(core): fix importing a dataset referenced from non-existent projects

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -362,6 +362,22 @@ def dataset_responses():
         yield rsps
 
 
+@pytest.fixture
+def missing_kg_project_responses():
+    """KG project query responses for missing project."""
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+
+        def request_callback(request):
+            return (404, {"Content-Type": "application/text"}, json.dumps({"message": "no project found"}))
+
+        rsps.add_callback(
+            responses.GET, re.compile("http(s)*://dev.renku.ch/knowledge-graph/projects/.*"), callback=request_callback
+        )
+        rsps.add_passthru(re.compile("http(s)*://dev.renku.ch/datasets/.*"))
+        rsps.add_passthru(re.compile("http(s)*://dev.renku.ch/knowledge-graph/datasets/.*"))
+        yield rsps
+
+
 @pytest.fixture()
 def directory_tree(tmp_path):
     """Create a test directory tree."""

--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -196,6 +196,10 @@ class ProjectNotSupported(RenkuException):
         )
 
 
+class ProjectNotFound(RenkuException):
+    """Raise when one or more projects couldn't be found in the KG."""
+
+
 class NothingToCommit(RenkuException):
     """Raise when there is nothing to commit."""
 

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -338,6 +338,16 @@ def test_dataset_import_renku_fail(runner, client, monkeypatch, url):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
+@pytest.mark.parametrize("url", ["https://dev.renku.ch/datasets/e3e1beba-0559-4fdd-8e46-82963cec9fe2",])
+def test_dataset_import_renku_missing_project(runner, client, missing_kg_project_responses, url):
+    """Test dataset import fails if cannot clone repo."""
+    result = runner.invoke(cli, ["dataset", "import", url], input="y")
+    assert 1 == result.exit_code
+    assert "Cannot find these projects in the knowledge graph" in result.output
+
+
+@pytest.mark.integration
+@flaky(max_runs=10, min_passes=1)
 @pytest.mark.parametrize(
     "url,exit_code",
     [


### PR DESCRIPTION
Don't raise an exception if a dataset is referenced from a project in the KG that does not exist on gitlab anymore.

closes #1569 