### PR TITLE
test: fix git commit hook tests on python3.6

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -125,6 +125,9 @@ jobs:
         git config --global --add user.name "Renku @ SDSC"
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
+      env:
+        LANG: en_US.UTF-8
+        LC_ALL: en_US.UTF-8
       run: pytest -v -m "not integration and not publish and not serial" -n auto tests/api
     - name: Coveralls
       env:
@@ -161,8 +164,14 @@ jobs:
         git config --global --add user.name "Renku @ SDSC"
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
+      env:
+        LANG: en_US.UTF-8
+        LC_ALL: en_US.UTF-8
       run: pytest -v -m "not integration and not publish and not serial" -n auto  tests/cli
     - name: Test with pytest(serial)
+      env:
+        LANG: en_US.UTF-8
+        LC_ALL: en_US.UTF-8
       run: pytest -v -m "not integration and not publish and serial"  tests/cli
     - name: Coveralls
       env:
@@ -199,8 +208,14 @@ jobs:
           git config --global --add user.name "Renku @ SDSC"
           git config --global --add user.email "renku@datascience.ch"
       - name: Test with pytest
+        env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
         run: pytest -v -m "not integration and not publish and not serial" -n auto tests/core
       - name: Test with pytest(serial)
+        env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
         run: pytest -v -m "not integration and not publish and serial" tests/core
       - name: Coveralls
         env:
@@ -237,6 +252,9 @@ jobs:
           git config --global --add user.name "Renku @ SDSC"
           git config --global --add user.email "renku@datascience.ch"
       - name: Test with pytest
+        env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
         run: pytest -v -m "not integration and not publish" -n auto tests/service
       - name: Coveralls
         env:
@@ -271,6 +289,8 @@ jobs:
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
       env:
+        LANG: en_US.UTF-8
+        LC_ALL: en_US.UTF-8
         RENKU_REQUESTS_TIMEOUT_SECONDS: 120
       run: pytest -v -m "not integration and not publish and not serial" tests/api
 
@@ -300,10 +320,14 @@ jobs:
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
       env:
+        LANG: en_US.UTF-8
+        LC_ALL: en_US.UTF-8
         RENKU_REQUESTS_TIMEOUT_SECONDS: 120
       run: pytest -v -m "not integration and not publish and not serial" tests/cli
     - name: Test with pytest(serial)
       env:
+        LANG: en_US.UTF-8
+        LC_ALL: en_US.UTF-8
         RENKU_REQUESTS_TIMEOUT_SECONDS: 120
       run: pytest -v -m "not integration and not publish and serial" tests/cli
 
@@ -333,10 +357,14 @@ jobs:
           git config --global --add user.email "renku@datascience.ch"
       - name: Test with pytest
         env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
           RENKU_REQUESTS_TIMEOUT_SECONDS: 120
         run: pytest -v -m "not integration and not publish and not serial" tests/core
       - name: Test with pytest(serial)
         env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
           RENKU_REQUESTS_TIMEOUT_SECONDS: 120
         run: pytest -v -m "not integration and not publish and serial" tests/core
 
@@ -366,6 +394,8 @@ jobs:
           git config --global --add user.email "renku@datascience.ch"
       - name: Test with pytest
         env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
           RENKU_REQUESTS_TIMEOUT_SECONDS: 120
         run: pytest -v -m "not integration and not publish" tests/service
 
@@ -397,6 +427,8 @@ jobs:
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
       env:
+        LANG: en_US.UTF-8
+        LC_ALL: en_US.UTF-8
         DATAVERSE_ACCESS_TOKEN: ${{ secrets.DATAVERSE_ACCESS_TOKEN }}
         IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
         ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
@@ -430,6 +462,8 @@ jobs:
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
       env:
+        LANG: en_US.UTF-8
+        LC_ALL: en_US.UTF-8
         DATAVERSE_ACCESS_TOKEN: ${{ secrets.DATAVERSE_ACCESS_TOKEN }}
         IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
         ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}

