### PR TITLE
feat(dataset): dataset provenance in a single file

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -68,19 +68,19 @@
         },
         "cachetools": {
             "hashes": [
-                "sha256:513d4ff98dd27f85743a8dc0e92f55ddb1b49e060c2d5961512855cda2c01a98",
-                "sha256:bbaa39c3dede00175df2dc2b03d0cf18dd2d32a7de7beb68072d13043c9edb20"
+                "sha256:3796e1de094f0eaca982441c92ce96c68c89cced4cd97721ab297ea4b16db90e",
+                "sha256:c6b07a6ded8c78bf36730b3dc452dfff7d95f2a12a2fed856b1a0cb13ca78c61"
             ],
             "markers": "python_version ~= '3.5'",
-            "version": "==4.1.1"
+            "version": "==4.2.0"
         },
         "calamus": {
             "hashes": [
-                "sha256:406fbecd8f2e7d703ca89115f4fe027019344c16b74604891b296283467e2f8b",
-                "sha256:86df8d249db27707c40f29b3a60e96206b8196b4f9fc1832c9cf2285ee22132d"
+                "sha256:485c8b1fe4be99b5759a1803d5ce68e920852a03e25f4b59361b776af81f6f6b",
+                "sha256:7ecd0b6160aef854793c1e890732a95d311f21a540ac9b63a655ef7c562330d9"
             ],
             "markers": "python_version < '4' and python_full_version >= '3.6.1'",
-            "version": "==0.3.3"
+            "version": "==0.3.6"
         },
         "certifi": {
             "hashes": [
@@ -168,11 +168,11 @@
         },
         "coloredlogs": {
             "hashes": [
-                "sha256:346f58aad6afd48444c2468618623638dadab76e4e70d5e10822676f2d32226a",
-                "sha256:a1fab193d2053aa6c0a97608c4342d031f1f93a3d1218432c59322441d31a505"
+                "sha256:5e78691e2673a8e294499e1832bb13efcfb44a86b92e18109fa18951093218ab",
+                "sha256:b7f630a8297a66984b6bae0f6a1b0e0afb9f2f6838ea3bfa58f50d3d13e133d6"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==14.0"
+            "version": "==15.0"
         },
         "commonmark": {
             "hashes": [
@@ -268,11 +268,11 @@
         },
         "humanfriendly": {
             "hashes": [
-                "sha256:175ffa628aa76da2c17369a5da5856084562cc66dfe7f82ae93ca3ef175277a6",
-                "sha256:3c9ab8d28e88e6cc998e41963357736dafd555ee5bb666b50e42f6ce28dd3e3d"
+                "sha256:066562956639ab21ff2676d1fda0b5987e985c534fc76700a19bd54bcb81121d",
+                "sha256:d5c731705114b9ad673754f3317d9fa4c23212f36b29bdc4272a892eafc9bc72"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==9.0"
+            "version": "==9.1"
         },
         "humanize": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -79,7 +79,7 @@
                 "sha256:485c8b1fe4be99b5759a1803d5ce68e920852a03e25f4b59361b776af81f6f6b",
                 "sha256:7ecd0b6160aef854793c1e890732a95d311f21a540ac9b63a655ef7c562330d9"
             ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.1'",
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
             "version": "==0.3.6"
         },
         "certifi": {
@@ -220,7 +220,7 @@
                 "sha256:1382dda7bc7cca6e7569555773361a444aa5bd5a01d9e8c106fdd8697bbafcfc",
                 "sha256:1e40cf62f708c670ed2e1594c5a85282cac68d2c6af1e91dfc5b94b40c7d9ece"
             ],
-            "markers": "python_version >= '3.5' and python_version < '4'",
+            "markers": "python_version >= '3.5' and python_version < '4.0'",
             "version": "==3.0.20200807132242"
         },
         "decorator": {
@@ -292,11 +292,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:6112e21359ef8f344e7178aa5b72dc6e62b38b0d008e6d3cb212c5b84df72013",
-                "sha256:b0c2d3b226157ae4517d9625decf63591461c66b3a808c2666d538946519d170"
+                "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed",
+                "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.1.1"
+            "version": "==3.3.0"
         },
         "isodate": {
             "hashes": [
@@ -434,11 +434,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:73facc37462dfc0b27f571bdaffbef7709e19f7a616beb3802ea425b07843f4e",
-                "sha256:e26763201474b588d144dae9a32bdd945cd26a06c943bc746a6882e850475378"
+                "sha256:4ab2fdb7f36eb61c3665da67a7ce281c8900db08d72ba6bf0e695828253581f7",
+                "sha256:eca81d53aa4aafbc0e20566973d0d2e50ce8bf0ee15165bb799bec0df1e50177"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.9.1"
+            "version": "==3.10.0"
         },
         "mistune": {
             "hashes": [
@@ -677,7 +677,7 @@
                 "sha256:13cdbb6b72798be9ef30caf460d3949bf057d9f073f73cc853908d50cc31229f",
                 "sha256:ca1008c18e91c2d0345764ddb871cc284feadc467241fbb468f14280b791388a"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==9.3.0"
         },
         "ruamel.yaml": {
@@ -798,6 +798,7 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
+            "markers": "python_version < '3.8'",
             "version": "==3.7.4.3"
         },
         "urllib3": {
@@ -805,7 +806,7 @@
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
                 "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.25.11"
         },
         "wcmatch": {
@@ -858,11 +859,11 @@
         },
         "docker": {
             "hashes": [
-                "sha256:317e95a48c32de8c1aac92a48066a5b73e218ed096e03758bcdd799a7130a1a1",
-                "sha256:cffc771d4ea1389fc66bc95cb72d304aa41d1a1563482a9a000fba3a84ed5071"
+                "sha256:0604a74719d5d2de438753934b755bfcda6f62f49b8e4b30969a4b0a2a8a1220",
+                "sha256:e455fa49aabd4f22da9f4e1c1f9d16308286adc60abaf64bf3e1feafaed81d06"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==4.4.0"
+            "version": "==4.4.1"
         },
         "idna": {
             "hashes": [
@@ -937,7 +938,7 @@
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
                 "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.25.11"
         },
         "websocket-client": {

--- a/conftest.py
+++ b/conftest.py
@@ -433,6 +433,16 @@ def client_with_datasets(client, directory_tree):
     yield client
 
 
+@pytest.fixture()
+def client_with_datasets_provenance(client):
+    """A client with dataset provenance."""
+    from renku.core.incubation.graph import generate_datasets_provenance
+
+    generate_datasets_provenance().build().execute()
+
+    yield client
+
+
 @pytest.fixture(params=[".", "some/sub/directory"])
 def subdirectory(project, request):
     """Runs tests in root directory and a subdirectory."""

--- a/renku/cli/graph.py
+++ b/renku/cli/graph.py
@@ -18,18 +18,27 @@
 """PoC command for testing the new graph design."""
 
 import functools
+import shutil
 import sys
+from pathlib import Path
 
 import click
+from git import NULL_TREE, GitCommandError
 
 from renku.cli.utils.callback import ClickCallback
 from renku.cli.utils.click import CaseInsensitiveChoice
+from renku.core import errors
+from renku.core.commands.client import pass_local_client
 from renku.core.incubation.command import Command
-from renku.core.incubation.graph import export_graph, generate_graph
+from renku.core.incubation.graph import GRAPH_METADATA_PATHS, export_graph, generate_graph
 from renku.core.incubation.graph import status as get_status
 from renku.core.incubation.graph import update as perform_update
+from renku.core.management.migrate import migrate
+from renku.core.models.provenance.datasets import DatasetProvenance
 from renku.core.models.workflow.dependency_graph import DependencyGraph
 from renku.core.utils.contexts import measure
+from renku.core.utils.migrate import read_project_version_from_yaml
+from renku.core.utils.scm import git_unicode_unescape
 
 
 @click.group(hidden=True)
@@ -170,3 +179,120 @@ def export(format):
     r"""Equivalent of `renku log --format json-ld`."""
     communicator = ClickCallback()
     (export_graph().with_communicator(communicator).build().execute(format=_FORMATS[format]))
+
+
+@graph.command()
+@click.option("-f", "--force", is_flag=True, help="Delete existing metadata and regenerate all.")
+@pass_local_client(requires_migration=True, commit=True, commit_only=GRAPH_METADATA_PATHS)
+def generate_dataset(client, force):
+    """Create new graph metadata for datasets."""
+
+    commits = list(client.repo.iter_commits(paths=".renku/datasets/*"))
+    n_commits = len(commits)
+    commits = reversed(commits)
+
+    if force:
+        try:
+            client.datasets_provenance_path.unlink()
+        except FileNotFoundError:
+            pass
+    else:
+        if client.datasets_provenance_path.exists():
+            raise errors.OperationError("Dataset provenance file exists. Use `--force` to regenerate it.")
+
+    # Create empty dataset provenance file
+    client.datasets_provenance_path.write_text("[]")
+
+    datasets_provenance = DatasetProvenance.from_json(client.datasets_provenance_path)
+
+    for n, commit in enumerate(commits, start=1):
+        print(f"\rProcessing commits {n}/{n_commits}\r", end="", file=sys.stderr)
+
+        files_diff = list(commit.diff(commit.parents or NULL_TREE, paths=".renku/datasets/*"))
+        paths = [git_unicode_unescape(f.a_path) for f in files_diff]
+        deleted_paths = [git_unicode_unescape(f.a_path) for f in files_diff if f.change_type == "A"]
+
+        datasets, deleted_datasets = _fetch_datasets(client, commit.hexsha, paths=paths, deleted_paths=deleted_paths)
+
+        revision = commit.hexsha
+        date = commit.committed_datetime
+
+        for dataset in datasets:
+            datasets_provenance.update_dataset(dataset, client=client, revision=revision, date=date)
+        for dataset in deleted_datasets:
+            datasets_provenance.remove_dataset(dataset, revision=revision, date=date)
+
+    datasets_provenance.to_json()
+
+    click.secho("\nOK", fg="green")
+
+
+def _fetch_datasets(client, revision, paths, deleted_paths):
+    from renku.core.models.datasets import Dataset
+
+    datasets_path = client.path / ".renku" / "tmp" / "datasets"
+    shutil.rmtree(datasets_path, ignore_errors=True)
+    datasets_path.mkdir(parents=True, exist_ok=True)
+
+    def read_project_version():
+        """Read project version at revision."""
+        try:
+            project_file_content = client.repo.git.show(f"{revision}:.renku/metadata.yml")
+        except GitCommandError:  # Project metadata file does not exist
+            return 1
+
+        metadata_path = datasets_path / "metadata.yml"
+        try:
+            metadata_path.write_text(project_file_content)
+            return int(read_project_version_from_yaml(metadata_path))
+        except ValueError:
+            return 1
+        finally:
+            metadata_path.unlink()
+
+    def copy_and_migrate_datasets():
+        existing = []
+        deleted = []
+
+        for path in paths:
+            rev = revision
+            if path in deleted_paths:
+                rev = client.find_previous_commit(path, revision=f"{revision}~")
+            identifier = Path(path).parent.name
+            new_path = datasets_path / identifier / "metadata.yml"
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+            content = client.repo.git.show(f"{rev}:{path}")
+            new_path.write_text(content)
+            if path in deleted_paths:
+                deleted.append(new_path)
+            else:
+                existing.append(new_path)
+
+        try:
+            project_version = read_project_version()
+            client.set_temporary_datasets_path(datasets_path)
+            migrate(client, project_version=project_version, skip_template_update=True, skip_docker_update=True)
+        finally:
+            client.clear_temporary_datasets_path()
+
+        return existing, deleted
+
+    paths, deleted_paths = copy_and_migrate_datasets()
+
+    datasets = []
+    for path in paths:
+        dataset = Dataset.from_yaml(path, client=client)
+        # NOTE: Fixing dataset path after migration
+        original_identifier = Path(dataset.path).name
+        dataset.path = f".renku/datasets/{original_identifier}"
+        datasets.append(dataset)
+
+    deleted_datasets = []
+    for path in deleted_paths:
+        dataset = Dataset.from_yaml(path, client=client)
+        # NOTE: Fixing dataset path after migration
+        original_identifier = Path(dataset.path).name
+        dataset.path = f".renku/datasets/{original_identifier}"
+        deleted_datasets.append(dataset)
+
+    return datasets, deleted_datasets

--- a/renku/cli/graph.py
+++ b/renku/cli/graph.py
@@ -18,27 +18,18 @@
 """PoC command for testing the new graph design."""
 
 import functools
-import shutil
 import sys
-from pathlib import Path
 
 import click
-from git import NULL_TREE, GitCommandError
 
 from renku.cli.utils.callback import ClickCallback
 from renku.cli.utils.click import CaseInsensitiveChoice
-from renku.core import errors
-from renku.core.commands.client import pass_local_client
 from renku.core.incubation.command import Command
-from renku.core.incubation.graph import GRAPH_METADATA_PATHS, export_graph, generate_graph
+from renku.core.incubation.graph import export_graph, generate_datasets_provenance, generate_graph
 from renku.core.incubation.graph import status as get_status
 from renku.core.incubation.graph import update as perform_update
-from renku.core.management.migrate import migrate
-from renku.core.models.provenance.datasets import DatasetProvenance
 from renku.core.models.workflow.dependency_graph import DependencyGraph
 from renku.core.utils.contexts import measure
-from renku.core.utils.migrate import read_project_version_from_yaml
-from renku.core.utils.scm import git_unicode_unescape
 
 
 @click.group(hidden=True)
@@ -175,124 +166,18 @@ _FORMATS = {
 
 @graph.command()
 @click.option("--format", type=CaseInsensitiveChoice(_FORMATS), default="json-ld", help="Choose an output format.")
-def export(format):
+@click.option("-d", "--dataset", is_flag=True, help="Include datasets.")
+def export(format, dataset):
     r"""Equivalent of `renku log --format json-ld`."""
     communicator = ClickCallback()
-    (export_graph().with_communicator(communicator).build().execute(format=_FORMATS[format]))
+    (export_graph().with_communicator(communicator).build().execute(format=_FORMATS[format], dataset=dataset))
 
 
 @graph.command()
 @click.option("-f", "--force", is_flag=True, help="Delete existing metadata and regenerate all.")
-@pass_local_client(requires_migration=True, commit=True, commit_only=GRAPH_METADATA_PATHS)
-def generate_dataset(client, force):
+def generate_dataset(force):
     """Create new graph metadata for datasets."""
-
-    commits = list(client.repo.iter_commits(paths=".renku/datasets/*"))
-    n_commits = len(commits)
-    commits = reversed(commits)
-
-    if force:
-        try:
-            client.datasets_provenance_path.unlink()
-        except FileNotFoundError:
-            pass
-    else:
-        if client.datasets_provenance_path.exists():
-            raise errors.OperationError("Dataset provenance file exists. Use `--force` to regenerate it.")
-
-    # Create empty dataset provenance file
-    client.datasets_provenance_path.write_text("[]")
-
-    datasets_provenance = DatasetProvenance.from_json(client.datasets_provenance_path)
-
-    for n, commit in enumerate(commits, start=1):
-        print(f"\rProcessing commits {n}/{n_commits}\r", end="", file=sys.stderr)
-
-        files_diff = list(commit.diff(commit.parents or NULL_TREE, paths=".renku/datasets/*"))
-        paths = [git_unicode_unescape(f.a_path) for f in files_diff]
-        deleted_paths = [git_unicode_unescape(f.a_path) for f in files_diff if f.change_type == "A"]
-
-        datasets, deleted_datasets = _fetch_datasets(client, commit.hexsha, paths=paths, deleted_paths=deleted_paths)
-
-        revision = commit.hexsha
-        date = commit.committed_datetime
-
-        for dataset in datasets:
-            datasets_provenance.update_dataset(dataset, client=client, revision=revision, date=date)
-        for dataset in deleted_datasets:
-            datasets_provenance.remove_dataset(dataset, revision=revision, date=date)
-
-    datasets_provenance.to_json()
+    communicator = ClickCallback()
+    (generate_datasets_provenance().with_communicator(communicator).build().execute(force=force))
 
     click.secho("\nOK", fg="green")
-
-
-def _fetch_datasets(client, revision, paths, deleted_paths):
-    from renku.core.models.datasets import Dataset
-
-    datasets_path = client.path / ".renku" / "tmp" / "datasets"
-    shutil.rmtree(datasets_path, ignore_errors=True)
-    datasets_path.mkdir(parents=True, exist_ok=True)
-
-    def read_project_version():
-        """Read project version at revision."""
-        try:
-            project_file_content = client.repo.git.show(f"{revision}:.renku/metadata.yml")
-        except GitCommandError:  # Project metadata file does not exist
-            return 1
-
-        metadata_path = datasets_path / "metadata.yml"
-        try:
-            metadata_path.write_text(project_file_content)
-            return int(read_project_version_from_yaml(metadata_path))
-        except ValueError:
-            return 1
-        finally:
-            metadata_path.unlink()
-
-    def copy_and_migrate_datasets():
-        existing = []
-        deleted = []
-
-        for path in paths:
-            rev = revision
-            if path in deleted_paths:
-                rev = client.find_previous_commit(path, revision=f"{revision}~")
-            identifier = Path(path).parent.name
-            new_path = datasets_path / identifier / "metadata.yml"
-            new_path.parent.mkdir(parents=True, exist_ok=True)
-            content = client.repo.git.show(f"{rev}:{path}")
-            new_path.write_text(content)
-            if path in deleted_paths:
-                deleted.append(new_path)
-            else:
-                existing.append(new_path)
-
-        try:
-            project_version = read_project_version()
-            client.set_temporary_datasets_path(datasets_path)
-            migrate(client, project_version=project_version, skip_template_update=True, skip_docker_update=True)
-        finally:
-            client.clear_temporary_datasets_path()
-
-        return existing, deleted
-
-    paths, deleted_paths = copy_and_migrate_datasets()
-
-    datasets = []
-    for path in paths:
-        dataset = Dataset.from_yaml(path, client=client)
-        # NOTE: Fixing dataset path after migration
-        original_identifier = Path(dataset.path).name
-        dataset.path = f".renku/datasets/{original_identifier}"
-        datasets.append(dataset)
-
-    deleted_datasets = []
-    for path in deleted_paths:
-        dataset = Dataset.from_yaml(path, client=client)
-        # NOTE: Fixing dataset path after migration
-        original_identifier = Path(dataset.path).name
-        dataset.path = f".renku/datasets/{original_identifier}"
-        deleted_datasets.append(dataset)
-
-    return datasets, deleted_datasets

--- a/renku/core/incubation/graph.py
+++ b/renku/core/incubation/graph.py
@@ -41,6 +41,7 @@ from renku.core.utils.scm import git_unicode_unescape
 GRAPH_METADATA_PATHS = [
     Path(RENKU_HOME) / Path(RepositoryApiMixin.DEPENDENCY_GRAPH),
     Path(RENKU_HOME) / Path(RepositoryApiMixin.PROVENANCE_GRAPH),
+    Path(RENKU_HOME) / Path(RepositoryApiMixin.DATASET_PROVENANCE),
 ]
 
 

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -69,10 +69,27 @@ class DatasetsApiMixin(object):
     CACHE = "cache"
     """Directory to cache transient data."""
 
+    _temporary_datasets_path = None
+
     @property
     def renku_datasets_path(self):
         """Return a ``Path`` instance of Renku dataset metadata folder."""
+        if self._temporary_datasets_path:
+            return self._temporary_datasets_path
+
         return self.path / self.renku_home / self.DATASETS
+
+    def set_temporary_datasets_path(self, path):
+        """Set path to Renku dataset metadata directory."""
+        self._temporary_datasets_path = path
+
+    def clear_temporary_datasets_path(self):
+        """Clear path to Renku dataset metadata directory."""
+        self._temporary_datasets_path = None
+
+    def is_using_temporary_datasets_path(self):
+        """Return true if temporary datasets path is set."""
+        return bool(self._temporary_datasets_path)
 
     @property
     def renku_pointers_path(self):

--- a/renku/core/management/migrate.py
+++ b/renku/core/management/migrate.py
@@ -86,6 +86,7 @@ def migrate(
     skip_docker_update=False,
     skip_migrations=False,
     progress_callback=None,
+    project_version=None,
 ):
     """Apply all migration files to the project."""
     template_updated = docker_updated = False
@@ -115,7 +116,7 @@ def migrate(
     if skip_migrations:
         return False, template_updated, docker_updated
 
-    project_version = _get_project_version(client)
+    project_version = project_version or _get_project_version(client)
     n_migrations_executed = 0
 
     for version, path in get_migrations():
@@ -129,7 +130,7 @@ def migrate(
             except (Exception, BaseException) as e:
                 raise MigrationError("Couldn't execute migration") from e
             n_migrations_executed += 1
-    if n_migrations_executed > 0:
+    if n_migrations_executed > 0 and not client.is_using_temporary_datasets_path():
         client._project = None  # NOTE: force reloading of project metadata
         client.project.version = str(version)
         client.project.to_yaml()

--- a/renku/core/management/migrations/m_0003__1_jsonld.py
+++ b/renku/core/management/migrations/m_0003__1_jsonld.py
@@ -46,6 +46,7 @@ def _migrate_project_metadata(client):
         jsonld_context=_INITIAL_JSONLD_PROJECT_CONTEXT,
         fields=_PROJECT_FIELDS,
         jsonld_translate=jsonld_translate,
+        persist_changes=not client.is_using_temporary_datasets_path(),
     )
 
 
@@ -75,7 +76,7 @@ def _migrate_datasets_metadata(client):
 
 
 def _apply_on_the_fly_jsonld_migrations(
-    path, jsonld_context, fields, client=None, jsonld_migrations=None, jsonld_translate=None
+    path, jsonld_context, fields, client=None, jsonld_migrations=None, jsonld_translate=None, persist_changes=True
 ):
     data = read_yaml(path)
 
@@ -138,7 +139,8 @@ def _apply_on_the_fly_jsonld_migrations(
 
     _migrate_types(data)
 
-    write_yaml(path, data)
+    if persist_changes:
+        write_yaml(path, data)
 
 
 def _migrate_dataset_schema(data, client):

--- a/renku/core/management/migrations/m_0004__submodules.py
+++ b/renku/core/management/migrations/m_0004__submodules.py
@@ -42,14 +42,6 @@ def _migrate_submodule_based_datasets(client):
     if not submodules:
         return
 
-    for s in submodules:
-        try:
-            s.update()
-        except GitError:
-            pass
-
-    submodules_urls = {s.path: s.url for s in submodules}
-
     repo_paths = []
     symlinks = []
 
@@ -73,6 +65,14 @@ def _migrate_submodule_based_datasets(client):
 
     if not symlinks:
         return
+
+    for s in submodules:
+        try:
+            s.update()
+        except GitError:
+            pass
+
+    submodules_urls = {s.path: s.url for s in submodules}
 
     remote_clients = {p: LocalClient(p) for p in repo_paths}
 

--- a/renku/core/management/migrations/models/v3.py
+++ b/renku/core/management/migrations/models/v3.py
@@ -200,7 +200,7 @@ class PersonSchemaV3(JsonLDSchema):
     _id = fields.Id()
     name = StringList(schema.name)
     email = fields.String(schema.email, missing=None)
-    label = StringList(rdfs.label)
+    label = StringList(rdfs.label, missing=None)
     affiliation = StringList(schema.affiliation, missing=None)
     alternate_name = StringList(schema.alternateName, missing=None)
 
@@ -243,7 +243,7 @@ class CommitMixinSchemaV3(JsonLDSchema):
     _id = fields.Id(missing=None)
     _label = fields.String(rdfs.label, missing=None)
     _project = fields.Nested(schema.isPartOf, ProjectSchemaV3, missing=None)
-    path = fields.String(prov.atLocation)
+    path = fields.String(prov.atLocation, missing=None)
 
 
 class EntitySchemaV3(CommitMixinSchemaV3):
@@ -328,20 +328,20 @@ class DatasetSchemaV3(CreatorMixinSchemaV3, EntitySchemaV3):
         model = Dataset
         unknown = EXCLUDE
 
-    creators = fields.Nested(schema.creator, PersonSchemaV3, many=True)
+    creators = fields.Nested(schema.creator, PersonSchemaV3, many=True, missing=None)
     date_created = fields.DateTime(schema.dateCreated, missing=None)
     date_published = fields.DateTime(schema.datePublished, missing=None)
     description = fields.String(schema.description, missing=None)
     files = fields.Nested(schema.hasPart, DatasetFileSchemaV3, many=True)
     identifier = fields.String(schema.identifier)
     in_language = fields.Nested(schema.inLanguage, LanguageSchemaV3, missing=None)
-    keywords = fields.List(schema.keywords, fields.String())
+    keywords = fields.List(schema.keywords, fields.String(), missing=None)
     license = Uri(schema.license, missing=None, allow_none=True)
     name = fields.String(schema.alternateName, missing=None)
     same_as = fields.Nested(schema.sameAs, UrlSchemaV3, missing=None)
-    tags = fields.Nested(schema.subjectOf, DatasetTagSchemaV3, many=True)
+    tags = fields.Nested(schema.subjectOf, DatasetTagSchemaV3, many=True, missing=None)
     title = fields.String(schema.name)
-    url = fields.String(schema.url)
+    url = fields.String(schema.url, missing=None)
     version = fields.String(schema.version, missing=None)
 
     @pre_load

--- a/renku/core/management/migrations/models/v8.py
+++ b/renku/core/management/migrations/models/v8.py
@@ -96,13 +96,13 @@ class DatasetSchemaV8(CreatorMixinSchemaV3, EntitySchemaV3):
     files = fields.Nested(schema.hasPart, DatasetFileSchemaV8, many=True)
     identifier = fields.String(schema.identifier)
     in_language = fields.Nested(schema.inLanguage, LanguageSchemaV3, missing=None)
-    keywords = fields.List(schema.keywords, fields.String())
-    license = Uri(schema.license, missing=None, allow_none=True)
+    keywords = fields.List(schema.keywords, fields.String(), missing=None)
+    license = Uri(schema.license, allow_none=True, missing=None)
     name = fields.String(schema.alternateName, missing=None)
     same_as = fields.Nested(schema.sameAs, UrlSchemaV3, missing=None)
-    tags = fields.Nested(schema.subjectOf, DatasetTagSchemaV3, many=True)
+    tags = fields.Nested(schema.subjectOf, DatasetTagSchemaV3, many=True, missing=None)
     title = fields.String(schema.name)
-    url = fields.String(schema.url)
+    url = fields.String(schema.url, missing=None)
     version = fields.String(schema.version, missing=None)
 
     @pre_dump

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -109,9 +109,6 @@ class RepositoryApiMixin(GitCore):
     PROVENANCE_GRAPH = "provenance.json"
     """File for storing ProvenanceGraph."""
 
-    DATASET_PROVENANCE = "dataset.json"
-    """File for storing datasets' provenance."""
-
     ACTIVITY_INDEX = "activity_index.yaml"
     """Caches activities that generated a path."""
 
@@ -212,11 +209,6 @@ class RepositoryApiMixin(GitCore):
     def dependency_graph_path(self):
         """Path to the dependency graph file."""
         return self.renku_path / self.DEPENDENCY_GRAPH
-
-    @property
-    def datasets_provenance_path(self):
-        """Path to store activity files."""
-        return self.renku_path / self.DATASET_PROVENANCE
 
     @cached_property
     def cwl_prefix(self):

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -109,6 +109,9 @@ class RepositoryApiMixin(GitCore):
     PROVENANCE_GRAPH = "provenance.json"
     """File for storing ProvenanceGraph."""
 
+    DATASET_PROVENANCE = "dataset.json"
+    """File for storing datasets' provenance."""
+
     ACTIVITY_INDEX = "activity_index.yaml"
     """Caches activities that generated a path."""
 
@@ -209,6 +212,11 @@ class RepositoryApiMixin(GitCore):
     def dependency_graph_path(self):
         """Path to the dependency graph file."""
         return self.renku_path / self.DEPENDENCY_GRAPH
+
+    @property
+    def datasets_provenance_path(self):
+        """Path to store activity files."""
+        return self.renku_path / self.DATASET_PROVENANCE
 
     @cached_property
     def cwl_prefix(self):

--- a/renku/core/models/datasets.py
+++ b/renku/core/models/datasets.py
@@ -451,6 +451,12 @@ class Dataset(Entity, CreatorMixin):
             return Path(self.client.data_dir) / self.name
         return ""
 
+    @property
+    def original_identifier(self):
+        """Return the first identifier of the dataset."""
+        if self.path:
+            return Path(self.path).name
+
     def contains_any(self, files):
         """Check if files are already within a dataset."""
         for file_ in files:

--- a/renku/core/models/datasets.py
+++ b/renku/core/models/datasets.py
@@ -292,6 +292,12 @@ class DatasetFile(Entity):
         if not self.url and self.client:
             self.url = self.default_url()
 
+    def update_commit(self, commit):
+        """Set commit and update associated fields."""
+        self.commit = commit
+        self._id = self.default_id()
+        self._label = self.default_label()
+
     @classmethod
     def from_jsonld(cls, data):
         """Create an instance from JSON-LD data."""
@@ -510,12 +516,15 @@ class Dataset(Entity, CreatorMixin):
         for new_file in files:
             old_file = self.find_file(new_file.path)
             if not old_file:
-                self._modified = True
                 new_files.append(new_file)
             elif new_file.commit != old_file.commit or new_file.added != old_file.added:
                 self.unlink_file(new_file.path)
                 new_files.append(new_file)
 
+        if not new_files:
+            return
+
+        self._modified = True
         self.files += new_files
 
         self._update_files_metadata()
@@ -729,7 +738,7 @@ class DatasetTagSchema(JsonLDSchema):
         unknown = EXCLUDE
 
     name = fields.String(schema.name)
-    description = fields.String(schema.description)
+    description = fields.String(schema.description, missing=None)
     commit = fields.String(schema.location)
     created = fields.DateTime(schema.startDate, missing=None, format="iso", extra_formats=("%Y-%m-%d",))
     dataset = fields.String(schema.about)
@@ -806,10 +815,10 @@ class DatasetSchema(EntitySchema, CreatorMixinSchema):
     description = fields.String(schema.description, missing=None)
     identifier = fields.String(schema.identifier)
     in_language = Nested(schema.inLanguage, LanguageSchema, missing=None)
-    keywords = fields.List(schema.keywords, fields.String(), missing=None, allow_none=True)
-    license = Uri(schema.license, missing=None, allow_none=True)
+    keywords = fields.List(schema.keywords, fields.String(), allow_none=True, missing=None)
+    license = Uri(schema.license, allow_none=True, missing=None)
     title = fields.String(schema.name)
-    url = fields.String(schema.url)
+    url = fields.String(schema.url, missing=None)
     version = fields.String(schema.version, missing=None)
     date_created = fields.DateTime(
         schema.dateCreated, missing=None, allow_none=True, format="iso", extra_formats=("%Y-%m-%d",)

--- a/renku/core/models/jsonld.py
+++ b/renku/core/models/jsonld.py
@@ -60,7 +60,7 @@ NoDatesSafeLoader.remove_implicit_resolver("tag:yaml.org,2002:timestamp")
 def read_yaml(path):
     """Load YAML file and return its content as a dict."""
     with Path(path).open(mode="r") as fp:
-        return yaml.load(fp, Loader=NoDatesSafeLoader) or {}
+        return load_yaml(fp)
 
 
 def write_yaml(path, data):
@@ -70,3 +70,8 @@ def write_yaml(path, data):
 
     with Path(path).open("w") as fp:
         yaml.dump(data, fp, default_flow_style=False, Dumper=Dumper)
+
+
+def load_yaml(data):
+    """Load YAML data and return its content as a dict."""
+    return yaml.load(data, Loader=NoDatesSafeLoader) or {}

--- a/renku/core/models/provenance/datasets.py
+++ b/renku/core/models/provenance/datasets.py
@@ -123,7 +123,7 @@ class DatasetFile:
             return
 
         parsed_url = urlparse(self.id)
-        return Path(parsed_url.path).name
+        return list(Path(parsed_url.path).parents)[-3].name
 
 
 class Dataset:

--- a/renku/core/models/provenance/datasets.py
+++ b/renku/core/models/provenance/datasets.py
@@ -1,0 +1,515 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2020 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Model objects representing datasets."""
+
+import datetime
+import json
+import os
+import pathlib
+import uuid
+from pathlib import Path
+from urllib.parse import quote, urljoin, urlparse
+
+from git import GitCommandError
+from marshmallow import EXCLUDE
+
+from renku.core import errors
+from renku.core.models.calamus import DateTimeList, JsonLDSchema, Nested, Uri, fields, prov, renku, schema
+from renku.core.models.datasets import (
+    DatasetFileSchema,
+    DatasetTagSchema,
+    LanguageSchema,
+    Url,
+    UrlSchema,
+    generate_dataset_file_url,
+    generate_dataset_id,
+    is_dataset_name_valid,
+)
+from renku.core.models.entities import Entity, EntitySchema
+from renku.core.models.provenance.agents import PersonSchema
+from renku.core.utils import communication
+from renku.core.utils.urls import get_host
+
+
+class DatasetFile:
+    """Represent a file in a dataset."""
+
+    def __init__(
+        self,
+        path,
+        client=None,
+        *,
+        based_on=None,
+        date_added=None,
+        date_deleted=None,
+        entity=None,
+        id=None,
+        is_external=False,
+        source=None,
+        url=None,
+    ):
+        if not path:
+            raise errors.ParameterError("Dataset file path must be set.")
+
+        self._client = client
+
+        self.based_on = based_on
+        self.date_added = date_added or datetime.datetime.now(datetime.timezone.utc)
+        self.date_deleted = date_deleted
+        self.entity = entity or Entity.from_revision(client=client, path=path)
+        self.id = id
+        self.is_external = is_external
+        self.source = source
+        self.url = url
+
+        self._update_client(client)
+
+    @staticmethod
+    def generate_id(client, identifier, path):
+        """Generate @id field."""
+        host = get_host(client)
+
+        identifier = quote(identifier, safe="")
+        path = str(path).strip("/")
+
+        return urljoin(f"https://{host}", pathlib.posixpath.join("dataset-files", identifier, path))
+
+    @property
+    def client(self):
+        """Return client."""
+        return self._client
+
+    @client.setter
+    def client(self, client):
+        """Set client."""
+        self._update_client(client)
+
+    @property
+    def full_path(self):
+        """Return full path in the current reference frame."""
+        path = self.client.path / self.entity.path if self.client else self.entity.path
+        return Path(os.path.abspath(path))
+
+    def is_deleted(self):
+        """Return true if dataset is deleted and should not be accessed."""
+        return self.date_deleted is not None
+
+    def _update_client(self, client):
+        """Set new client and update related fields."""
+        self._client = client
+
+        identifier = self._extract_identifier() or str(uuid.uuid4())
+        self.id = self.generate_id(client, identifier, self.entity.path)
+
+        self.url = generate_dataset_file_url(client=client, filepath=self.entity.path)
+
+    def _extract_identifier(self):
+        if not self.id:
+            return
+
+        parsed_url = urlparse(self.id)
+        return Path(parsed_url.path).name
+
+
+class Dataset:
+    """Represent a dataset."""
+
+    def __init__(
+        self,
+        name,
+        client=None,
+        *,
+        creators=None,
+        date_created=None,
+        date_deleted=None,
+        date_published=None,
+        derived_from=None,
+        description=None,
+        files=None,
+        id=None,
+        identifier=None,
+        immutable=False,
+        in_language=None,
+        keywords=None,
+        license=None,
+        original_identifier=None,
+        same_as=None,
+        tags=None,
+        title=None,
+        url=None,
+        version=None,
+    ):
+        if not is_dataset_name_valid(name):
+            raise errors.ParameterError(f"Invalid dataset name: {name}")
+
+        self.name = name
+        self._client = client
+
+        self.creators = creators or []
+        self.date_created = date_created or datetime.datetime.now(datetime.timezone.utc)
+        self.date_deleted = date_deleted
+        self.date_published = date_published
+        self.derived_from = derived_from
+        self.description = description
+        self.files = files or []
+        self.id = id
+        self.identifier = identifier or str(uuid.uuid4())
+        self.immutable = immutable
+        self.in_language = in_language
+        self.keywords = keywords or []
+        self.license = license
+        self.original_identifier = original_identifier
+        self.same_as = same_as
+        self.tags = tags or []
+        self.title = title
+        self.url = url
+        self.version = version
+
+        self._modified = False
+        self._mutated = False
+        self._metadata_path = False
+
+        # if `date_published` is set, we are probably dealing with an imported dataset so `date_created` is not needed
+        if self.date_published:
+            self.date_created = None
+
+        self._update_client(client)
+
+    @classmethod
+    def from_dataset(cls, dataset, client, revision):
+        """Create an instance by converting from renku.core.models.datasets.Dataset."""
+        files = _convert_dataset_files(dataset.files, client, revision)
+
+        return Dataset(
+            name=dataset.name,
+            client=client,
+            creators=dataset.creators,
+            date_created=dataset.date_created,
+            date_deleted=None,
+            date_published=dataset.date_published,
+            derived_from=dataset.derived_from,
+            description=dataset.description,
+            files=files,
+            id=None,
+            identifier=dataset.identifier,
+            in_language=dataset.in_language,
+            keywords=dataset.keywords,
+            license=dataset.license,
+            original_identifier=dataset.original_identifier,
+            same_as=dataset.same_as,
+            tags=dataset.tags,
+            title=dataset.title,
+            url=dataset.url,
+            version=dataset.version,
+        )
+
+    @property
+    def client(self):
+        """Return client."""
+        return self._client
+
+    @client.setter
+    def client(self, client):
+        """Set client."""
+        self._update_client(client)
+
+    def is_deleted(self):
+        """Return true if dataset is deleted and should not be accessed."""
+        return self.date_deleted is not None
+
+    def find_files(self, paths):
+        """Return all paths that are in files container."""
+        files_paths = {str(self.client.path / f.path) for f in self.files}
+        return {p for p in paths if str(p) in files_paths}
+
+    def find_file(self, path, return_index=False):
+        """Find a file in files container using its relative path."""
+        for index, file_ in enumerate(self.files):
+            if str(file_.path) == str(path):
+                if return_index:
+                    return index
+                file_.client = self.client
+                return file_
+
+    def _set_identifier(self, new_identifier):
+        """Set identifier and update all related fields."""
+        self.identifier = new_identifier
+        self.id = generate_dataset_id(client=self.client, identifier=self.identifier)
+        self.url = self.id
+
+    def _update_client(self, client):
+        """Set new client and update related fields."""
+        self._client = client
+
+        self._set_identifier(self.identifier)
+
+        if self.derived_from:
+            host = get_host(self.client)
+            derived_from_id = self.derived_from._id
+            derived_from_url = self.derived_from.url.get("@id")
+            u = urlparse(derived_from_url)
+            derived_from_url = u._replace(netloc=host).geturl()
+            self.derived_from = Url(id=derived_from_id, url_id=derived_from_url)
+
+        for file_ in self.files:
+            file_.client = client
+
+    def update_from(self, dataset, client, revision, date):
+        """Update metadata from a new version of the dataset."""
+        self._set_identifier(dataset.identifier)
+
+        self._update_files(dataset, client, revision, date)
+
+        self.creators = dataset.creators
+        self.date_created = dataset.date_created
+        self.date_deleted = None
+        self.date_published = dataset.date_published
+        self.derived_from = dataset.derived_from
+        self.description = dataset.description
+        self.id = None
+        self.identifier = None
+        self.in_language = dataset.in_language
+        self.keywords = dataset.keywords
+        self.license = dataset.license
+        self.same_as = dataset.same_as
+        self.tags = dataset.tags
+        self.title = dataset.title
+        self.version = dataset.version
+
+    def _update_files(self, dataset, client, revision, date):
+        current_files = {f.entity.path: f for f in self.files if not f.is_deleted()}
+        updated_files = {f.path: f for f in dataset.files}
+
+        current_paths = set(current_files.keys())
+        updated_paths = set(updated_files.keys())
+
+        deleted_paths = current_paths - updated_paths
+        for path in deleted_paths:
+            file_ = current_files[path]
+            file_.date_deleted = date
+
+        new_paths = updated_paths - current_paths
+        if not new_paths:
+            return
+
+        new_files = [v for k, v in updated_files.items() if k in new_paths]
+        dataset_files = _convert_dataset_files(new_files, client, revision)
+        self.files.extend(dataset_files)
+
+
+def _convert_dataset_files(files, client, revision):
+    dataset_files = []
+    files = {f.path: f for f in files}  # NOTE: To make sure there are no duplicate paths
+    for path in files:
+        file_ = files[path]
+        checksum = _get_object_hash(revision=revision, path=file_.path, client=client)
+        if not checksum:
+            continue
+
+        host = get_host(client)
+        id_ = _generate_entity_id(entity_checksum=checksum, path=file_.path, host=host)
+        entity = Entity(id=id_, checksum=checksum, path=file_.path)
+
+        dataset_file = DatasetFile(
+            path=file_.path,
+            client=client,
+            based_on=file_.based_on,
+            date_added=file_.added,
+            entity=entity,
+            id=None,
+            is_external=file_.external,
+            source=file_.source,
+            url=None,
+        )
+
+        dataset_files.append(dataset_file)
+
+    return dataset_files
+
+
+def _generate_entity_id(entity_checksum, path, host):
+    quoted_path = quote(path)
+    path = pathlib.posixpath.join("blob", entity_checksum, quoted_path)
+
+    return urljoin(f"https://{host}", path)
+
+
+def _get_object_hash(revision, path, client):
+    try:
+        return client.repo.git.rev_parse(f"{revision}:{str(path)}")
+    except GitCommandError:
+        return None
+
+
+class DatasetProvenance:
+    """A set of datasets."""
+
+    def __init__(self, datasets=None):
+        """Initialize."""
+        self._datasets = datasets or []
+        self._path = None
+
+    def add(self, dataset):
+        """Add a Dataset."""
+        self._datasets.append(dataset)
+
+    def get(self, identifier):
+        """Return a dataset by its original identifier."""
+        datasets = [d for d in self._datasets if d.identifier == identifier]
+        assert len(datasets) <= 1, f"Found more than one with identifier `{identifier}`."
+        return datasets[0] if datasets else None
+
+    @property
+    def datasets(self):
+        """Return list of datasets."""
+        return self._datasets
+
+    def update_dataset(self, dataset, client=None, revision=None, date=None):
+        """Add/update a dataset according to its new content."""
+        revision = revision or "HEAD"
+        date = date or datetime.datetime.now(datetime.timezone.utc)
+
+        current_dataset = self.get(dataset.identifier)
+
+        if not current_dataset:
+            current_dataset = Dataset.from_dataset(dataset, client, revision)
+            self.add(current_dataset)
+            return
+
+        if current_dataset.is_deleted():
+            communication.warn(f"Deleted dataset is being updated `{dataset.identifier}` at revision `{revision}`")
+            current_dataset.date_deleted = None
+
+        current_dataset.update_from(dataset, client, revision, date)
+
+    def remove_dataset(self, dataset, revision=None, date=None):
+        """Remove a dataset."""
+        revision = revision or "HEAD"
+        date = date or datetime.datetime.now(datetime.timezone.utc)
+        current_dataset = self.get(dataset.identifier)
+        if not current_dataset:
+            communication.warn(f"Cannot find dataset to delete `{dataset.identifier}` at revision `{revision}`")
+            return
+        assert not current_dataset.is_deleted(), f"Dataset `{current_dataset.name}` was deleted before."
+        current_dataset.date_deleted = date
+
+    @classmethod
+    def from_json(cls, path):
+        """Return an instance from a file."""
+        if Path(path).exists():
+            with open(path) as file_:
+                data = json.load(file_)
+                self = cls.from_jsonld(data=data) if data else DatasetProvenance()
+        else:
+            self = DatasetProvenance()
+
+        self._path = path
+
+        return self
+
+    @classmethod
+    def from_jsonld(cls, data):
+        """Create an instance from JSON-LD data."""
+        if isinstance(data, cls):
+            return data
+        elif not isinstance(data, list):
+            raise ValueError(data)
+
+        return DatasetProvenanceSchema(flattened=True).load(data)
+
+    def to_json(self, path=None):
+        """Write to file."""
+        path = path or self._path
+        data = self.to_jsonld()
+        with open(path, "w", encoding="utf-8") as file_:
+            json.dump(data, file_, ensure_ascii=False, sort_keys=True, indent=2)
+
+    def to_jsonld(self):
+        """Create JSON-LD."""
+        return DatasetProvenanceSchema(flattened=True).dump(self)
+
+
+class NewDatasetFileSchema(JsonLDSchema):
+    """DatasetFile schema."""
+
+    class Meta:
+        """Meta class."""
+
+        rdf_type = [prov.Entity, schema.DigitalDocument]
+        model = DatasetFile
+        unknown = EXCLUDE
+
+    based_on = Nested(schema.isBasedOn, DatasetFileSchema, missing=None, propagate_client=False)
+    date_added = DateTimeList(schema.dateCreated, format="iso", extra_formats=("%Y-%m-%d",))
+    date_deleted = fields.DateTime(prov.invalidatedAtTime, missing=None, allow_none=True, format="iso")
+    entity = Nested(renku.entity, EntitySchema, missing=None)
+    id = fields.Id(init_name="id")
+    is_external = fields.Boolean(renku.external, missing=False)
+    source = fields.String(renku.source, missing=None)
+    url = fields.String(schema.url, missing=None)
+
+
+class NewDatasetSchema(JsonLDSchema):
+    """Dataset schema."""
+
+    class Meta:
+        """Meta class."""
+
+        rdf_type = schema.Dataset
+        model = Dataset
+        unknown = EXCLUDE
+
+    creators = Nested(schema.creator, PersonSchema, many=True)
+    date_created = fields.DateTime(
+        schema.dateCreated, missing=None, allow_none=True, format="iso", extra_formats=("%Y-%m-%d",),
+    )
+    date_deleted = fields.DateTime(prov.invalidatedAtTime, missing=None, allow_none=True, format="iso")
+    date_published = fields.DateTime(
+        schema.datePublished,
+        missing=None,
+        allow_none=True,
+        format="%Y-%m-%d",
+        extra_formats=("iso", "%Y-%m-%dT%H:%M:%S"),
+    )
+    derived_from = Nested(prov.wasDerivedFrom, UrlSchema, missing=None)
+    description = fields.String(schema.description, missing=None)
+    files = Nested(schema.hasPart, NewDatasetFileSchema, many=True)
+    id = fields.Id(init_name="id", missing=None)
+    identifier = fields.String(schema.identifier)
+    in_language = Nested(schema.inLanguage, LanguageSchema, missing=None)
+    keywords = fields.List(schema.keywords, fields.String(), missing=None, allow_none=True)
+    license = Uri(schema.license, missing=None, allow_none=True)
+    original_identifier = fields.String(renku.originalIdentifier)
+    same_as = Nested(schema.sameAs, UrlSchema, missing=None)
+    tags = Nested(schema.subjectOf, DatasetTagSchema, many=True)
+    title = fields.String(schema.name)
+    url = fields.String(schema.url)
+    version = fields.String(schema.version, missing=None)
+
+
+class DatasetProvenanceSchema(JsonLDSchema):
+    """DatasetProvenance schema."""
+
+    class Meta:
+        """Meta class."""
+
+        rdf_type = renku.DatasetProvenance
+        model = DatasetProvenance
+        unknown = EXCLUDE
+
+    _datasets = Nested(schema.hasPart, NewDatasetSchema, init_name="datasets", many=True, missing=None)

--- a/renku/core/models/provenance/datasets.py
+++ b/renku/core/models/provenance/datasets.py
@@ -271,7 +271,9 @@ class Dataset:
 
     def update_from(self, dataset, client, revision, date):
         """Update metadata from a new version of the dataset."""
-        self._set_identifier(dataset.identifier)
+        assert (
+            self.identifier == dataset.identifier
+        ), f"Dataset is being updated with a different identifier `{dataset.identifier}`"
 
         self._update_files(dataset, client, revision, date)
 
@@ -470,7 +472,7 @@ class NewDatasetSchema(JsonLDSchema):
     class Meta:
         """Meta class."""
 
-        rdf_type = schema.Dataset
+        rdf_type = [prov.Entity, schema.Dataset]
         model = Dataset
         unknown = EXCLUDE
 

--- a/renku/core/models/provenance/provenance_graph.py
+++ b/renku/core/models/provenance/provenance_graph.py
@@ -122,7 +122,12 @@ class ProvenanceGraph:
         if self._graph:
             return
 
-        self._graph = ConjunctiveGraph().parse(location=str(self._path), format="json-ld")
+        self._graph = ConjunctiveGraph()
+
+        if not self._path.exists():
+            return
+
+        self._graph.parse(location=str(self._path), format="json-ld")
 
         self._graph.bind("foaf", "http://xmlns.com/foaf/0.1/")
         self._graph.bind("oa", "http://www.w3.org/ns/oa#")

--- a/renku/core/utils/migrate.py
+++ b/renku/core/utils/migrate.py
@@ -76,12 +76,12 @@ def get_pre_0_3_4_datasets_metadata(client):
 
 def read_project_version(client):
     """Read project version from metadata file."""
-    return read_project_version_from_yaml(client.renku_metadata_path)
+    yaml_data = read_yaml(client.renku_metadata_path)
+    return read_project_version_from_yaml(yaml_data)
 
 
-def read_project_version_from_yaml(path):
-    """Read project version from a metadata YAML file."""
-    yaml_data = read_yaml(path)
+def read_project_version_from_yaml(yaml_data):
+    """Read project version from YAML data."""
     jsonld = pyld.jsonld.expand(yaml_data)[0]
     jsonld = normalize(jsonld)
     return _get_jsonld_property(jsonld, "http://schema.org/schemaVersion", "1")

--- a/renku/core/utils/migrate.py
+++ b/renku/core/utils/migrate.py
@@ -76,17 +76,15 @@ def get_pre_0_3_4_datasets_metadata(client):
 
 def read_project_version(client):
     """Read project version from metadata file."""
-    metadata = read_jsonld_yaml(client.renku_metadata_path)
-    return _get_jsonld_property(metadata, "http://schema.org/schemaVersion", "1")
+    return read_project_version_from_yaml(client.renku_metadata_path)
 
 
-def read_jsonld_yaml(path):
-    """Read YAML file and return normalized expanded JSON-LD."""
-    data = read_yaml(path)
-    jsonld = pyld.jsonld.expand(data)[0]
-    v = normalize(jsonld)
-
-    return v
+def read_project_version_from_yaml(path):
+    """Read project version from a metadata YAML file."""
+    yaml_data = read_yaml(path)
+    jsonld = pyld.jsonld.expand(yaml_data)[0]
+    jsonld = normalize(jsonld)
+    return _get_jsonld_property(jsonld, "http://schema.org/schemaVersion", "1")
 
 
 def _get_jsonld_property(jsonld, property, default=None):

--- a/renku/core/utils/urls.py
+++ b/renku/core/utils/urls.py
@@ -49,5 +49,10 @@ def get_host(client):
 
     Default is localhost. If RENKU_DOMAIN is set, it overrides the host from remote.
     """
-    host = client.remote.get("host") or "localhost"
+    host = "localhost"
+
+    if not client:
+        return host
+
+    host = client.remote.get("host") or host
     return os.environ.get("RENKU_DOMAIN") or host

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ install_requires = [
     "appdirs>=1.4.3,<=1.4.4 ",
     "apispec>=4.0.0,<=4.1.0",
     "attrs>=19.3.0,<=20.2.0",
-    "calamus>=0.3.3,<0.3.4",
+    "calamus>=0.3.6,<0.3.7",
     "click-completion>=0.5.0,<=0.5.3",
     "click>=7.0,<=7.1.2",
     "click-plugins==1.1.1",

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -1360,6 +1360,24 @@ def test_immutability_after_import(runner, client):
 
 
 @pytest.mark.integration
+@flaky(max_runs=10, min_passes=1)
+def test_immutability_after_update(client, runner):
+    """Test dataset is mutated after an update."""
+    url = "https://github.com/SwissDataScienceCenter/renku-jupyter.git"
+
+    result = runner.invoke(cli, ["dataset", "add", "--create", "my-data", "--ref", "0.3.0", "-s", "README.md", url])
+    assert 0 == result.exit_code, result.output + str(result.stderr_bytes)
+
+    old_dataset = client.load_dataset("my-data")
+
+    assert 0 == runner.invoke(cli, ["dataset", "update"], catch_exceptions=False).exit_code
+
+    dataset = client.load_dataset("my-data")
+    mutator = Person.from_git(client.repo)
+    assert_dataset_is_mutated(old=old_dataset, new=dataset, mutator=mutator)
+
+
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "url",
     [
@@ -1380,3 +1398,46 @@ def test_import_returns_last_dataset_version(runner, client, url):
     latest_identifier = "0dc3a120-e4af-4a4c-a888-70d1719c4631"
     assert dataset.identifier not in [initial_identifier, latest_identifier]
     assert f"https://dev.renku.ch/datasets/{latest_identifier}" == dataset.same_as.url["@id"]
+
+
+@pytest.mark.integration
+@flaky(max_runs=10, min_passes=1)
+def test_datasets_provenance_after_import(runner, client_with_datasets_provenance):
+    """Test dataset provenance is updated after importing a dataset."""
+    assert 0 == runner.invoke(cli, ["dataset", "import", "-y", "--name", "my-data", "10.7910/DVN/F4NUMR"]).exit_code
+
+    dataset = client_with_datasets_provenance.datasets_provenance.get_by_name("my-data")
+
+    assert dataset is not None
+
+
+@pytest.mark.integration
+@flaky(max_runs=10, min_passes=1)
+def test_datasets_provenance_after_git_update(client_with_datasets_provenance, runner):
+    """Test dataset provenance is updated after an update."""
+    url = "https://github.com/SwissDataScienceCenter/renku-jupyter.git"
+
+    result = runner.invoke(cli, ["dataset", "add", "--create", "my-data", "--ref", "0.3.0", "-s", "README.md", url])
+    assert 0 == result.exit_code, result.output + str(result.stderr_bytes)
+
+    assert 0 == runner.invoke(cli, ["dataset", "update"], catch_exceptions=False).exit_code
+
+    dataset = client_with_datasets_provenance.load_dataset("my-data")
+    current_version = client_with_datasets_provenance.datasets_provenance.get(dataset.identifier)
+
+    assert current_version.identifier != current_version.original_identifier
+
+
+@pytest.mark.integration
+@flaky(max_runs=10, min_passes=1)
+def test_datasets_provenance_after_external_provider_update(client_with_datasets_provenance, runner):
+    """Test dataset provenance is updated after an update from an external provider."""
+    doi = "10.5281/zenodo.2658634"
+    assert 0 == runner.invoke(cli, ["dataset", "import", "-y", "--name", "my-data", doi]).exit_code
+
+    assert 0 == runner.invoke(cli, ["dataset", "update", "my-data"]).exit_code
+
+    dataset = client_with_datasets_provenance.load_dataset("my-data")
+    current_version = client_with_datasets_provenance.datasets_provenance.get(dataset.identifier)
+
+    assert current_version.identifier != current_version.original_identifier

--- a/tests/core/commands/test_client.py
+++ b/tests/core/commands/test_client.py
@@ -60,6 +60,7 @@ def test_safe_class_attributes(tmpdir):
         "CACHE",
         "CONFIG_NAME",
         "DATASETS",
+        "DATASET_PROVENANCE",
         "DATA_DIR_CONFIG_KEY",
         "DEPENDENCY_GRAPH",
         "DOCKERFILE",
@@ -82,6 +83,7 @@ def test_safe_class_attributes(tmpdir):
         "_CMD_STORAGE_UNTRACK",
         "_LFS_HEADER",
         "_global_config_dir",
+        "_temporary_datasets_path",
     ]
 
     client1 = LocalClient(str(tmpdir.mkdir("project1")))

--- a/tests/core/commands/test_client.py
+++ b/tests/core/commands/test_client.py
@@ -60,7 +60,7 @@ def test_safe_class_attributes(tmpdir):
         "CACHE",
         "CONFIG_NAME",
         "DATASETS",
-        "DATASET_PROVENANCE",
+        "DATASETS_PROVENANCE",
         "DATA_DIR_CONFIG_KEY",
         "DEPENDENCY_GRAPH",
         "DOCKERFILE",
@@ -82,6 +82,7 @@ def test_safe_class_attributes(tmpdir):
         "_CMD_STORAGE_TRACK",
         "_CMD_STORAGE_UNTRACK",
         "_LFS_HEADER",
+        "_datasets_provenance",
         "_global_config_dir",
         "_temporary_datasets_path",
     ]


### PR DESCRIPTION
# Description

Parses git history and puts all datasets' metadata in a single file: `.renku/dataset.json`. To generate this file use: `renku graph generate-dataset`. To export add `-d` flag to the export command: `renku graph export -d --format jsonld`.

Fixes #1710 
