### PR TITLE
fix(core): Fix graph building for nodes with same subpath

### DIFF
--- a/renku/core/commands/graph.py
+++ b/renku/core/commands/graph.py
@@ -272,7 +272,11 @@ class Graph(object):
                         if all(member.path != d.path for d in dependencies) and any(
                             u.startswith(member.path) for u in usage_paths
                         ):
-                            dependencies = [d for d in dependencies if not d.path.startswith(member.path)]
+                            dependencies = [
+                                d
+                                for d in dependencies
+                                if not (self.client.path / member.path).is_dir() or not d.path.startswith(member.path)
+                            ]
                             dependencies.append(member)
 
         from renku.core.models.sort import topological


### PR DESCRIPTION
fixes a bug where `rerun` would not rerun all steps if one of the output paths of a step was a subpath of an output of a previous step.
E.g. step1 -> `hello` and step2 -> `hello.wc`