### PR TITLE
chore: revert to editable service install

### DIFF
--- a/Dockerfile.svc
+++ b/Dockerfile.svc
@@ -19,7 +19,7 @@ RUN requirements-builder -e service --level=pypi setup.py > /tmp/requirements.tx
     pip install -r /tmp/requirements.txt
 
 COPY . /code/renku
-RUN pip install .[service]
+RUN pip install -e .[service]
 
 # shuhitsu (執筆): The "secretary" of the renga, as it were, who is responsible for
 # writing down renga verses and for the proceedings of the renga.


### PR DESCRIPTION
This fixes the broken docker image where the main service failed to start. 

Follow up issue to improve on this: https://github.com/SwissDataScienceCenter/renku-python/issues/1751

The image is deployed on https://rok.dev.renku.ch