--- a/renku/data/pre-commit.sh
+++ b/renku/data/pre-commit.sh
@@ -66,7 +66,7 @@ if [ ${#MODIFIED_FILES[@]} -ne 0 ] ; then
     echo 'To commit anyway, use "git commit --no-verify".'
     exit 1
   fi
-  IMMUTABLE_TEMPLATE_FILES=$(renku migrate check-immutable-template-files "${MODIFIED_FILES[@]}")
+  IMMUTABLE_TEMPLATE_FILES=$(renku check-immutable-template-files "${MODIFIED_FILES[@]}")
   if [ "$IMMUTABLE_TEMPLATE_FILES" ]; then
     echo 'You are trying to update files marked as immutable in your project template.'
     echo 'This would prevent the project from being updated with new versions of the template in the future.'

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1292,9 +1292,9 @@ def test_lfs_hook(runner, client, subdirectory, large_file):
     # Commit fails when file is not tracked in LFS
     with pytest.raises(git.exc.HookExecutionError) as e:
         client.repo.index.commit("large files not in LFS")
-        output = str(e)
-        assert "You are trying to commit large files to Git" in output
-        assert large_file.name in output
+
+    assert "You are trying to commit large files to Git" in e.value.stdout
+    assert large_file.name in e.value.stdout
 
     # Can be committed after being tracked in LFS
     client.track_paths_in_storage(large_file.name)
@@ -1310,7 +1310,11 @@ def test_lfs_hook_autocommit(runner, client, subdirectory, large_file):
     shutil.copy(large_file, client.path)
     client.repo.git.add("--all")
 
-    result = client.repo.git.commit(message="large files not in LFS", with_extended_output=True)
+    result = client.repo.git.commit(
+        message="large files not in LFS",
+        with_extended_output=True,
+        env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"},
+    )
     assert large_file.name in result[1]
     assert ".gitattributes" in result[1]
     assert "You are trying to commit large files to Git instead of Git-LFS" in result[2]
@@ -1325,7 +1329,11 @@ def test_lfs_hook_autocommit_env(runner, client, subdirectory, large_file):
     shutil.copy(large_file, client.path)
     client.repo.git.add("--all")
 
-    result = client.repo.git.commit(message="large files not in LFS", with_extended_output=True)
+    result = client.repo.git.commit(
+        message="large files not in LFS",
+        with_extended_output=True,
+        env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"},
+    )
     assert large_file.name in result[1]
     assert ".gitattributes" in result[1]
     assert "You are trying to commit large files to Git instead of Git-LFS" in result[2]

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -113,7 +113,8 @@ def test_git_pre_commit_hook(runner, project, capsys):
     repo.git.add("--all")
     with pytest.raises(git.HookExecutionError) as error:
         repo.index.commit("hello")
-        assert output.name in error.stdout
+
+    assert output.name in error.value.stdout
 
     result = runner.invoke(cli, ["githooks", "uninstall"])
     assert 0 == result.exit_code
@@ -133,9 +134,9 @@ def test_git_pre_commit_hook_in_old_project(isolated_runner, old_dataset_project
     with pytest.raises(git.exc.HookExecutionError) as e:
         old_dataset_project.repo.index.commit("update project metadata")
 
-    assert "Cannot verify validity of the commit: Project metadata is outdated." in str(e.value)
-    assert "Run 'renku migrate' command to fix the issue." in str(e.value)
-    assert "You are trying to update generated files" not in str(e.value)
+    assert "Cannot verify validity of the commit: Project metadata is outdated." in str(e.value.stdout)
+    assert "Run 'renku migrate' command to fix the issue." in str(e.value.stdout)
+    assert "You are trying to update generated files" not in str(e.value.stdout)
 
 
 def test_git_pre_commit_hook_in_unsupported_project(unsupported_project):
@@ -148,9 +149,11 @@ def test_git_pre_commit_hook_in_unsupported_project(unsupported_project):
     with pytest.raises(git.exc.HookExecutionError) as e:
         unsupported_project.repo.index.commit("update project metadata")
 
-    assert "Cannot verify validity of the commit: Project was created with a newer version of Renku." in str(e.value)
-    assert "Upgrade Renku to the latest version." in str(e.value)
-    assert "You are trying to update generated files" not in str(e.value)
+    assert "Cannot verify validity of the commit: Project was created with a newer version of Renku." in str(
+        e.value.stdout
+    )
+    assert "Upgrade Renku to the latest version." in str(e.value.stdout)
+    assert "You are trying to update generated files" not in str(e.value.stdout)
 
 
 def test_workflow(runner, project):


### PR DESCRIPTION
Fixes locale problem with pytest, gitpython, click and python3.6
Fixes GitHookException stdout in case where messages are too long.