### PR TITLE
fix(service): reset cache after failed push

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -433,7 +433,16 @@ jobs:
         IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
         ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
         RENKU_REQUESTS_TIMEOUT_SECONDS: 120
-      run: pytest -m integration -v --timeout=600 -n auto
+      run: pytest -m "integration and not serial" -v --timeout=600 -n auto
+    - name: Test with pytest(serial)
+      env:
+        LANG: en_US.UTF-8
+        LC_ALL: en_US.UTF-8
+        DATAVERSE_ACCESS_TOKEN: ${{ secrets.DATAVERSE_ACCESS_TOKEN }}
+        IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
+        ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
+        RENKU_REQUESTS_TIMEOUT_SECONDS: 120
+      run: pytest -m "integration and serial" -v --timeout=600 -n auto
 
   test-macos-integration:
     runs-on: macos-latest
@@ -468,7 +477,16 @@ jobs:
         IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
         ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
         RENKU_REQUESTS_TIMEOUT_SECONDS: 120
-      run: pytest -m integration -v
+      run: pytest -m "integration and not serial" -v
+    - name: Test with pytest(serial)
+      env:
+        LANG: en_US.UTF-8
+        LC_ALL: en_US.UTF-8
+        DATAVERSE_ACCESS_TOKEN: ${{ secrets.DATAVERSE_ACCESS_TOKEN }}
+        IT_OAUTH_GIT_TOKEN: ${{ secrets.IT_OAUTH_GIT_TOKEN }}
+        ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
+        RENKU_REQUESTS_TIMEOUT_SECONDS: 120
+      run: pytest -m "integration and serial" -v
 
   publish-pypi:
     runs-on: ubuntu-latest

--- a/conftest.py
+++ b/conftest.py
@@ -881,16 +881,12 @@ def datapack_gz(directory_tree):
 @pytest.fixture(scope="module")
 def mock_redis():
     """Monkey patch service cache with mocked redis."""
-    from renku.core.commands import save
     from renku.service.cache.base import BaseCache
     from renku.service.cache.models.file import File
     from renku.service.cache.models.job import Job
     from renku.service.cache.models.project import Project
     from renku.service.cache.models.user import User
     from renku.service.jobs.queues import WorkerQueues
-
-    def repo_sync_mock(p, remote=None):
-        return None, "origin"
 
     monkey_patch = MonkeyPatch()
     with monkey_patch.context() as m:
@@ -906,15 +902,24 @@ def mock_redis():
         m.setattr(File, "__database__", fake_model_db)
         m.setattr(Project, "__database__", fake_model_db)
 
-        save.repo_sync = repo_sync_mock
-
         yield
 
     monkey_patch.undo()
 
 
 @pytest.fixture(scope="module")
-def svc_client(mock_redis):
+def mock_sync():
+    """Mocked redis with mocked sync."""
+    from renku.core.commands import save
+
+    def repo_sync_mock(p, remote=None):
+        return None, "origin"
+
+    save.repo_sync = repo_sync_mock
+
+
+@pytest.fixture(scope="module")
+def svc_client(mock_redis, mock_sync):
     """Renku service client."""
     from renku.service.entrypoint import create_app
 
@@ -931,8 +936,32 @@ def svc_client(mock_redis):
     ctx.pop()
 
 
+@pytest.fixture
+def svc_client_with_sync(mock_redis):
+    """Renku service client."""
+    import importlib
+
+    from renku.core.commands import save
+    from renku.service.entrypoint import create_app
+
+    # NOTE: Use this fixture only in serial tests. save.repo_sync is mocked; reloading the save module to undo the mock.
+    importlib.reload(save)
+
+    flask_app = create_app()
+
+    testing_client = flask_app.test_client()
+    testing_client.testing = True
+
+    ctx = flask_app.app_context()
+    ctx.push()
+
+    yield testing_client
+
+    ctx.pop()
+
+
 @pytest.fixture()
-def svc_client_cache(mock_redis, identity_headers):
+def svc_client_cache(mock_redis, mock_sync, identity_headers):
     """Service jobs fixture."""
     from renku.service.entrypoint import create_app
 
