### PR TITLE
chore(service): specify gunicorn config via values

### DIFF
--- a/Dockerfile.svc
+++ b/Dockerfile.svc
@@ -29,12 +29,15 @@ RUN if [ -n "${CLEAN_INSTALL}" ]; then git reset --hard ; fi && pip install -e .
 # writing down renga verses and for the proceedings of the renga.
 USER shuhitsu
 
-ENTRYPOINT [ \
-    "gunicorn", \
-    "renku.service.entrypoint:app", \
-    "-b", "0.0.0.0:8080", \
-    "--timeout", "600", \
-    "--workers", "32", \
-    "--worker-class", "gthread", \
-    "--threads", "1"\
+ENV RENKU_SVC_NUM_WORKERS 1
+ENV RENKU_SVC_NUM_THREADS 1
+CMD [ \
+    "sh", "-c", \
+    "gunicorn \
+    renku.service.entrypoint:app \
+    -b 0.0.0.0:8080 \
+    --timeout 600 \
+    --workers $RENKU_SVC_NUM_WORKERS \
+    --worker-class gthread \
+    --threads $RENKU_SVC_NUM_THREADS" \
 ]

--- a/Dockerfile.svc
+++ b/Dockerfile.svc
@@ -29,11 +29,12 @@ RUN if [ -n "${CLEAN_INSTALL}" ]; then git reset --hard ; fi && pip install -e .
 # writing down renga verses and for the proceedings of the renga.
 USER shuhitsu
 
-ENTRYPOINT ["gunicorn", \
-            "renku.service.entrypoint:app", \
-            "-b", "0.0.0.0:8080", \
-            "--timeout", "600", \
-            "--workers", "4", \
-            "--worker-class", "gthread", \
-            "--threads", "8"\
+ENTRYPOINT [ \
+    "gunicorn", \
+    "renku.service.entrypoint:app", \
+    "-b", "0.0.0.0:8080", \
+    "--timeout", "600", \
+    "--workers", "32", \
+    "--worker-class", "gthread", \
+    "--threads", "1"\
 ]

--- a/helm-chart/renku-core/Chart.yaml
+++ b/helm-chart/renku-core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: renku-core
-version: 0.12.1
+version: 0.12.1-9f7fb95a

--- a/helm-chart/renku-core/Chart.yaml
+++ b/helm-chart/renku-core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: renku-core
-version: 0.12.1-9f7fb95a
+version: 0.12.1

--- a/helm-chart/renku-core/templates/deployment.yaml
+++ b/helm-chart/renku-core/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
             - name: RENKU_SVC_NUM_THREADS
               value: {{ .Values.nThreads | quote }}
             {{ end }}
+            - name: GIT_LFS_SKIP_SMUDGE
+              value: {{ .Values.gitLFSSkipSmudge | quote }}
           volumeMounts:
             - name: shared-volume
               mountPath: {{ .Values.cacheDirectory }}

--- a/helm-chart/renku-core/templates/deployment.yaml
+++ b/helm-chart/renku-core/templates/deployment.yaml
@@ -39,6 +39,51 @@ spec:
             - name: RQ_REDIS_HOST
               value: {{ include "call-nested" (list . "redis" "redis.fullname") }}-master
       {{ end }}
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: REDIS_HOST
+              value: {{ include "call-nested" (list . "redis" "redis.fullname") }}-master
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_DATABASE
+              value: "0"
+            - name: REDIS_PASSWORD
+              value:
+            - name: CACHE_DIR
+              value: {{ .Values.cacheDirectory }}
+            - name: PROJECT_CLONE_DEPTH_DEFAULT
+              value: {{ .Values.projectCloneDepth | quote }}
+            - name: TEMPLATE_CLONE_DEPTH_DEFAULT
+              value: {{ .Values.templateCloneDepth | quote }}
+            - name: CORE_SERVICE_PREFIX
+              value: /renku
+            - name: RENKU_SVC_SWAGGER_URL
+              value: /renku/openapi.json
+            - name: SERVICE_LOG_LEVEL
+              value: {{ .Values.logLevel }}
+            - name: SENTRY_DSN
+              value: {{ .Values.sentry.dsn }}
+            - name: SENTRY_ENV
+              value: {{ .Values.sentry.environment }}
+          volumeMounts:
+            - name: shared-volume
+              mountPath: {{ .Values.cacheDirectory }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
         - name: {{ .Chart.Name }}-datasets-workers
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -135,54 +180,6 @@ spec:
               value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENV
               value: {{ .Values.sentry.environment }}
-
-        - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: REDIS_HOST
-              value: {{ include "call-nested" (list . "redis" "redis.fullname") }}-master
-            - name: REDIS_PORT
-              value: "6379"
-            - name: REDIS_DATABASE
-              value: "0"
-            - name: REDIS_PASSWORD
-              value:
-            - name: CACHE_DIR
-              value: {{ .Values.cacheDirectory }}
-            - name: PROJECT_CLONE_DEPTH_DEFAULT
-              value: {{ .Values.projectCloneDepth | quote }}
-            - name: TEMPLATE_CLONE_DEPTH_DEFAULT
-              value: {{ .Values.templateCloneDepth | quote }}
-            - name: CORE_SERVICE_PREFIX
-              value: /renku
-            - name: RENKU_SVC_SWAGGER_URL
-              value: /renku/openapi.json
-            - name: SERVICE_LOG_LEVEL
-              value: {{ .Values.logLevel }}
-            - name: SENTRY_DSN
-              value: {{ .Values.sentry.dsn }}
-            - name: SENTRY_ENV
-              value: {{ .Values.sentry.environment }}
-            - name: GIT_LFS_SKIP_SMUDGE
-              value: {{ .Values.gitLFSSkipSmudge | quote }}
-          volumeMounts:
-            - name: shared-volume
-              mountPath: {{ .Values.cacheDirectory }}
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/renku-core/templates/deployment.yaml
+++ b/helm-chart/renku-core/templates/deployment.yaml
@@ -67,6 +67,14 @@ spec:
               value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENV
               value: {{ .Values.sentry.environment }}
+            {{ if .Values.nWorkers }}
+            - name: RENKU_SVC_NUM_WORKERS
+              value: {{ .Values.nWorkers | quote }}
+            {{ end }}
+            {{ if .Values.nThreads }}
+            - name: RENKU_SVC_NUM_THREADS
+              value: {{ .Values.nThreads | quote }}
+            {{ end }}
           volumeMounts:
             - name: shared-volume
               mountPath: {{ .Values.cacheDirectory }}

--- a/helm-chart/renku-core/values.yaml
+++ b/helm-chart/renku-core/values.yaml
@@ -22,8 +22,8 @@ gitLFSSkipSmudge: 1
 jwtTokenSecret: bW9menZ3cnh6cWpkcHVuZ3F5aWJycmJn
 
 image:
-  repository: renku/renku-core
-  tag: 'latest'
+  repository: rrrrrok/renku-core
+  tag: '0.12.1-9f7fb95a'
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/helm-chart/renku-core/values.yaml
+++ b/helm-chart/renku-core/values.yaml
@@ -18,12 +18,16 @@ logLevel: INFO
 # override to automatically pull LFS data on clone
 gitLFSSkipSmudge: 1
 
+# concurrency settings for the main service
+nWorkers:
+nThreads:
+
 # NOTE: Make sure token secret is greater or equal to 32 bytes.
 jwtTokenSecret: bW9menZ3cnh6cWpkcHVuZ3F5aWJycmJn
 
 image:
-  repository: rrrrrok/renku-core
-  tag: '0.12.1-9f7fb95a'
+  repository: renku/renku-core
+  tag: 'latest'
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
this PR allows the renkulab admin to set the gunicorn worker config via helm values. 

~~edit: I can't get the values to work if I pass them via `--set core.nWorkers=4` with `helm`, for example... but they work if I set them in the values file~~