### PR TITLE
fix(core): fix gitlab url parsing when GITLAB_BASE_URL is set without port

### DIFF
--- a/renku/core/models/git.py
+++ b/renku/core/models/git.py
@@ -120,12 +120,12 @@ class GitURL(object):
                 _RE_PROTOCOL,
                 _RE_USERNAME_PASSWORD,
                 r"(?P<hostname>" + re.escape(gitlab_url.hostname) + ")",
-                r":(?P<port>" + gitlab_url.port + ")" if gitlab_url.port else None,
+                r":(?P<port>" + str(gitlab_url.port) + ")" if gitlab_url.port else "",
                 r"/",
-                re.escape(gitlab_url.path) + r"/" if gitlab_url.path else None,
+                re.escape(gitlab_url.path) + r"/" if gitlab_url.path else "",
                 _RE_PATHNAME,
             )
-            url_regexes = (gitlab_re) + url_regexes
+            url_regexes = (gitlab_re,) + url_regexes
 
         for regex in url_regexes:
             matches = re.search(regex, href)

--- a/tests/core/models/test_git.py
+++ b/tests/core/models/test_git.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """Git regex tests."""
 
+import os
 import pytest
 
 from renku.core import errors
@@ -227,9 +228,62 @@ from renku.core.models.git import GitURL
             "pathname": "1234/prefix/owner/repo.git",
             "owner": "1234/prefix/owner",
         },
+        {
+            "href": "https://example.com:1234/gitlab/owner/repo.git",
+            "protocol": "https",
+            "hostname": "example.com",
+            "name": "repo",
+            "pathname": "gitlab/owner/repo.git",
+            "owner": "owner",
+            "port": "1234",
+            "env": "https://example.com:1234/gitlab/",
+        },
+        {
+            "href": "https://example.com:1234/gitlab/owner/repo.git",
+            "protocol": "https",
+            "hostname": "example.com",
+            "name": "repo",
+            "pathname": "gitlab/owner/repo.git",
+            "owner": "owner",
+            "port": "1234",
+            "env": "https://example.com/gitlab/",
+        },
+        {
+            "href": "https://example.com/gitlab/owner/repo.git",
+            "protocol": "https",
+            "hostname": "example.com",
+            "name": "repo",
+            "pathname": "gitlab/owner/repo.git",
+            "owner": "owner",
+            "env": "https://example.com/gitlab/",
+        },
+        {
+            "href": "https://gitlab.example.com/owner/repo.git",
+            "protocol": "https",
+            "hostname": "gitlab.example.com",
+            "name": "repo",
+            "pathname": "owner/repo.git",
+            "owner": "owner",
+            "env": "https://gitlab.example.com/",
+        },
+        {
+            "href": "https://gitlab.example.com:1234/owner/repo.git",
+            "protocol": "https",
+            "hostname": "gitlab.example.com",
+            "name": "repo",
+            "pathname": "owner/repo.git",
+            "owner": "owner",
+            "port": "1234",
+            "env": "https://gitlab.example.com:1234/",
+        },
     ],
 )
 def test_valid_href(fields):
     """Test the various repo regexes."""
     fields.pop("protocols", None)
+    gitlab_env = fields.pop("env", None)
+
+    if gitlab_env:
+        os.environ["GITLAB_BASE_URL"] = gitlab_env
+
     assert GitURL(**fields) == GitURL.parse(fields["href"])

--- a/tests/core/models/test_git.py
+++ b/tests/core/models/test_git.py
@@ -18,6 +18,7 @@
 """Git regex tests."""
 
 import os
+
 import pytest
 
 from renku.core import errors


### PR DESCRIPTION
Fixes issue with RE string concatenation when one part is `None`