### PR TITLE
fix(core): pre-commit hook message for unsupported project

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -638,6 +638,19 @@ def old_repository_with_submodules(request, tmpdir_factory):
     shutil.rmtree(working_dir)
 
 
+@pytest.fixture
+def unsupported_project(client):
+    """A client with a newer project version."""
+    with client.with_metadata() as project:
+        impossible_newer_version = 42000
+        project.version = impossible_newer_version
+
+    client.repo.git.add(".renku")
+    client.repo.index.commit("update renku.ini", skip_hooks=True)
+
+    yield client
+
+
 @pytest.fixture(autouse=True)
 def add_client(doctest_namespace):
     """Add Renku client to doctest namespace."""

--- a/renku/cli/exception_handler.py
+++ b/renku/cli/exception_handler.py
@@ -92,8 +92,10 @@ class RenkuExceptionsHandler(click.Group):
             exit_code = 1
             if isinstance(e, (ParameterError, UsageError)):
                 exit_code = 2
-            elif isinstance(e, (MigrationRequired, ProjectNotSupported)):
+            elif isinstance(e, MigrationRequired):
                 exit_code = 3
+            elif isinstance(e, ProjectNotSupported):
+                exit_code = 4
             sys.exit(exit_code)
 
 

--- a/renku/cli/exception_handler.py
+++ b/renku/cli/exception_handler.py
@@ -60,7 +60,7 @@ from urllib.parse import urlencode
 import click
 import filelock
 
-from renku.core.errors import ParameterError, RenkuException, UsageError
+from renku.core.errors import MigrationRequired, ParameterError, ProjectNotSupported, RenkuException, UsageError
 
 _BUG = click.style("Ahhhhhhhh! You have found a bug. 🐞\n\n", fg="red", bold=True,)
 
@@ -92,6 +92,8 @@ class RenkuExceptionsHandler(click.Group):
             exit_code = 1
             if isinstance(e, (ParameterError, UsageError)):
                 exit_code = 2
+            elif isinstance(e, (MigrationRequired, ProjectNotSupported)):
+                exit_code = 3
             sys.exit(exit_code)
 
 

--- a/renku/core/commands/migrate.py
+++ b/renku/core/commands/migrate.py
@@ -17,11 +17,21 @@
 # limitations under the License.
 """Migrate project to the latest Renku version."""
 
-from renku.core.management.migrate import is_docker_update_possible, is_migration_required, is_project_unsupported
-from renku.core.management.migrate import is_renku_project as is_renku_project_helper
-from renku.core.management.migrate import is_template_update_possible, migrate
+from renku.core.management.migrate import (
+    is_docker_update_possible,
+    is_migration_required,
+    is_project_unsupported,
+    is_renku_project,
+    is_template_update_possible,
+    migrate,
+)
 
 from .client import pass_local_client
+
+SUPPORTED_RENKU_PROJECT = 0
+MIGRATION_REQUIRED = 1
+UNSUPPORTED_PROJECT = 2
+NON_RENKU_REPOSITORY = 3
 
 
 @pass_local_client