@@ -1007,7 +1036,7 @@ def identity_headers():
 
 
 @pytest.fixture(scope="module")
-def integration_lifecycle(svc_client, mock_redis, identity_headers):
+def integration_lifecycle(svc_client, mock_redis, mock_sync, identity_headers):
     """Setup and teardown steps for integration tests."""
     from renku.core.models.git import GitURL
 
@@ -1077,7 +1106,7 @@ def svc_client_with_repo(svc_client_setup):
 
 
 @pytest.fixture
-def svc_client_with_templates(svc_client, mock_redis, identity_headers, template):
+def svc_client_with_templates(svc_client, mock_redis, mock_sync, identity_headers, template):
     """Setup and teardown steps for templates tests."""
 
     yield svc_client, identity_headers, template
@@ -1128,8 +1157,39 @@ def svc_protected_repo(svc_client, identity_headers):
 
     response = svc_client.post("/cache.project_clone", data=json.dumps(payload), headers=identity_headers)
 
-    project_id = response.json["result"]["project_id"]
-    _ = svc_client.post("/cache.migrate", data=json.dumps(dict(project_id=project_id)), headers=identity_headers)
+    payload = {
+        "project_id": response.json["result"]["project_id"],
+        "skip_template_update": True,
+        "skip_docker_update": True,
+    }
+    svc_client.post("/cache.migrate", data=json.dumps(payload), headers=identity_headers)
+
+    yield svc_client, identity_headers, payload, response
+
+
+@pytest.fixture
+def svc_protected_old_repo(svc_client_with_sync, identity_headers):
+    """Service client with remote protected repository."""
+    svc_client = svc_client_with_sync
+    # from renku.core.management import LocalClient
+    # from renku.core.management.migrate import SUPPORTED_PROJECT_VERSION
+
+    # svc_client, identity_headers, cache, user = svc_client_with_user
+    payload = {
+        "git_url": IT_PROTECTED_REMOTE_REPO_URL,
+    }
+
+    response = svc_client.post("/cache.project_clone", data=json.dumps(payload), headers=identity_headers)
+
+    # project_id = response.json["result"]["project_id"]
+    # project = cache.get_project(user, project_id)
+    # client = LocalClient(path=project.abs_path)
+    # with client.with_metadata() as project:
+    #     old_version = SUPPORTED_PROJECT_VERSION - 1
+    #     project.version = old_version
+    #
+    # client.repo.git.add(".renku")
+    # client.repo.index.commit("Downgrade project version", skip_hooks=True)
 
     yield svc_client, identity_headers, payload, response
 
@@ -1174,7 +1234,7 @@ def svc_protected_repo(svc_client, identity_headers):
         },
     ]
 )
