### PR TITLE
chore: add acceptance test action

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -58,7 +58,7 @@ jobs:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
         RENKU_ANONYMOUS_SESSIONS: false
         RENKU_TESTS_ENABLED: true
-        renku: "@development"
+        renku: "@000-deploy-action"
         renku_core: "@${{ github.head_ref }}"
   test-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - id: deploy-comment
-      uses: SwissDataScienceCenter/actions/check-pr-description@000-deploy-action
+      uses: SwissDataScienceCenter/renku/actions/check-pr-description@000-deploy-action
       with:
         string: /deploy
         pr_ref: ${{ github.event.number }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - run: echo $REPO_NAME
+      env:
+        REPO_NAME: ${{ github.repository.name }}
     - name: renku build and deploy
       uses: SwissDataScienceCenter/renku/actions/deploy-renku@000-deploy-action
       env:
@@ -27,9 +30,9 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
         KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
-        RENKU_NAMESPACE: ci-renku-python-${{ github.event.number }}
-        RENKU_TMP_NAMESPACE: ci-renku-python-${{ github.event.number }}-tmp
-        RENKU_RELEASE: ci-renku-python-${{ github.event.number }}
+        RENKU_NAMESPACE: ci-rp-${{ github.event.number }}-renku
+        RENKU_TMP_NAMESPACE: ci-rp-${{ github.event.number }}-renku-tmp
+        RENKU_RELEASE: ci-rp-${{ github.event.number }}-renku
         RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
         RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
@@ -52,10 +55,10 @@ jobs:
     - name: Test the PR
       env:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
-        RENKU_RELEASE: "ci-renku-python-${{ github.event.number }}"
+        RENKU_RELEASE: "ci-rp-${{ github.event.number }}-renku"
       run: |
         RENKU_PYTHON_VERSION=$(git rev-parse HEAD)
-        echo "Passing renku-python version $RENKU_PYTHON_VERSION"
+        echo "Passing rp version $RENKU_PYTHON_VERSION"
 
         git clone https://github.com/SwissDataScienceCenter/renku.git /tmp/renku
         cd /tmp/renku/
@@ -92,6 +95,6 @@ jobs:
         GITLAB_TOKEN: ${{ secrets.GITLAB_DEV_TOKEN }}
         KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_KUBECONFIG }}
