### PR TITLE
chore: fix dirty version on chartpress build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,8 +6,6 @@ __pycache__
 
 build
 dist
-docs
-tests
 
 *.mo
 *.pyc
@@ -19,11 +17,4 @@ tests
 *.egg-info
 .eggs
 
-docker-compose.yml
-docker-compose-dev.yml
-
 Procfile*
-
-helm-chart
-
-Dockerfile*

--- a/Dockerfile.svc
+++ b/Dockerfile.svc
@@ -19,7 +19,11 @@ RUN requirements-builder -e service --level=pypi setup.py > /tmp/requirements.tx
     pip install -r /tmp/requirements.txt
 
 COPY . /code/renku
-RUN pip install -e .[service]
+
+# Set CLEAN_INSTALL to a non-null value to ensure that only a committed version of
+# renku-python is installed in the image. This is the default for chartpress builds.
+ARG CLEAN_INSTALL
+RUN if [ -n "${CLEAN_INSTALL}" ]; then git reset --hard ; fi && pip install -e .[service]
 
 # shuhitsu (執筆): The "secretary" of the renga, as it were, who is responsible for
 # writing down renga verses and for the proceedings of the renga.

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -12,3 +12,5 @@ charts:
         contextPath: .
         dockerfilePath: Dockerfile.svc
         valuesPath: image
+        buildArgs:
+          CLEAN_INSTALL: "1"


### PR DESCRIPTION
This is hopefully the last in the series of "quick fix to dirty version" PRs. 

The solution was a bit more involved than previously thought - because we use `chartpress` to publish our images and because `chartpress` modifies some files in the repo before building the image, it will necessarily result in a "dirty" version of the installed package. I circumvent this here by introducing a docker build argument which can be set to in order to `git reset --hard` the repo before the installation in the `Dockerfile`. The default behavior is still to build with the local (uncommitted) changes in order to not surprise any unsuspecting developers who might be otherwise left wondering what happened to their code in the docker image. 

To test:

```
$ chartpress
$ docker run --rm -ti --entrypoint bash <image> renku --version
```