### PR TITLE
chore: do not pull LFS in service

### DIFF
--- a/helm-chart/renku-core/templates/deployment.yaml
+++ b/helm-chart/renku-core/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: SENTRY_ENV
               value: {{ .Values.sentry.environment }}
             - name: GIT_LFS_SKIP_SMUDGE
-              value: "1"
+              value: {{ .Values.gitLFSSkipSmudge | quote }}
           volumeMounts:
             - name: shared-volume
               mountPath: {{ .Values.cacheDirectory }}
@@ -108,7 +108,7 @@ spec:
             - name: SENTRY_ENV
               value: {{ .Values.sentry.environment }}
             - name: GIT_LFS_SKIP_SMUDGE
-              value: "1"
+              value: {{ .Values.gitLFSSkipSmudge | quote }}
           volumeMounts:
             - name: shared-volume
               mountPath: {{ .Values.cacheDirectory }}
@@ -165,7 +165,7 @@ spec:
             - name: SENTRY_ENV
               value: {{ .Values.sentry.environment }}
             - name: GIT_LFS_SKIP_SMUDGE
-              value: "1"
+              value: {{ .Values.gitLFSSkipSmudge | quote }}
           volumeMounts:
             - name: shared-volume
               mountPath: {{ .Values.cacheDirectory }}

--- a/helm-chart/renku-core/templates/deployment.yaml
+++ b/helm-chart/renku-core/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
               value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENV
               value: {{ .Values.sentry.environment }}
+            - name: GIT_LFS_SKIP_SMUDGE
+              value: "1"
           volumeMounts:
             - name: shared-volume
               mountPath: {{ .Values.cacheDirectory }}
@@ -105,6 +107,8 @@ spec:
               value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENV
               value: {{ .Values.sentry.environment }}
+            - name: GIT_LFS_SKIP_SMUDGE
+              value: "1"
           volumeMounts:
             - name: shared-volume
               mountPath: {{ .Values.cacheDirectory }}
@@ -160,6 +164,8 @@ spec:
               value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENV
               value: {{ .Values.sentry.environment }}
+            - name: GIT_LFS_SKIP_SMUDGE
+              value: "1"
           volumeMounts:
             - name: shared-volume
               mountPath: {{ .Values.cacheDirectory }}

--- a/helm-chart/renku-core/values.yaml
+++ b/helm-chart/renku-core/values.yaml
@@ -15,6 +15,9 @@ cleanupFilesTTL: 1800
 cleanupProjectsTTL: 1800
 logLevel: INFO
 
+# override to automatically pull LFS data on clone
+gitLFSSkipSmudge: 1
+
 # NOTE: Make sure token secret is greater or equal to 32 bytes.
 jwtTokenSecret: bW9menZ3cnh6cWpkcHVuZ3F5aWJycmJn
 


### PR DESCRIPTION
This PR adds the `GIT_LFS_SKIP_SMUDGE=1` environment variable to the service containers to prevent pulling LFS data when not needed. The operations that require LFS objects do so explicitly anyway (e.g. dataset import from renku projects). This significantly improves the performance of common operations like `dataset.list`. 