-        RENKU_RELEASE: ci-renku-python-${{ github.event.number }}
-        RENKU_NAMESPACE: ci-renku-python-${{ github.event.number }}
-        RENKU_TMP_NAMESPACE: ci-renku-python-${{ github.event.number }}-tmp
+        RENKU_RELEASE: ci-rp-${{ github.event.number }}-renku
+        RENKU_NAMESPACE: ci-rp-${{ github.event.number }}-renku
+        RENKU_TMP_NAMESPACE: ci-rp-${{ github.event.number }}-renku-tmp

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - id: deploy-comment
-      uses: ./actions/check-pr-description
+      uses: SwissDataScienceCenter/actions/check-pr-description@000-deploy-action
       with:
         string: /deploy
         pr_ref: ${{ github.event.number }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -8,17 +8,13 @@ on:
     - synchronize
     - reopened
     - closed
-    paths:
-    # - renku/service/**
-    # - renku/core/**
-    # - helm-chart/**
 
 jobs:
   deploy-pr:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     environment:
-      name: ci-renku-${{ github.event.number }}
+      name: ci-rp-${{ github.event.number }}
     steps:
     - uses: actions/checkout@v2
     - id: deploy-comment
@@ -26,23 +22,8 @@ jobs:
       with:
         string: /deploy
         pr_ref: ${{ github.event.number }}
-    - name: Check existing renkubot comment
-      if: steps.deploy-comment.outputs.pr-contains-string
-      uses: peter-evans/find-comment@v1
-      id: findcomment
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'RenkuBot'
-    - name: Create comment pre deploy
-      if: "steps.findcomment.outputs.comment-id == 0 && steps.deploy-comment.outputs.pr-contains-string == true"
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
-        issue-number: ${{ github.event.pull_request.number }}
-        body: |
-          You can access the deployment of this PR at https://ci-renku-${{ github.event.number }}.dev.renku.ch
-    - name: renku build and deploy
-      if: steps.deploy-comment.outputs.pr-contains-string == true
+    - name: deploy-pr
+      if: steps.deploy-comment.outputs.pr-contains-string == 'true'
       uses: SwissDataScienceCenter/renku/actions/deploy-renku@000-deploy-action
       env:
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
@@ -60,6 +41,22 @@ jobs:
         RENKU_TESTS_ENABLED: true
         renku: "@000-deploy-action"
         renku_core: "@${{ github.head_ref }}"
+    - name: Check existing renkubot comment
+      if: steps.deploy-comment.outputs.pr-contains-string
+      uses: peter-evans/find-comment@v1
+      id: findcomment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'RenkuBot'
+    - name: Create comment pre deploy
+      if: steps.findcomment.outputs.comment-id == 0 && steps.deploy-comment.outputs.pr-contains-string == 'true'
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          You can access the deployment of this PR at https://ci-rp-${{ github.event.number }}.dev.renku.ch
+
   test-pr:
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
@@ -74,7 +71,7 @@ jobs:
         sudo apt-get update -y && sudo apt-get install -y grep
         pip install yq
     - name: Test the PR
-      if: steps.deploy-comment.outputs.pr-contains-string == true
+      if: steps.deploy-comment.outputs.pr-contains-string == 'true'
       env:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
         RENKU_RELEASE: "ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true'
     runs-on: ubuntu-20.04
     environment:
-      name: ci-rp-${{ github.event.number }}
+      name: renku-ci-rp-${{ github.event.number }}
     steps:
     - name: deploy-pr
       uses: SwissDataScienceCenter/renku/actions/deploy-renku@master
@@ -42,7 +42,7 @@ jobs:
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
         KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
         RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
-        RENKU_RELEASE: ci-rp-${{ github.event.number }}
+        RENKU_RELEASE: renku-ci-rp-${{ github.event.number }}
         RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
         RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
@@ -66,7 +66,7 @@ jobs:
         token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          You can access the deployment of this PR at https://ci-rp-${{ github.event.number }}.dev.renku.ch
+          You can access the deployment of this PR at https://renku-ci-rp-${{ github.event.number }}.dev.renku.ch
 
   test-pr:
     runs-on: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
       if: needs.check-deploy.outputs.pr-contains-string == 'true'
       env:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
-        RENKU_RELEASE: "ci-rp-${{ github.event.number }}"
+        RENKU_RELEASE: "renku-ci-rp-${{ github.event.number }}"
       run: |
         RENKU_PYTHON_VERSION=$(git rev-parse HEAD)
         echo "Passing rp version $RENKU_PYTHON_VERSION"
@@ -125,4 +125,4 @@ jobs:
         GITLAB_TOKEN: ${{ secrets.GITLAB_DEV_TOKEN }}
         KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
-        RENKU_RELEASE: ci-rp-${{ github.event.number }}
+        RENKU_RELEASE: renku-ci-rp-${{ github.event.number }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -27,14 +27,14 @@ jobs:
         string: /deploy
         pr_ref: ${{ github.event.number }}
     - name: Check existing renkubot comment
-      if: ${{ steps.deploy-comment.outputs.pr-contains-string }}
+      if: steps.deploy-comment.outputs.pr-contains-string
       uses: peter-evans/find-comment@v1
       id: findcomment
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'RenkuBot'
     - name: Create comment pre deploy
-      if: "steps.findcomment.outputs.comment-id == 0 && steps.deploy-comment.outputs.pr-contains-string"
+      if: "steps.findcomment.outputs.comment-id == 0 && steps.deploy-comment.outputs.pr-contains-string == true"
       uses: peter-evans/create-or-update-comment@v1
       with:
         token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
@@ -42,7 +42,7 @@ jobs:
         body: |
           You can access the deployment of this PR at https://ci-renku-${{ github.event.number }}.dev.renku.ch
     - name: renku build and deploy
-      if: ${{ steps.deploy-comment.outputs.pr-contains-string }}
+      if: steps.deploy-comment.outputs.pr-contains-string == true
       uses: SwissDataScienceCenter/renku/actions/deploy-renku@000-deploy-action
       env:
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
@@ -50,7 +50,7 @@ jobs:
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
         KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
         RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
-        RENKU_RELEASE: ci-renku-${{ github.event.number }}
+        RENKU_RELEASE: ci-rp-${{ github.event.number }}
         RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
         RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
@@ -74,6 +74,7 @@ jobs:
         sudo apt-get update -y && sudo apt-get install -y grep
         pip install yq
     - name: Test the PR
+      if: steps.deploy-comment.outputs.pr-contains-string == true
       env:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
         RENKU_RELEASE: "ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -16,7 +16,7 @@ jobs:
       pr-contains-string: ${{ steps.deploy-comment.outputs.pr-contains-string }}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku/actions/check-pr-description@000-deploy-action
+        uses: SwissDataScienceCenter/renku/actions/check-pr-description
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -28,7 +28,7 @@ jobs:
       name: ci-rp-${{ github.event.number }}
     steps:
     - name: deploy-pr
-      uses: SwissDataScienceCenter/renku/actions/deploy-renku@000-deploy-action
+      uses: SwissDataScienceCenter/renku/actions/deploy-renku
       env:
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -43,7 +43,6 @@ jobs:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
         RENKU_ANONYMOUS_SESSIONS: false
         RENKU_TESTS_ENABLED: true
-        renku: "@000-deploy-action"
         renku_core: "@${{ github.head_ref }}"
     - name: Check existing renkubot comment
       uses: peter-evans/find-comment@v1
@@ -113,7 +112,7 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
-    - uses: SwissDataScienceCenter/renku/actions/teardown-renku@000-deploy-action
+    - uses: SwissDataScienceCenter/renku/actions/teardown-renku
       env:
         GITLAB_TOKEN: ${{ secrets.GITLAB_DEV_TOKEN }}
         KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -17,26 +17,47 @@ jobs:
   deploy-pr:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    environment:
+      name: ci-renku-${{ github.event.number }}
     steps:
     - uses: actions/checkout@v2
-    - run: echo $REPO_NAME
-      env:
-        REPO_NAME: ${{ github.event.repository.name }}
+    - id: deploy-comment
+      uses: ./actions/check-pr-description
+      with:
+        string: /deploy
+        pr_ref: ${{ github.event.number }}
+    - name: Check existing renkubot comment
+      if: ${{ steps.deploy-comment.outputs.pr-contains-string }}
+      uses: peter-evans/find-comment@v1
+      id: findcomment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'RenkuBot'
+    - name: Create comment pre deploy
+      if: "steps.findcomment.outputs.comment-id == 0 && steps.deploy-comment.outputs.pr-contains-string"
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          You can access the deployment of this PR at https://ci-renku-${{ github.event.number }}.dev.renku.ch
     - name: renku build and deploy
+      if: ${{ steps.deploy-comment.outputs.pr-contains-string }}
       uses: SwissDataScienceCenter/renku/actions/deploy-renku@000-deploy-action
       env:
-        RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
         KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
-        RENKU_NAMESPACE: ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku
-        RENKU_TMP_NAMESPACE: ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku-tmp
-        RENKU_RELEASE: ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku
+        RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
+        RENKU_RELEASE: ci-renku-${{ github.event.number }}
         RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
         RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
+        RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
+        RENKU_ANONYMOUS_SESSIONS: false
+        RENKU_TESTS_ENABLED: true
         renku: "@development"
         renku_core: "@${{ github.head_ref }}"
   test-pr:
@@ -71,7 +92,7 @@ jobs:
                            -e RENKU_TEST_REGISTER="1" \
                            -e RENKU_TEST_USERNAME="renku-test" \
                            -e RENKU_TEST_PASSWORD="$RENKU_BOT_DEV_PASSWORD" \
-                           -e RENKU_TEST_ANON_AVAILABLE="true" sbt
+                           -e RENKU_TEST_ANON_AVAILABLE="false" sbt
     - name: Prepare artifact for packaging on failure
       if: failure()
       run: |

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -113,7 +113,7 @@ jobs:
       env:
         GITLAB_TOKEN: ${{ secrets.GITLAB_DEV_TOKEN }}
         KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
-        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_KUBECONFIG }}
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         RENKU_RELEASE: ci-rp-${{ github.event.number }}-renku
         RENKU_NAMESPACE: ci-rp-${{ github.event.number }}-renku
         RENKU_TMP_NAMESPACE: ci-rp-${{ github.event.number }}-renku-tmp

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -78,7 +78,7 @@ jobs:
       if: needs.check-deploy.outputs.pr-contains-string == 'true'
       env:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
