### PR TITLE
feat(cli): add migrationscheck command

### DIFF
--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -79,7 +79,7 @@ from renku.cli.exception_handler import IssueFromTraceback
 from renku.cli.githooks import githooks as githooks_command
 from renku.cli.init import init as init_command
 from renku.cli.log import log
-from renku.cli.migrate import check_immutable_template_files, migrate
+from renku.cli.migrate import check_immutable_template_files, migrate, migrationscheck
 from renku.cli.move import move
 from renku.cli.remove import remove
 from renku.cli.rerun import rerun
@@ -196,6 +196,7 @@ cli.add_command(githooks_command)
 cli.add_command(init_command)
 cli.add_command(log)
 cli.add_command(migrate)
+cli.add_command(migrationscheck)
 cli.add_command(check_immutable_template_files)
 cli.add_command(move)
 cli.add_command(remove)

--- a/renku/cli/migrate.py
+++ b/renku/cli/migrate.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Migrate project to the latest Renku version."""
+import json
 import os
 
 import click
@@ -29,6 +30,8 @@ from renku.core.commands.migrate import (
     check_project,
     migrate_project,
     migrate_project_no_commit,
+    migrations_check,
+    migrations_versions,
 )
 from renku.core.errors import MigrationRequired, ProjectNotSupported
 
@@ -64,6 +67,37 @@ def migrate(check, no_commit):
         if check_project() == NON_RENKU_REPOSITORY:
             click.secho(WARNING + "Not a renku project.")
         click.secho("No migrations required.")
+
+
+@click.command(hidden=True)
+def migrationscheck():
+    """Check status of the project and current renku-python version."""
+    latest_version, project_version = migrations_versions()
+    (
+        migration_required,
+        project_supported,
+        template_update_possible,
+        current_template_version,
+        latest_template_version,
+        automated_update,
+        docker_update_possible,
+    ) = migrations_check()
+
+    click.echo(
+        json.dumps(
+            {
+                "latest_version": latest_version,
+                "project_version": project_version,
+                "migration_required": migration_required,
+                "project_supported": project_supported,
+                "template_update_possible": template_update_possible,
+                "current_template_version": str(current_template_version),
+                "latest_template_version": str(latest_template_version),
+                "automated_update": automated_update,
+                "docker_update_possible": docker_update_possible,
+            }
+        )
+    )
 
 
 @click.command(hidden=True)

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -154,7 +154,12 @@ class RepositoryApiMixin(GitCore):
     @property
     def latest_agent(self):
         """Returns latest agent version used in the repository."""
-        return self.project.agent_version
+        try:
+            return self.project.agent_version
+        except ValueError as e:
+            if "Project name not set" in str(e):
+                return None
+            raise
 
     @property
     def lock(self):

--- a/tests/cli/test_migrate.py
+++ b/tests/cli/test_migrate.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test ``migrate`` command."""
+import json
 import os
 from pathlib import Path
 
@@ -45,6 +46,25 @@ def test_migrate_project(isolated_runner, old_project):
     client = LocalClient(path=old_project.working_dir)
     assert client.project
     assert client.project.name
+
+
+@pytest.mark.migration
+def test_migration_check(isolated_runner, project):
+    """Test migrate on old repository."""
+    result = isolated_runner.invoke(cli, ["migrationscheck"])
+    assert 0 == result.exit_code
+    output = json.loads(result.output)
+    assert output.keys() == {
+        "latest_version",
+        "project_version",
+        "migration_required",
+        "project_supported",
+        "template_update_possible",
+        "current_template_version",
+        "latest_template_version",
+        "automated_update",
+        "docker_update_possible",
+    }
 
 
 @pytest.mark.migration


### PR DESCRIPTION
adds a `renku migrationscheck` command that produces output of the form
```
{
    "latest_version": "0.12.2.dev11+dirty", 
    "project_version": '"0.12.2.dev11+dirty", 
    "migration_required": false,
    "project_supported": true, 
    "template_update_possible": false, 
    "current_template_version": "0.12.2.dev11+dirty", 
    "latest_template_version": "0.12.2.dev11+dirty", 
    "automated_update": false, 
    "docker_update_possible": false
}
```
Closes #1760