@@ -90,6 +100,13 @@ def migrate_project_no_commit(
 
 
 @pass_local_client
-def is_renku_project(client):
-    """Check if repository is a renku project."""
-    return is_renku_project_helper(client)
+def check_project(client):
+    """Check if repository is a renku project, unsupported, or requires migration."""
+    if not is_renku_project(client):
+        return NON_RENKU_REPOSITORY
+    elif is_migration_required(client):
+        return MIGRATION_REQUIRED
+    elif is_project_unsupported(client):
+        return UNSUPPORTED_PROJECT
+
+    return SUPPORTED_RENKU_PROJECT

--- a/renku/core/utils/contexts.py
+++ b/renku/core/utils/contexts.py
@@ -26,9 +26,6 @@ from pathlib import Path
 @contextlib.contextmanager
 def chdir(path):
     """Change the current working directory."""
-    if isinstance(path, Path):
-        path = str(path)
-
     cwd = os.getcwd()
     os.chdir(path)
     try:

--- a/renku/data/pre-commit.sh
+++ b/renku/data/pre-commit.sh
@@ -40,8 +40,17 @@ fi
 
 if [ ${#MODIFIED_FILES[@]} -ne 0 ] ; then
   MODIFIED_OUTPUTS=$(renku show outputs "${MODIFIED_FILES[@]}")
-  if [ $? -eq 3 ]; then
-    echo "Cannot verify validity of the commit: Project is either unsupported or requires a migration."
+  EXIT_CODE=$?
+  if [ $EXIT_CODE -eq 3 ]; then
+    echo "Cannot verify validity of the commit: Project metadata is outdated."
+    echo "Run 'renku migrate' command to fix the issue."
+    echo
+    echo 'To commit anyway, use "git commit --no-verify".'
+    exit 1
+  fi
+  if [ $EXIT_CODE -eq 4 ]; then
+    echo "Cannot verify validity of the commit: Project was created with a newer version of Renku."
+    echo "Upgrade Renku to the latest version."
     echo
     echo 'To commit anyway, use "git commit --no-verify".'
     exit 1

--- a/renku/data/pre-commit.sh
+++ b/renku/data/pre-commit.sh
@@ -40,6 +40,12 @@ fi
 
 if [ ${#MODIFIED_FILES[@]} -ne 0 ] ; then
   MODIFIED_OUTPUTS=$(renku show outputs "${MODIFIED_FILES[@]}")
+  if [ $? -eq 3 ]; then
+    echo "Cannot verify validity of the commit: Project is either unsupported or requires a migration."
+    echo
+    echo 'To commit anyway, use "git commit --no-verify".'
+    exit 1
+  fi
   if [ "$MODIFIED_OUTPUTS" ]; then
     echo 'You are trying to update generated files.'
     echo

--- a/tests/cli/test_migrate.py
+++ b/tests/cli/test_migrate.py
@@ -288,7 +288,7 @@ def test_migrate_non_renku_repository(isolated_runner):
 def test_commands_fail_on_old_repository(isolated_runner, old_repository_with_submodules, command):
     """Test commands that fail on projects created by old version of renku."""
     result = isolated_runner.invoke(cli, command)
-    assert 1 == result.exit_code, result.output
+    assert 3 == result.exit_code, result.output
     assert "Project version is outdated and a migration is required" in result.output
 
 

--- a/tests/cli/test_migrate.py
+++ b/tests/cli/test_migrate.py
@@ -181,7 +181,7 @@ def test_comprehensive_dataset_migration(isolated_runner, old_dataset_project):
     assert 0 == result.exit_code
     assert "OK" in result.output
 
-    client = LocalClient(path=old_dataset_project.working_dir)
+    client = old_dataset_project
 
     dataset = client.load_dataset("dataverse")
     assert dataset._id.endswith("/datasets/1d2ed1e4-3aeb-4f25-90b2-38084ee3d86c")
@@ -236,7 +236,7 @@ def test_no_blank_node_after_dataset_migration(isolated_runner, old_dataset_proj
     """Test migration of datasets with blank nodes creates IRI identifiers."""
     assert 0 == isolated_runner.invoke(cli, ["migrate"]).exit_code
 
-    dataset = LocalClient(path=old_dataset_project.working_dir).load_dataset("201901_us_flights_1")
+    dataset = old_dataset_project.load_dataset("201901_us_flights_1")
 
     assert not dataset.creators[0]._id.startswith("_:")
     assert not dataset.same_as._id.startswith("_:")
@@ -257,6 +257,38 @@ def test_migrate_non_renku_repository(isolated_runner):
     assert 0 == result.exit_code, result.output
     assert "Warning: Not a renku project." in result.output
     assert "No migrations required." in result.output
+
+
+@pytest.mark.migration
+def test_migrate_check_on_old_project(isolated_runner, old_repository_with_submodules):
+    """Test migration check on an old project."""
+    result = isolated_runner.invoke(cli, ["migrate", "--check"])
+
+    assert 3 == result.exit_code
+    assert "Project version is outdated and a migration is required" in result.output
+
+
+@pytest.mark.migration
+def test_migrate_check_on_unsupported_project(isolated_runner, unsupported_project):
+    """Test migration check on an unsupported project."""
+    result = isolated_runner.invoke(cli, ["migrate", "--check"])
+
+    assert 4 == result.exit_code
+    assert "Project is not supported by this version of Renku." in result.output
+
+
+@pytest.mark.migration
+def test_migrate_check_on_non_renku_repository(isolated_runner):
+    """Test migration check on non-renku repo."""
+    from git import Repo
+
+    Repo.init(".")
+    os.mkdir(".renku")
+
+    result = isolated_runner.invoke(cli, ["migrate", "--check"])
+
+    assert 0 == result.exit_code, result.output
+    assert "Warning: Not a renku project." in result.output
 
 
 @pytest.mark.migration

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -121,7 +121,24 @@ def test_git_pre_commit_hook(runner, project, capsys):
     repo.index.commit("hello")
 
 
-def test_git_pre_commit_hook_in_unsupported_project(runner, unsupported_project):
+def test_git_pre_commit_hook_in_old_project(isolated_runner, old_dataset_project):
+    """Test proper messaging in git hooks when project requires migration."""
+    assert 0 == isolated_runner.invoke(cli, ["githooks", "install"]).exit_code
+
+    with old_dataset_project.with_metadata() as project:
+        project.created = datetime.datetime.now(datetime.timezone.utc)
+
+    old_dataset_project.repo.git.add("--all")
+
+    with pytest.raises(git.exc.HookExecutionError) as e:
+        old_dataset_project.repo.index.commit("update project metadata")
+
+    assert "Cannot verify validity of the commit: Project metadata is outdated." in str(e.value)
+    assert "Run 'renku migrate' command to fix the issue." in str(e.value)
+    assert "You are trying to update generated files" not in str(e.value)
+
+
+def test_git_pre_commit_hook_in_unsupported_project(unsupported_project):
     """Test proper messaging in git hooks when project version is not supported."""
     with unsupported_project.with_metadata() as project:
         project.created = datetime.datetime.now(datetime.timezone.utc)
@@ -131,7 +148,8 @@ def test_git_pre_commit_hook_in_unsupported_project(runner, unsupported_project)
     with pytest.raises(git.exc.HookExecutionError) as e:
         unsupported_project.repo.index.commit("update project metadata")
 
-    assert "Cannot verify validity of the commit: Project is either unsupported or requires a migration" in str(e.value)
+    assert "Cannot verify validity of the commit: Project was created with a newer version of Renku." in str(e.value)
+    assert "Upgrade Renku to the latest version." in str(e.value)
     assert "You are trying to update generated files" not in str(e.value)
 
 


### PR DESCRIPTION
# Description

Print proper message in git pre-commit hooks when project version is unsupported or requires a migration.

Fixes #1697 
