### PR TITLE
docs: update renku config documentation

### DIFF
--- a/renku/cli/config.py
+++ b/renku/cli/config.py
@@ -25,7 +25,7 @@ URL, with a command like:
 
 .. code-block:: console
 
-    $ renku config set registry https://registry.gitlab.com/demo/demo
+    $ renku config set interactive.default_url "/tree"
 
 By default, configuration is stored locally in the project's directory. Use
 ``--global`` option to store configuration for all projects in your home
@@ -38,7 +38,7 @@ To remove a specific key from configuration use:
 
 .. code-block:: console
 
-    $ renku config remove registry
+    $ renku config remove interactive.default_url
 
 By default, only local configuration is searched for removal. Use ``--global``
 option to remove a global configuration value.
@@ -51,6 +51,8 @@ You can display all configuration values with:
 .. code-block:: console
 
     $ renku config show
+    [renku "interactive"]
+    default_url = /lab
 
 Both local and global configuration files are read. Values in local
 configuration take precedence over global values. Use ``--local`` or
@@ -60,33 +62,44 @@ You can provide a KEY to display only its value:
 
 .. code-block:: console
 
-    $ renku config show registry
-    https://registry.gitlab.com/demo/demo
+    $ renku config show interactive.default_url
+    default_url = /lab
 
 Available configuration values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following values are available for the ``renku config`` command:
 
-+------------------------+-------------------------------------+-----------+
-| Name                   | Description                         | Default   |
-+========================+=====================================+===========+
-| registry               | The image registry to store Docker  | ``None``  |
-|                        | images in                           |           |
-+------------------------+-------------------------------------+-----------+
-| zenodo.access_token    | Access token for Zenodo API         | ``None``  |
-+------------------------+-------------------------------------+-----------+
-| dataverse.access_token | Access token for Dataverse API      | ``None``  |
-+------------------------+-------------------------------------+-----------+
-| dataverse.server_url   | URL for the Dataverse API server    | ``None``  |
-|                        | to use                              |           |
-+------------------------+-------------------------------------+-----------+
-| show_lfs_message       | Whether to show messages about      | ``True``  |
-|                        | files being added to git LFS or not |           |
-+------------------------+-------------------------------------+-----------+
-| lfs_threshold          | Threshold file size below which     | ``100kb`` |
-|                        | files are not added to git LFS      |           |
-+------------------------+-------------------------------------+-----------+
++----------------------------+-------------------------------------+-----------+
+| Name                       | Description                         | Default   |
++============================+=====================================+===========+
+| show_lfs_message           | Whether to show messages about      | ``True``  |
+|                            | files being added to git LFS or not |           |
++----------------------------+-------------------------------------+-----------+
+| lfs_threshold              | Threshold file size below which     | ``100kb`` |
+|                            | files are not added to git LFS      |           |
++----------------------------+-------------------------------------+-----------+
+| zenodo.access_token        | Access token for Zenodo API         | ``None``  |
++----------------------------+-------------------------------------+-----------+
+| dataverse.access_token     | Access token for Dataverse API      | ``None``  |
++----------------------------+-------------------------------------+-----------+
+| dataverse.server_url       | URL for the Dataverse API server    | ``None``  |
+|                            | to use                              |           |
++----------------------------+-------------------------------------+-----------+
+| interactive.default_url    | URL for interactive environments    | ``None``  |
++----------------------------+-------------------------------------+-----------+
+| interactive.cpu_request    | CPU quota for environments          | ``None``  |
++----------------------------+-------------------------------------+-----------+
+| interactive.mem_request    | Memory quota for environments       | ``None``  |
++----------------------------+-------------------------------------+-----------+
+| interactive.gpu_request    | GPU quota for environments          | ``None``  |
++----------------------------+-------------------------------------+-----------+
+| interactive.lfs_auto_fetch | Whether to automatically fetch lfs  | ``None``  |
+|                            | files on environments startup       |           |
++----------------------------+-------------------------------------+-----------+
+| interactive.image          | Pinned Docker image for             | ``None``  |
+|                            | environments                        |           |
++----------------------------+-------------------------------------+-----------+
 """
 import click
 


### PR DESCRIPTION
# Description

Update the documentation around `renku config` to include the full list of supported options.
It was pointed out that there isn't a docs page for that in renku, and this seems to be the best place where to add this information now that both `renku` and `renku-python` docs are unified.

Any reference to the `registry` config has been removed since it's not used anywhere and it was used in the examples.
If you prefer to keep it there for any reason, feel free to push changes directly to this PR or to request the change.

re SwissDataScienceCenter/renku#1647