-def service_allowed_endpoint(request, svc_client, mock_redis):
+def service_allowed_endpoint(request, svc_client, mock_redis, mock_sync):
     """Ensure allowed methods and correct headers."""
     methods = {
         "GET": svc_client.get,
@@ -1191,7 +1251,7 @@ def service_allowed_endpoint(request, svc_client, mock_redis):
 
 
 @pytest.fixture
-def service_job(svc_client, mock_redis):
+def service_job(svc_client, mock_redis, mock_sync):
     """Ensure correct environment during testing of service jobs."""
     old_environ = dict(os.environ)
 
@@ -1311,7 +1371,7 @@ def ctrl_init(svc_client_cache):
 
 
 @pytest.fixture
-def reset_environment(svc_client, mock_redis):
+def reset_environment(svc_client, mock_redis, mock_sync):
     """Restore environment variable to their values before test execution."""
     current_environment = os.environ.copy()
 

--- a/conftest.py
+++ b/conftest.py
@@ -1157,12 +1157,8 @@ def svc_protected_repo(svc_client, identity_headers):
 
     response = svc_client.post("/cache.project_clone", data=json.dumps(payload), headers=identity_headers)
 
-    payload = {
-        "project_id": response.json["result"]["project_id"],
-        "skip_template_update": True,
-        "skip_docker_update": True,
-    }
-    svc_client.post("/cache.migrate", data=json.dumps(payload), headers=identity_headers)
+    project_id = response.json["result"]["project_id"]
+    _ = svc_client.post("/cache.migrate", data=json.dumps(dict(project_id=project_id)), headers=identity_headers)
 
     yield svc_client, identity_headers, payload, response
 

--- a/conftest.py
+++ b/conftest.py
@@ -1167,7 +1167,7 @@ def svc_protected_old_repo(svc_synced_client):
     response = svc_client.post("/cache.project_clone", data=json.dumps(payload), headers=identity_headers)
     project_id = response.json["result"]["project_id"]
 
-    yield svc_client, identity_headers, project_id
+    yield svc_client, identity_headers, project_id, cache, user
 
 
 @pytest.fixture(

--- a/renku/core/commands/save.py
+++ b/renku/core/commands/save.py
@@ -24,6 +24,7 @@ import git
 
 from renku.core import errors
 from renku.core.utils.scm import git_unicode_unescape
+from renku.service.logger import worker_log
 
 from .client import pass_local_client
 
@@ -60,7 +61,9 @@ def repo_sync(repo, message=None, remote=None, paths=None):
 
     # get branch that's pushed
     if repo.active_branch.tracking_branch():
-        pushed_branch = repo.active_branch.tracking_branch().name
+        ref = repo.active_branch.tracking_branch().name
+        pushed_branch = ref.split("/")[-1]
+        worker_log.debug(f"PUSHING TO {pushed_branch}")
     else:
         pushed_branch = repo.active_branch.name
 
@@ -116,7 +119,9 @@ def repo_sync(repo, message=None, remote=None, paths=None):
             origin.pull(repo.active_branch)
 
         result = origin.push(repo.active_branch)
+
         if result and "[remote rejected] (pre-receive hook declined)" in result[0].summary:
+            worker_log.debug("SYNC REJECTED")
             # NOTE: Push to new remote branch if original one is protected and reset the cache.
             old_pushed_branch = pushed_branch
             old_active_branch = repo.active_branch
@@ -124,11 +129,17 @@ def repo_sync(repo, message=None, remote=None, paths=None):
             try:
                 repo.create_head(pushed_branch)
                 repo.remote().push(pushed_branch)
+            except Exception as e:
+                worker_log.debug(f"SYNC FAILED, {str(e)}")
             finally:
                 # Reset cache
-                repo.chechout(old_active_branch)
-                ref = f"{origin}/{old_pushed_branch}"
-                repo.index.reset(commit=ref, head=True, working_tree=True)
+                try:
+                    repo.git.checkout(old_active_branch)
+                    ref = f"{origin}/{old_pushed_branch}"
+                    worker_log.debug(f"RESETTING to {ref}         {origin}    {old_pushed_branch}")
+                    repo.index.reset(commit=ref, head=True, working_tree=True)
+                except Exception as e:
+                    worker_log.debug(f"RESET FAILED, {str(e)}")
 
     except git.exc.GitCommandError as e:
         raise errors.GitError("Cannot push changes") from e

--- a/tests/service/jobs/test_jobs.py
+++ b/tests/service/jobs/test_jobs.py
@@ -35,7 +35,7 @@ from tests.service.views.test_dataset_views import assert_rpc_response
 @pytest.mark.integration
 @pytest.mark.jobs
 @flaky(max_runs=30, min_passes=1)
-def test_cleanup_old_files(datapack_zip, svc_client_with_repo, service_job, mock_redis):
+def test_cleanup_old_files(datapack_zip, svc_client_with_repo, service_job):
     """Upload archive and add its contents to a dataset."""
     svc_client, headers, _, _ = svc_client_with_repo
     headers.pop("Content-Type")
@@ -103,7 +103,7 @@ def test_cleanup_files_old_keys(svc_client_with_user, service_job, tmp_path):
 @pytest.mark.jobs
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_cleanup_old_project(datapack_zip, svc_client_with_repo, service_job, mock_redis):
+def test_cleanup_old_project(datapack_zip, svc_client_with_repo, service_job):
     """Upload archive and add its contents to a dataset."""
     svc_client, headers, _, _ = svc_client_with_repo
     headers.pop("Content-Type")

--- a/tests/service/views/test_cache_views.py
+++ b/tests/service/views/test_cache_views.py
@@ -679,9 +679,12 @@ def test_check_no_migrations(svc_client_with_repo):
 
 @pytest.mark.service
 @pytest.mark.integration
-def test_migrating_protected_branch(svc_client_setup):
+@pytest.mark.serial
+@flaky(max_runs=10, min_passes=1)
+def test_migrating_protected_branch(svc_protected_old_repo):
     """Check migrating on a protected branch does not change cache state."""
-    svc_client, headers, project_id, _ = svc_client_setup
+    svc_client, headers, _, response = svc_protected_old_repo
+    project_id = response.json["result"]["project_id"]
 
     response = svc_client.get("/cache.migrations_check", query_string=dict(project_id=project_id), headers=headers)
     assert 200 == response.status_code

--- a/tests/service/views/test_cache_views.py
+++ b/tests/service/views/test_cache_views.py
@@ -683,8 +683,7 @@ def test_check_no_migrations(svc_client_with_repo):
 @flaky(max_runs=10, min_passes=1)
 def test_migrating_protected_branch(svc_protected_old_repo):
     """Check migrating on a protected branch does not change cache state."""
-    svc_client, headers, _, response = svc_protected_old_repo
-    project_id = response.json["result"]["project_id"]
+    svc_client, headers, project_id = svc_protected_old_repo
 
     response = svc_client.get("/cache.migrations_check", query_string=dict(project_id=project_id), headers=headers)
     assert 200 == response.status_code

--- a/tests/service/views/test_dataset_views.py
+++ b/tests/service/views/test_dataset_views.py
@@ -855,7 +855,7 @@ def test_add_existing_file(svc_client_with_repo):
 @pytest.mark.integration
 @pytest.mark.service
 @flaky(max_runs=30, min_passes=1)
-def test_import_dataset_job_enqueue(doi, svc_client_cache, project, mock_redis):
+def test_import_dataset_job_enqueue(doi, svc_client_cache, project):
     """Test import a dataset."""
     client, headers, cache = svc_client_cache
 
@@ -903,7 +903,7 @@ def test_import_dataset_job_enqueue(doi, svc_client_cache, project, mock_redis):
 @pytest.mark.integration
 @pytest.mark.service
 @flaky(max_runs=30, min_passes=1)
-def test_dataset_add_remote(url, svc_client_cache, project_metadata, mock_redis):
+def test_dataset_add_remote(url, svc_client_cache, project_metadata):
     """Test import a dataset."""
     project, project_meta = project_metadata
     client, headers, cache = svc_client_cache
@@ -937,7 +937,7 @@ def test_dataset_add_remote(url, svc_client_cache, project_metadata, mock_redis)
 @pytest.mark.integration
 @pytest.mark.service
 @flaky(max_runs=30, min_passes=1)
-def test_dataset_add_multiple_remote(svc_client_cache, project_metadata, mock_redis):
+def test_dataset_add_multiple_remote(svc_client_cache, project_metadata):
     """Test dataset add multiple remote files."""
     project, project_meta = project_metadata
     url_gist = "https://gist.github.com/jsam/d957f306ed0fe4ff018e902df6a1c8e3"
@@ -1054,7 +1054,7 @@ def test_protected_branch(svc_protected_repo):
 
     assert_rpc_response(response)
     assert {"result"} == set(response.json.keys())
-    assert "master" != response.json["result"]["remote_branch"]
+    assert "master" not in response.json["result"]["remote_branch"]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
# Description

Reset service cache state if pushing to remote branch fails. The push will be done to another remote branch which its name is returned as `remote_branch` in the JSON response.

Fixes #1795 
Fixes #1794 

