### PR TITLE
fix(core): fixes renku save with staged changes

### DIFF
--- a/renku/core/commands/save.py
+++ b/renku/core/commands/save.py
@@ -43,7 +43,7 @@ def save_and_push(client, message=None, remote=None, paths=None):
             if not_passed:
                 raise errors.RenkuSaveError(
                     "These files are in the git staging area, but weren't passed to renku save. Unstage them or pass"
-                    + " them explicitely: \n"
+                    + " them explicitly: \n"
                     + "\n".join(not_passed)
                 )
 

--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -450,3 +450,7 @@ class CommandNotFinalizedError(RenkuException):
 
 class CommandFinalizedError(RenkuException):
     """Raised when trying to modify a finalized command builder."""
+
+
+class RenkuSaveError(RenkuException):
+    """Raised when renku save doesn't work."""

--- a/renku/core/management/git.py
+++ b/renku/core/management/git.py
@@ -128,7 +128,10 @@ class GitCore:
     def dirty_paths(self):
         """Get paths of dirty files in the repository."""
         repo_path = self.repo.working_dir
-        return {os.path.join(repo_path, p) for p in self.repo.untracked_files + self.modified_paths}
+        return {
+            os.path.join(repo_path, p)
+            for p in self.repo.untracked_files + self.modified_paths + self.repo.index.diff("HEAD")
+        }
 
     @property
     def candidate_paths(self):

--- a/renku/core/management/git.py
+++ b/renku/core/management/git.py
@@ -128,10 +128,8 @@ class GitCore:
     def dirty_paths(self):
         """Get paths of dirty files in the repository."""
         repo_path = self.repo.working_dir
-        return {
-            os.path.join(repo_path, p)
-            for p in self.repo.untracked_files + self.modified_paths + self.repo.index.diff("HEAD")
-        }
+        staged_files = self.repo.index.diff("HEAD") if self.repo.head.is_valid() else []
+        return {os.path.join(repo_path, p) for p in self.repo.untracked_files + self.modified_paths + staged_files}
 
     @property
     def candidate_paths(self):

--- a/tests/cli/test_save.py
+++ b/tests/cli/test_save.py
@@ -72,7 +72,10 @@ def test_save_with_staged(runner, project, client_with_remote, tmpdir_factory):
     assert 1 == result.exit_code
     assert "These files are in the git staging area, but " in result.output
     assert "tracked" in result.output
+    assert "tracked" in [f.a_path for f in client.repo.index.diff("HEAD")]
+    assert "modified" in client.repo.untracked_files
 
     result = runner.invoke(cli, ["save", "-m", "save changes", "tracked", "modified"], catch_exceptions=False)
 
     assert 0 == result.exit_code
+    assert {"tracked", "modified"} == {f.a_path for f in client.repo.head.commit.diff("HEAD~1")}

--- a/tests/cli/test_save.py
+++ b/tests/cli/test_save.py
@@ -54,3 +54,25 @@ def test_save_with_remote(runner, project, client_with_remote, tmpdir_factory):
     assert 0 == result.exit_code
     assert "tracked" in result.output
     assert "save changes" in client.repo.head.commit.message
+
+
+def test_save_with_staged(runner, project, client_with_remote, tmpdir_factory):
+    """Test saving local changes."""
+    client = client_with_remote["client"]
+    with (client.path / "tracked").open("w") as fp:
+        fp.write("tracked file")
+
+    with (client.path / "modified").open("w") as fp:
+        fp.write("modified file")
+
+    client.repo.git.add("tracked")
+
+    result = runner.invoke(cli, ["save", "-m", "save changes", "modified"], catch_exceptions=False)
+
+    assert 1 == result.exit_code
+    assert "These files are in the git staging area, but " in result.output
+    assert "tracked" in result.output
+
+    result = runner.invoke(cli, ["save", "-m", "save changes", "tracked", "modified"], catch_exceptions=False)
+
+    assert 0 == result.exit_code


### PR DESCRIPTION
Includes staged files in `dirty_paths` logic.

Saves staged files along unstaged ones if called without paths.

Raises exception if called with paths but staged paths not included in command.
 
Closes #1692 