### PR TITLE
chore: fix exclusion of pipfile lock action from dependabot PRs

### DIFF
--- a/.github/workflows/pipfile-update.yml
+++ b/.github/workflows/pipfile-update.yml
@@ -5,7 +5,7 @@ on:
     paths:
     - 'setup.py'
     branches-ignore:
-      - 'dependabot/**'
+    - 'dependabot-updates'
 
 jobs:
   update-pipfile:


### PR DESCRIPTION
Apparently the branches-ignore keyword does not apply to the originating branch of a PR but to the target branch of a PR