### PR TITLE
docs: pipx installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ and make sure that the ``$PATH`` is correctly configured.
 ::
 
     $ python3 -m pip install --user pipx
-    $ pipx ensurepath
+    $ python3 -m pipx ensurepath
 
 Once ``pipx`` is installed use following command to install ``renku``.
 


### PR DESCRIPTION
# Description

I think you should adjust the instruction about the installation of pipx:
The current instructions use the following command to ensure pipx is included in $PATH:

`pipx ensurepath`

I think the correct way to do this is the following:

`python3 -m pipx ensurepath`

Also, this is how the official pipx documentation suggests it.
(https://github.com/pipxproject/pipx#install-pipx)


## Type of change
docs
