### PR TITLE
chore: use sensible defaults for worker parallelism

### DIFF
--- a/Dockerfile.svc
+++ b/Dockerfile.svc
@@ -29,8 +29,8 @@ RUN if [ -n "${CLEAN_INSTALL}" ]; then git reset --hard ; fi && pip install -e .
 # writing down renga verses and for the proceedings of the renga.
 USER shuhitsu
 
-ENV RENKU_SVC_NUM_WORKERS 1
-ENV RENKU_SVC_NUM_THREADS 1
+ENV RENKU_SVC_NUM_WORKERS 4
+ENV RENKU_SVC_NUM_THREADS 8
 CMD [ \
     "sh", "-c", \
     "gunicorn \

--- a/helm-chart/renku-core/values.yaml
+++ b/helm-chart/renku-core/values.yaml
@@ -18,7 +18,8 @@ logLevel: INFO
 # override to automatically pull LFS data on clone
 gitLFSSkipSmudge: 1
 
-# concurrency settings for the main service
+# Concurrency settings for the main service:
+# the default it 4 workers with 8 threads set in the Dockerfile
 nWorkers:
 nThreads:
 


### PR DESCRIPTION
Sets the default to use threading so the service can respond to k8s probes while serving requests. 