-        RENKU_RELEASE: "ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku"
+        RENKU_RELEASE: "ci-rp-${{ github.event.number }}"
       run: |
         RENKU_PYTHON_VERSION=$(git rev-parse HEAD)
         echo "Passing rp version $RENKU_PYTHON_VERSION"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,0 +1,28 @@
+name: Acceptance tests
+
+on:
+  pull_request: []
+    # paths: ['renku/service']
+
+jobs:
+  deploy-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: renku build and deploy
+      uses: SwissDataScienceCenter/renku/actions/deploy-renku@000-deploy-action
+      env:
+        RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
+        DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
+        DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
+        KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
+        RENKU_NAMESPACE: ci-renku-python-${{ github.event.number }}-renku
+        RENKU_TMP_NAMESPACE: ci-renku-python-${{ github.event.number }}-renku-tmp
+        RENKU_RELEASE: ci-renku-python-${{ github.event.number }}-renku
+        RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
+        RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
+        RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
+        renku: "@development"
+        renku_core: "@${{ github.head_ref }}"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,8 +1,13 @@
 name: Acceptance tests
 
 on:
-  pull_request: []
-    # paths: ['renku/service']
+  pull_request:
+    types:
+    - opened
+    - edited
+    - synchronize
+    - reopened
+    - closed
 
 jobs:
   deploy-pr:
@@ -42,9 +47,8 @@ jobs:
     - name: Test the PR
       env:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
+        RENKU_RELEASE: "ci-renku-python-${{ github.event.number }}-renku"
       run: |
-        export RENKU_RELEASE="ci-renku-python-${{ github.event.number }}-renku"
-
         RENKU_PYTHON_VERSION=$(git rev-parse HEAD)
         echo "Passing renku-python version $RENKU_PYTHON_VERSION"
 
@@ -74,3 +78,29 @@ jobs:
       with:
         name: acceptance-test-artifacts
         path: test-artifacts
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker://alpine/k8s:1.16.8
+      name: k8s teardown
+      env:
+        KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_KUBECONFIG }}
+        RENKU_RELEASE: "ci-${{ github.event.number }}-renku"
+        RENKU_NAMESPACE: "ci-${{ github.event.number }}-renku"
+      run: |
+          echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
+          chmod 400 renkubot-kube.config
+          kubectl delete ns $RENKU_NAMESPACE
+          kubectl delete ns $RENKU_NAMESPACE-tmp
+    - name: gitlab teardown
+      env:
+        GITLAB_TOKEN: ${{ secrets.GITLAB_DEV_TOKEN }}
+        RENKU_RELEASE: "ci-${{ github.event.number }}-renku"
+      run: |
+        apps=$(curl -s https://dev.renku.ch/gitlab/api/v4/applications -H "private-token: ${GITLAB_TOKEN}" | jq -r ".[] | select(.application_name == \"${RENKU_RELEASE}\") | .id")
+        for app in $apps
+        do
+          curl -X DELETE https://dev.renku.ch/gitlab/api/v4/applications/${app} -H "private-token: ${GITLAB_TOKEN}"
+        done

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -9,9 +9,9 @@ on:
     - reopened
     - closed
     paths:
-    - renku/service
-    - renku/core
-    - helm-chart
+    - renku/service/**
+    - renku/core/**
+    - helm-chart/**
 
 jobs:
   deploy-pr:
@@ -27,9 +27,9 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
         KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
-        RENKU_NAMESPACE: ci-renku-python-${{ github.event.number }}-renku
-        RENKU_TMP_NAMESPACE: ci-renku-python-${{ github.event.number }}-renku-tmp
-        RENKU_RELEASE: ci-renku-python-${{ github.event.number }}-renku
+        RENKU_NAMESPACE: ci-renku-python-${{ github.event.number }}
+        RENKU_TMP_NAMESPACE: ci-renku-python-${{ github.event.number }}-tmp
+        RENKU_RELEASE: ci-renku-python-${{ github.event.number }}
         RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
         RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
@@ -52,7 +52,7 @@ jobs:
     - name: Test the PR
       env:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
-        RENKU_RELEASE: "ci-renku-python-${{ github.event.number }}-renku"
+        RENKU_RELEASE: "ci-renku-python-${{ github.event.number }}"
       run: |
         RENKU_PYTHON_VERSION=$(git rev-parse HEAD)
         echo "Passing renku-python version $RENKU_PYTHON_VERSION"
@@ -87,26 +87,11 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
-    - uses: docker://alpine/k8s:1.16.8
-      name: k8s teardown
-      env:
-        KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
-        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_KUBECONFIG }}
-        RENKU_RELEASE: "ci-${{ github.event.number }}-renku"
-        RENKU_NAMESPACE: "ci-${{ github.event.number }}-renku"
-      with:
-        command: |
-          echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
-          chmod 400 renkubot-kube.config
-          kubectl delete ns $RENKU_NAMESPACE
-          kubectl delete ns $RENKU_NAMESPACE-tmp
-    - name: gitlab teardown
+    - uses: SwissDataScienceCenter/renku/actions/teardown-renku@000-deploy-action
       env:
         GITLAB_TOKEN: ${{ secrets.GITLAB_DEV_TOKEN }}
-        RENKU_RELEASE: "ci-${{ github.event.number }}-renku"
-      run: |
-        apps=$(curl -s https://dev.renku.ch/gitlab/api/v4/applications -H "private-token: ${GITLAB_TOKEN}" | jq -r ".[] | select(.application_name == \"${RENKU_RELEASE}\") | .id")
-        for app in $apps
-        do
-          curl -X DELETE https://dev.renku.ch/gitlab/api/v4/applications/${app} -H "private-token: ${GITLAB_TOKEN}"
-        done
+        KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
+        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_KUBECONFIG }}
+        RENKU_RELEASE: ci-renku-python-${{ github.event.number }}
+        RENKU_NAMESPACE: ci-renku-python-${{ github.event.number }}
+        RENKU_TMP_NAMESPACE: ci-renku-python-${{ github.event.number }}-tmp

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -48,7 +48,7 @@ jobs:
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
-        RENKU_ANONYMOUS_SESSIONS: false
+        RENKU_ANONYMOUS_SESSIONS: true
         RENKU_TESTS_ENABLED: true
         renku_core: "@${{ github.head_ref }}"
         renku: "@development"
@@ -101,7 +101,7 @@ jobs:
                            -e RENKU_TEST_REGISTER="1" \
                            -e RENKU_TEST_USERNAME="renku-test" \
                            -e RENKU_TEST_PASSWORD="$RENKU_BOT_DEV_PASSWORD" \
-                           -e RENKU_TEST_ANON_AVAILABLE="false" sbt
+                           -e RENKU_TEST_ANON_AVAILABLE="true" sbt
     - name: Prepare artifact for packaging on failure
       if: failure()
       run: |

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   deploy-pr:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -51,6 +51,7 @@ jobs:
         RENKU_ANONYMOUS_SESSIONS: false
         RENKU_TESTS_ENABLED: true
         renku_core: "@${{ github.head_ref }}"
+        renku: "@development"
     - name: Check existing renkubot comment
       uses: peter-evans/find-comment@v1
       id: findcomment
@@ -124,4 +125,4 @@ jobs:
         GITLAB_TOKEN: ${{ secrets.GITLAB_DEV_TOKEN }}
         KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
-        RENKU_RELEASE: ci-rp-${{ github.event.number }}-renku
+        RENKU_RELEASE: ci-rp-${{ github.event.number }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -8,6 +8,10 @@ on:
     - synchronize
     - reopened
     - closed
+    paths:
+    - renku/service
+    - renku/core
+    - helm-chart
 
 jobs:
   deploy-pr:
@@ -89,7 +93,8 @@ jobs:
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_KUBECONFIG }}
         RENKU_RELEASE: "ci-${{ github.event.number }}-renku"
         RENKU_NAMESPACE: "ci-${{ github.event.number }}-renku"
-      run: |
+      with:
+        command: |
           echo "$RENKUBOT_KUBECONFIG" > renkubot-kube.config
           chmod 400 renkubot-kube.config
           kubectl delete ns $RENKU_NAMESPACE

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -118,5 +118,3 @@ jobs:
         KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         RENKU_RELEASE: ci-rp-${{ github.event.number }}-renku
-        RENKU_NAMESPACE: ci-rp-${{ github.event.number }}-renku
-        RENKU_TMP_NAMESPACE: ci-rp-${{ github.event.number }}-renku-tmp

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -9,9 +9,9 @@ on:
     - reopened
     - closed
     paths:
-    - renku/service/**
-    - renku/core/**
-    - helm-chart/**
+    # - renku/service/**
+    # - renku/core/**
+    # - helm-chart/**
 
 jobs:
   deploy-pr:
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2
     - run: echo $REPO_NAME
       env:
-        REPO_NAME: ${{ github.repository.name }}
+        REPO_NAME: ${{ github.event.repository.name }}
     - name: renku build and deploy
       uses: SwissDataScienceCenter/renku/actions/deploy-renku@000-deploy-action
       env:
@@ -30,9 +30,9 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
         KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
-        RENKU_NAMESPACE: ci-rp-${{ github.event.number }}-renku
-        RENKU_TMP_NAMESPACE: ci-rp-${{ github.event.number }}-renku-tmp
-        RENKU_RELEASE: ci-rp-${{ github.event.number }}-renku
+        RENKU_NAMESPACE: ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku
+        RENKU_TMP_NAMESPACE: ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku-tmp
+        RENKU_RELEASE: ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku
         RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
         RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
@@ -55,7 +55,7 @@ jobs:
     - name: Test the PR
       env:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
-        RENKU_RELEASE: "ci-rp-${{ github.event.number }}-renku"
+        RENKU_RELEASE: "ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku"
       run: |
         RENKU_PYTHON_VERSION=$(git rev-parse HEAD)
         echo "Passing rp version $RENKU_PYTHON_VERSION"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -51,7 +51,9 @@ jobs:
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'RenkuBot'
+        body-includes: "You can access the deployment of this PR at"
     - name: Create comment pre deploy
+      if: steps.findcomment.outputs.comment-id == 0
       uses: peter-evans/create-or-update-comment@v1
       with:
         token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -10,20 +10,24 @@ on:
     - closed
 
 jobs:
+  check-deploy:
+    runs-on: ubuntu-20.04
+    outputs:
+      pr-contains-string: ${{ steps.deploy-comment.outputs.pr-contains-string }}
+    steps:
+      - id: deploy-comment
+        uses: SwissDataScienceCenter/renku/actions/check-pr-description@000-deploy-action
+        with:
+          string: /deploy
+          pr_ref: ${{ github.event.number }}
   deploy-pr:
-    if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
+    needs: check-deploy
+    if: github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true'
+    runs-on: ubuntu-20.04
     environment:
       name: ci-rp-${{ github.event.number }}
     steps:
-    - uses: actions/checkout@v2
-    - id: deploy-comment
-      uses: SwissDataScienceCenter/renku/actions/check-pr-description@000-deploy-action
-      with:
-        string: /deploy
-        pr_ref: ${{ github.event.number }}
     - name: deploy-pr
-      if: steps.deploy-comment.outputs.pr-contains-string == 'true'
       uses: SwissDataScienceCenter/renku/actions/deploy-renku@000-deploy-action
       env:
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
@@ -42,14 +46,12 @@ jobs:
         renku: "@000-deploy-action"
         renku_core: "@${{ github.head_ref }}"
     - name: Check existing renkubot comment
-      if: steps.deploy-comment.outputs.pr-contains-string
       uses: peter-evans/find-comment@v1
       id: findcomment
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'RenkuBot'
     - name: Create comment pre deploy
-      if: steps.findcomment.outputs.comment-id == 0 && steps.deploy-comment.outputs.pr-contains-string == 'true'
       uses: peter-evans/create-or-update-comment@v1
       with:
         token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
@@ -60,7 +62,7 @@ jobs:
   test-pr:
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
-    needs: deploy-pr
+    needs: [check-deploy, deploy-pr]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
@@ -71,7 +73,7 @@ jobs:
         sudo apt-get update -y && sudo apt-get install -y grep
         pip install yq
     - name: Test the PR
-      if: steps.deploy-comment.outputs.pr-contains-string == 'true'
+      if: needs.check-deploy.outputs.pr-contains-string == 'true'
       env:
         RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
         RENKU_RELEASE: "ci-${{ github.event.repository.name }}-${{ github.event.number }}-renku"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -10,13 +10,20 @@ on:
     - closed
 
 jobs:
+  cleanup-previous-runs:
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    steps:
+    - uses: rokroskar/workflow-run-cleanup-action@master
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   check-deploy:
     runs-on: ubuntu-20.04
     outputs:
       pr-contains-string: ${{ steps.deploy-comment.outputs.pr-contains-string }}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku/actions/check-pr-description
+        uses: SwissDataScienceCenter/renku/actions/check-pr-description@master
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -28,7 +35,7 @@ jobs:
       name: ci-rp-${{ github.event.number }}
     steps:
     - name: deploy-pr
-      uses: SwissDataScienceCenter/renku/actions/deploy-renku
+      uses: SwissDataScienceCenter/renku/actions/deploy-renku@master
       env:
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -112,7 +119,7 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
-    - uses: SwissDataScienceCenter/renku/actions/teardown-renku
+    - uses: SwissDataScienceCenter/renku/actions/teardown-renku@master
       env:
         GITLAB_TOKEN: ${{ secrets.GITLAB_DEV_TOKEN }}
         KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -26,3 +26,51 @@ jobs:
         RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
         renku: "@development"
         renku_core: "@${{ github.head_ref }}"
+  test-pr:
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    needs: deploy-pr
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -y && sudo apt-get install -y grep
+        pip install yq
+    - name: Test the PR
+      env:
+        RENKU_BOT_DEV_PASSWORD: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
+      run: |
+        export RENKU_RELEASE="ci-renku-python-${{ github.event.number }}-renku"
+
+        RENKU_PYTHON_VERSION=$(git rev-parse HEAD)
+        echo "Passing renku-python version $RENKU_PYTHON_VERSION"
+
+        git clone https://github.com/SwissDataScienceCenter/renku.git /tmp/renku
+        cd /tmp/renku/
+        git checkout development
+        cd acceptance-tests
+        COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build --build-arg renku_python_ref=${RENKU_PYTHON_VERSION} sbt
+        docker-compose run -e RENKU_TEST_URL=https://${RENKU_RELEASE}.dev.renku.ch \
+                           -e RENKU_TEST_FULL_NAME="Renku Bot" \
+                           -e RENKU_TEST_EMAIL="renku@datascience.ch" \
+                           -e RENKU_TEST_REGISTER="1" \
+                           -e RENKU_TEST_USERNAME="renku-test" \
+                           -e RENKU_TEST_PASSWORD="$RENKU_BOT_DEV_PASSWORD" \
+                           -e RENKU_TEST_ANON_AVAILABLE="true" sbt
+    - name: Prepare artifact for packaging on failure
+      if: failure()
+      run: |
+        mkdir test-artifacts
+        cp target/*.png test-artifacts 2>/dev/null || :
+        cp target/*.log test-artifacts 2>/dev/null || :
+        sudo rm -rf target/20*/.renku/cache 2>/dev/null || :
+        cp -r target/20* test-artifacts 2>/dev/null || :
+    - name: Upload screenshots on failure
+      if: failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: acceptance-test-artifacts
+        path: test-artifacts


### PR DESCRIPTION
Adds an action to automatically deploy renku to a clean namespace and run acceptance tests. Only runs on PRs that affect the service. 

Points left to do:

1. determine when this should run
2. how to do the teardown

For 1. it was discussed that this should run on all PRs that push changes to `service` and `core` but to not be required for PRs to pass because of possible issues with dependencies with other components. It should also run on `master` and tags. 

For 2. I would leave it as it is done in the main renku repo atm, which is that the deployment gets destroyed after the PR is closed. But maybe in the near future this should change to doing a `helm uninstall` if the tests pass to release some of the resources followed by a namespace delete after the PR is merged. If we delete the namespace right away we run into issues with LetsEncrypt rate limiting if the tests have to run again. 

/deploy
