### PR TITLE
refactor(core): unify new graph generation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -434,11 +434,11 @@ def client_with_datasets(client, directory_tree):
 
 
 @pytest.fixture()
-def client_with_datasets_provenance(client):
-    """A client with dataset provenance."""
-    from renku.core.incubation.graph import generate_datasets_provenance
+def client_with_new_graph(client):
+    """A client with new graph metadata."""
+    from renku.core.incubation.graph import generate_graph
 
-    generate_datasets_provenance().build().execute()
+    generate_graph().build().execute(force=True)
 
     yield client
 

--- a/renku/cli/graph.py
+++ b/renku/cli/graph.py
@@ -17,15 +17,12 @@
 # limitations under the License.
 """PoC command for testing the new graph design."""
 
-import functools
-import sys
-
 import click
 
 from renku.cli.utils.callback import ClickCallback
 from renku.cli.utils.click import CaseInsensitiveChoice
 from renku.core.incubation.command import Command
-from renku.core.incubation.graph import export_graph, generate_datasets_provenance, generate_graph
+from renku.core.incubation.graph import FORMATS, export_graph, generate_graph
 from renku.core.incubation.graph import status as get_status
 from renku.core.incubation.graph import update as perform_update
 from renku.core.models.workflow.dependency_graph import DependencyGraph
@@ -122,62 +119,13 @@ def save(path):
         Command().command(_to_png).build().execute(path=path)
 
 
-def _dot(rdf_graph, simple=True, debug=False, landscape=False):
-    """Format graph as a dot file."""
-    from rdflib.tools.rdf2dot import rdf2dot
-
-    from renku.core.commands.format.graph import _rdf2dot_reduced, _rdf2dot_simple
-
-    if debug:
-        rdf2dot(rdf_graph, sys.stdout)
-        return
-
-    sys.stdout.write('digraph { \n node [ fontname="DejaVu Sans" ] ; \n ')
-    if landscape:
-        sys.stdout.write('rankdir="LR" \n')
-    if simple:
-        _rdf2dot_simple(rdf_graph, sys.stdout, graph=graph)
-        return
-    _rdf2dot_reduced(rdf_graph, sys.stdout)
-
-
-_dot_full = functools.partial(_dot, simple=False, landscape=False)
-_dot_landscape = functools.partial(_dot, simple=True, landscape=True)
-_dot_full_landscape = functools.partial(_dot, simple=False, landscape=True)
-_dot_debug = functools.partial(_dot, debug=True)
-
-
-def _json_ld(rdf_graph):
-    """Format graph as JSON-LD."""
-    data = rdf_graph.serialize(format="json-ld").decode("utf-8")
-    print(data)
-
-
-_FORMATS = {
-    "dot": _dot,
-    "dot-full": _dot_full,
-    "dot-landscape": _dot_landscape,
-    "dot-full-landscape": _dot_full_landscape,
-    "dot-debug": _dot_debug,
-    "json-ld": _json_ld,
-    "jsonld": _json_ld,
-}
-
-
 @graph.command()
-@click.option("--format", type=CaseInsensitiveChoice(_FORMATS), default="json-ld", help="Choose an output format.")
-@click.option("-d", "--dataset", is_flag=True, help="Include datasets.")
-def export(format, dataset):
+@click.option("--format", type=CaseInsensitiveChoice(FORMATS), default="json-ld", help="Choose an output format.")
+@click.option("--strict", is_flag=True, default=False, help="Validate triples before output.")
+@click.option("--workflows-only", is_flag=True, help="Exclude datasets metadata from export.")
+def export(format, strict, workflows_only):
     r"""Equivalent of `renku log --format json-ld`."""
     communicator = ClickCallback()
-    (export_graph().with_communicator(communicator).build().execute(format=_FORMATS[format], dataset=dataset))
-
-
-@graph.command()
-@click.option("-f", "--force", is_flag=True, help="Delete existing metadata and regenerate all.")
-def generate_dataset(force):
-    """Create new graph metadata for datasets."""
-    communicator = ClickCallback()
-    (generate_datasets_provenance().with_communicator(communicator).build().execute(force=force))
-
-    click.secho("\nOK", fg="green")
+    export_graph().with_communicator(communicator).build().execute(
+        format=format, workflows_only=workflows_only, strict=strict
+    )

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -131,8 +131,19 @@ class DatasetsApiMixin(object):
         self.datasets_provenance.to_json()
 
     def has_datasets_provenance_file(self):
-        """Return true if dependency or provenance graph exists."""
+        """Return true if dataset provenance exists."""
         return self.datasets_provenance_path.exists()
+
+    def remove_datasets_provenance_file(self):
+        """Remove dataset provenance."""
+        try:
+            self.datasets_provenance_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    def initialize_datasets_provenance(self):
+        """Create empty dataset provenance file."""
+        self.datasets_provenance_path.write_text("[]")
 
     def datasets_from_commit(self, commit=None):
         """Return datasets defined in a commit."""

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -134,6 +134,8 @@ class RepositoryApiMixin(GitCore):
 
     _remote_cache = attr.ib(factory=dict)
 
+    _dependency_graph = None
+
     def __attrs_post_init__(self):
         """Initialize computed attributes."""
         #: Configure Renku path.
@@ -215,6 +217,16 @@ class RepositoryApiMixin(GitCore):
         """Return a CWL prefix."""
         self.workflow_path.mkdir(parents=True, exist_ok=True)  # for Python 3.5
         return str(self.workflow_path.resolve().relative_to(self.path))
+
+    @property
+    def dependency_graph(self):
+        """Return dependency graph if available."""
+        if not self.has_graph_files():
+            return
+        if not self._dependency_graph:
+            self._dependency_graph = DependencyGraph.from_json(self.dependency_graph_path)
+
+        return self._dependency_graph
 
     @property
     def project(self):
@@ -488,6 +500,22 @@ class RepositoryApiMixin(GitCore):
     def has_graph_files(self):
         """Return true if dependency or provenance graph exists."""
         return self.dependency_graph_path.exists() or self.provenance_graph_path.exists()
+
+    def initialize_graph(self):
+        """Create empty graph files."""
+        self.dependency_graph_path.write_text("[]")
+        self.provenance_graph_path.write_text("[]")
+
+    def remove_graph_files(self):
+        """Remove all graph files."""
+        try:
+            self.dependency_graph_path.unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            self.provenance_graph_path.unlink()
+        except FileNotFoundError:
+            pass
 
     def init_repository(self, force=False, user=None):
         """Initialize an empty Renku repository."""

--- a/renku/core/models/provenance/datasets.py
+++ b/renku/core/models/provenance/datasets.py
@@ -463,7 +463,7 @@ class NewDatasetFileSchema(JsonLDSchema):
     based_on = Nested(schema.isBasedOn, DatasetFileSchema, missing=None, propagate_client=False)
     date_added = DateTimeList(schema.dateCreated, format="iso", extra_formats=("%Y-%m-%d",))
     date_deleted = fields.DateTime(prov.invalidatedAtTime, missing=None, allow_none=True, format="iso")
-    entity = Nested(renku.entity, EntitySchema)
+    entity = Nested(prov.entity, EntitySchema)
     id = fields.Id()
     is_external = fields.Boolean(renku.external, missing=False)
     source = fields.String(renku.source, missing=None)

--- a/renku/data/new_graph_shacl_shape.json
+++ b/renku/data/new_graph_shacl_shape.json
@@ -1,0 +1,1131 @@
+{
+   "@context": {
+      "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "sh": "http://www.w3.org/ns/shacl#",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "schema": "http://schema.org/",
+      "prov": "http://www.w3.org/ns/prov#",
+      "renku": "https://swissdatasciencecenter.github.io/renku-ontology#",
+      "closed": {
+         "@id": "sh:closed",
+         "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+      },
+      "datatype": {
+         "@id": "sh:datatype",
+         "@type": "@id"
+      },
+      "ignoredProperties": {
+         "@id": "sh:ignoredProperties",
+         "@container": "@list"
+      },
+      "or": {
+         "@id": "sh:or",
+         "@container": "@list"
+      },
+      "minCount": "sh:minCount",
+      "maxCount": "sh:maxCount",
+      "nodeKind": {
+         "@id": "sh:nodeKind",
+         "@type": "@id"
+      },
+      "property": "sh:property",
+      "path": {
+         "@id": "sh:path",
+         "@type": "@id"
+      },
+      "targetClass": {
+         "@id": "sh:targetClass",
+         "@type": "@id"
+      },
+      "target": {
+         "@id": "sh:target",
+         "@type": "@id"
+      }
+   },
+   "@graph": [
+      {
+         "@id": "schema:",
+         "sh:declare": [
+            {
+               "sh:prefix": [
+                  {
+                     "@value": "schema"
+                  }
+               ],
+               "sh:namespace": [
+                  {
+                     "@value": "http://schema.org/",
+                     "@type": "xsd:anyURI"
+                  }
+               ]
+            }
+         ]
+      },
+      {
+         "@id": "prov:",
+         "sh:declare": [
+            {
+               "sh:prefix": [
+                  {
+                     "@value": "prov"
+                  }
+               ],
+               "sh:namespace": [
+                  {
+                     "@value": "http://www.w3.org/ns/prov#",
+                     "@type": "xsd:anyURI"
+                  }
+               ]
+            }
+         ]
+      },
+      {
+         "@id": "_:projectShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "schema:Project",
+         "property": [
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:dateCreated",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:schemaVersion",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:agent",
+               "datatype": {
+                 "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:name",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "path": "schema:creator",
+               "sh:class":{
+                  "@id": "schema:Person"
+               },
+               "minCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:templateSource",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:templateReference",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:templateId",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:templateVersion",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:templateMetadata",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:immutableTemplateFiles",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:automatedTemplateUpdate",
+               "datatype": {
+                  "@id": "xsd:boolean"
+               },
+               "maxCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:creatorShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "target": [
+            {
+               "@type": "sh:SPARQLTarget",
+               "sh:prefixes": [
+                  {
+                     "@id": "schema:"
+                  },
+                  {
+                     "@id": "prov:"
+                  }
+               ],
+               "sh:select": [
+                  {
+                     "@value": "SELECT ?this\nWHERE {\n  ?this a schema:Person .\n  MINUS { ?this a prov:Person . }\n}\n"
+                  }
+               ]
+            }
+         ],
+         "property": [
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:name",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:email",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:alternateName",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:affiliation",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            }
+         ]
+      },
+      {
+         "@id": "_:datasetShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "schema:Dataset",
+         "property": [
+            {
+               "path": "schema:creator",
+               "sh:class": {
+                  "@id": "schema:Person"
+               },
+               "minCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:dateCreated",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1,
+               "sh:lessThanOrEquals": {
+                  "@id": "schema:datePublished"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "prov:invalidatedAtTime",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1,
+               "sh:moreThanOrEquals": {
+                  "@id": "schema:dateCreated"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:datePublished",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:description",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1
+            },
+            {
+               "path": "prov:wasDerivedFrom",
+               "sh:class": {
+                  "@id": "schema:URL"
+               }
+            },
+            {
+               "path": "schema:hasPart",
+               "sh:class": {
+                  "@id": "schema:DigitalDocument"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:identifier",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "path": "schema:inLanguage",
+               "sh:class": {
+                  "@id": "schema:Language"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:keywords",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:license",
+               "or": [
+                  {
+                     "nodeKind": "sh:Literal",
+                     "datatype": {
+                        "@id": "xsd:string"
+                     }
+                  },
+                  {
+                     "nodeKind": "sh:BlankNodeOrIRI"
+                  }
+               ]
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:alternateName",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:originalIdentifier",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 0,
+               "maxCount": 1
+            },
+            {
+               "path": "schema:isPartOf",
+               "sh:class": {
+                  "@id": "schema:Project"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "path": "schema:sameAs",
+               "sh:class": {
+                  "@id": "schema:URL"
+               }
+            },
+            {
+               "path": "schema:subjectOf",
+               "sh:class": {
+                  "@id": "schema:PublicationEvent"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:name",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:url",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:version",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            }
+         ]
+      },
+      {
+         "@id": "_:URLShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "schema:URL",
+         "property": [
+            {
+               "path": "schema:url",
+               "or": [
+                  {
+                     "nodeKind": "sh:Literal",
+                     "datatype": {
+                        "@id": "xsd:string"
+                     }
+                  },
+                  {
+                     "nodeKind": "sh:IRI"
+                  }
+               ],
+               "maxCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:inLanguageShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "schema:Language",
+         "property": [
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:name",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:alternateName",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            }
+         ]
+      },
+      {
+         "@id": "_:datasetTagShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "schema:PublicationEvent",
+         "property": [
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:name",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:description",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:startDate",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:location",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:about",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:datasetFileShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "schema:DigitalDocument",
+         "property": [
+            {
+               "path": "schema:isBasedOn",
+               "sh:class": {
+                  "@id": "schema:DigitalDocument"
+               },
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:dateCreated",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "prov:invalidatedAtTime",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "maxCount": 1
+            },
+            {
+               "path": "prov:entity",
+               "sh:class": {
+                  "@id": "prov:Entity"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:external",
+               "datatype": {
+                  "@id": "xsd:boolean"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:source",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:url",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:usageShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "prov:Usage",
+         "property": [
+            {
+               "path": "prov:entity",
+               "minCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "prov:hadRole",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            }
+         ]
+      },
+      {
+         "@id": "_:activityShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "prov:Activity",
+         "property": [
+            {
+               "path": "prov:wasAssociatedWith",
+               "or": [
+                  {
+                     "sh:class": {
+                        "@id": "prov:SoftwareAgent"
+                     }
+                  },
+                  {
+                     "sh:class": {
+                        "@id": "schema:Person"
+                     }
+                  },
+                  {
+                     "nodeKind": "sh:IRI"
+                  }
+               ],
+               "minCount": 2,
+               "maxCount": 2
+            },
+            {
+               "path": "prov:qualifiedAssociation",
+               "sh:class": {
+                  "@id": "prov:Association"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "prov:endedAtTime",
+               "datatype": {
+                  "@id": "xsd:dateTime"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "path": "prov:qualifiedGeneration",
+               "sh:class": {
+                  "@id": "prov:Generation"
+               }
+            },
+            {
+               "path": "renku:order",
+               "datatype": {
+                  "@id": "xsd:integer"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "path": "schema:isPartOf",
+               "sh:class": {
+                  "@id": "schema:Project"
+               },
+               "minCount": 0,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "prov:atLocation",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "path": "prov:qualifiedUsage",
+               "sh:class": {
+                  "@id": "prov:Usage"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "prov:startedAtTime",
+               "datatype": {
+                  "@id": "xsd:dateTime"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:associationShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "prov:Association",
+         "property": [
+            {
+               "path": "prov:hadPlan",
+               "sh:class": {
+                  "@id": "prov:Plan"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "path": "prov:agent",
+               "sh:class": {
+                  "@id": "prov:SoftwareAgent"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:softwareAgentShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "prov:SoftwareAgent",
+         "property": [
+            {
+               "nodeKind": "sh:Literal",
+               "path": "rdfs:label",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1,
+               "sh:pattern": "renku (pre )?\\d+\\.\\d+\\.\\d+(?:\\.dev\\d+)?",
+               "sh:flags": "i"
+            }
+         ]
+      },
+      {
+         "@id": "_:generationShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "prov:Generation",
+         "property": [
+            {
+               "path": {
+                  "sh:inversePath": {
+                     "@id": "prov:qualifiedGeneration"
+                  }
+               },
+               "nodeKind": "sh:BlankNodeOrIRI"
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "prov:hadRole",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "sh:class": {
+                  "@id": "prov:Activity"
+               },
+               "path": "prov:activity",
+               "minCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:entityShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": false,
+         "target": [
+            {
+               "@type": "sh:SPARQLTarget",
+               "sh:prefixes": [
+                  {
+                     "@id": "schema:"
+                  }
+               ],
+               "sh:select": [
+                  {
+                     "@value": "SELECT ?this WHERE { ?this a prov:Entity . FILTER NOT EXISTS { ?this a schema:Dataset } FILTER NOT EXISTS { ?this a schema:DigitalDocument } }"
+                  }
+               ]
+            }
+         ],
+         "property": [
+            {
+               "sh:class": {
+                  "@id": "prov:Activity"
+               },
+               "path": "prov:wasInvalidatedBy"
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "prov:atLocation",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:planShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "prov:Plan",
+         "property": [
+            {
+               "sh:class": {
+                  "@id": "renku:CommandArgument"
+               },
+               "path": "renku:hasArguments"
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:command",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "sh:class": {
+                  "@id": "renku:CommandInputTemplate"
+               },
+               "path": "renku:hasInputs"
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:name",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 0,
+               "maxCount": 1
+            },
+            {
+               "sh:class": {
+                  "@id": "renku:CommandOutputTemplate"
+               },
+               "path": "renku:hasOutputs"
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:successCodes",
+               "datatype": {
+                  "@id": "xsd:integer"
+               }
+            }
+         ]
+      },
+      {
+         "@id": "_:renkuCommandArgumentShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "renku:CommandArgument",
+         "property": [
+            {
+               "nodeKind": "sh:Literal",
+               "path": "rdfs:label",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:position",
+               "datatype": {
+                  "@id": "xsd:integer"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:prefix",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:value",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            }
+         ]
+      },
+      {
+         "@id": "_:renkuRunParameterShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "renku:RunParameter",
+         "property": [
+            {
+               "nodeKind": "sh:Literal",
+               "path": "rdfs:label",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "schema:name",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:type",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:value",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:commandInputTemplateShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "renku:CommandInputTemplate",
+         "property": [
+            {
+               "nodeKind": "sh:Literal",
+               "path": "rdfs:label",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:position",
+               "datatype": {
+                  "@id": "xsd:integer"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:prefix",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "path": "renku:consume",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 1,
+               "maxCount": 1
+            },
+            {
+               "path": "renku:mappedTo",
+               "sh:class": {
+                  "@id": "renku:IOStream"
+               },
+               "minCount": 0,
+               "maxCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:commandOutputTemplateShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "renku:CommandOutputTemplate",
+         "property": [
+            {
+               "nodeKind": "sh:Literal",
+               "path": "rdfs:label",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:position",
+               "datatype": {
+                  "@id": "xsd:integer"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:prefix",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:createFolder",
+               "datatype": {
+                  "@id": "xsd:boolean"
+               }
+            },
+            {
+               "path": "renku:mappedTo",
+               "sh:class": {
+                  "@id": "renku:IOStream"
+               },
+               "minCount": 0,
+               "maxCount": 1
+            },
+            {
+               "path": "renku:produces",
+               "datatype": {
+                  "@id": "xsd:string"
+               },
+               "minCount": 0,
+               "maxCount": 1
+            }
+         ]
+      },
+      {
+         "@id": "_:renkuIOStreamShape",
+         "@type": "sh:NodeShape",
+         "ignoredProperties": [
+            {
+               "@id": "rdf:type"
+            }
+         ],
+         "closed": true,
+         "targetClass": "renku:IOStream",
+         "property": [
+            {
+               "nodeKind": "sh:Literal",
+               "path": "renku:streamType",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
+               "path": "rdfs:label",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1750,7 +1750,7 @@ def test_immutability_after_remove(directory_tree, runner, client):
     assert_dataset_is_mutated(old=old_dataset, new=dataset)
 
 
-def test_datasets_provenance_after_create(runner, client_with_datasets_provenance):
+def test_datasets_provenance_after_create(runner, client_with_new_graph):
     """Test datasets provenance is updated after creating a dataset."""
     assert (
         0
@@ -1776,7 +1776,7 @@ def test_datasets_provenance_after_create(runner, client_with_datasets_provenanc
         ).exit_code
     )
 
-    dataset = client_with_datasets_provenance.datasets_provenance.get_by_name("my-data")[0]
+    dataset = client_with_new_graph.datasets_provenance.get_by_name("my-data")[0]
 
     assert "Long Title" == dataset.title
     assert "my-data" == dataset.name
@@ -1786,19 +1786,19 @@ def test_datasets_provenance_after_create(runner, client_with_datasets_provenanc
     assert "John Smiths" in [c.name for c in dataset.creators]
     assert "john.smiths@mail.ch" in [c.email for c in dataset.creators]
     assert {"keyword-1", "keyword-2"} == set(dataset.keywords)
-    assert client_with_datasets_provenance.project._id == dataset.project._id
+    assert client_with_new_graph.project._id == dataset.project._id
 
-    assert not client_with_datasets_provenance.repo.is_dirty()
+    assert not client_with_new_graph.repo.is_dirty()
 
 
-def test_datasets_provenance_after_edit(runner, client_with_datasets_provenance):
+def test_datasets_provenance_after_edit(runner, client_with_new_graph):
     """Test datasets provenance is updated after editing a dataset."""
     assert 0 == runner.invoke(cli, ["dataset", "create", "my-data"]).exit_code
     assert 0 == runner.invoke(cli, ["dataset", "edit", "my-data", "-k", "new-data"]).exit_code
 
-    dataset = client_with_datasets_provenance.load_dataset("my-data")
-    current_version = client_with_datasets_provenance.datasets_provenance.get(dataset.identifier)
-    old_version = client_with_datasets_provenance.datasets_provenance.get(dataset.original_identifier)
+    dataset = client_with_new_graph.load_dataset("my-data")
+    current_version = client_with_new_graph.datasets_provenance.get(dataset.identifier)
+    old_version = client_with_new_graph.datasets_provenance.get(dataset.original_identifier)
 
     assert current_version.identifier != old_version.identifier
     assert current_version.name == old_version.name
@@ -1806,14 +1806,14 @@ def test_datasets_provenance_after_edit(runner, client_with_datasets_provenance)
     assert {"new-data"} == set(current_version.keywords)
 
 
-def test_datasets_provenance_after_add(runner, client_with_datasets_provenance, directory_tree):
+def test_datasets_provenance_after_add(runner, client_with_new_graph, directory_tree):
     """Test datasets provenance is updated after adding data to a dataset."""
     assert 0 == runner.invoke(cli, ["dataset", "add", "my-data", "-c", str(directory_tree / "file1")]).exit_code
 
-    dataset = client_with_datasets_provenance.datasets_provenance.get_by_name("my-data")[0]
+    dataset = client_with_new_graph.datasets_provenance.get_by_name("my-data")[0]
     path = os.path.join(DATA_DIR, "my-data", "file1")
     file_ = dataset.find_file(path)
-    object_hash = client_with_datasets_provenance.repo.git.rev_parse(f"HEAD:{path}")
+    object_hash = client_with_new_graph.repo.git.rev_parse(f"HEAD:{path}")
 
     assert object_hash in file_.entity._id
     assert path in file_.entity._id
@@ -1821,28 +1821,28 @@ def test_datasets_provenance_after_add(runner, client_with_datasets_provenance, 
     assert path == file_.entity.path
 
 
-def test_datasets_provenance_not_updated_after_same_add(runner, client_with_datasets_provenance, directory_tree):
+def test_datasets_provenance_not_updated_after_same_add(runner, client_with_new_graph, directory_tree):
     """Test datasets provenance is not updated if adding same files multiple times."""
     assert 0 == runner.invoke(cli, ["dataset", "add", "my-data", "--create", str(directory_tree)]).exit_code
-    commit_sha_before = client_with_datasets_provenance.repo.head.object.hexsha
+    commit_sha_before = client_with_new_graph.repo.head.object.hexsha
 
     assert 1 == runner.invoke(cli, ["dataset", "add", "my-data", str(directory_tree)]).exit_code
-    commit_sha_after = client_with_datasets_provenance.repo.head.object.hexsha
+    commit_sha_after = client_with_new_graph.repo.head.object.hexsha
 
-    datasets = client_with_datasets_provenance.datasets_provenance.get_by_name("my-data")
+    datasets = client_with_new_graph.datasets_provenance.get_by_name("my-data")
 
     assert 1 == len(datasets)
     assert commit_sha_before == commit_sha_after
 
 
-def test_datasets_provenance_after_file_unlink(runner, client_with_datasets_provenance, directory_tree):
+def test_datasets_provenance_after_file_unlink(runner, client_with_new_graph, directory_tree):
     """Test datasets provenance is updated after removing data."""
     assert 0 == runner.invoke(cli, ["dataset", "add", "my-data", "-c", str(directory_tree)]).exit_code
     assert 0 == runner.invoke(cli, ["dataset", "unlink", "my-data", "--include", "*/dir1/*"], input="y").exit_code
 
-    dataset = client_with_datasets_provenance.load_dataset("my-data")
-    current_version = client_with_datasets_provenance.datasets_provenance.get(dataset.identifier)
-    old_version = client_with_datasets_provenance.datasets_provenance.get(dataset.original_identifier)
+    dataset = client_with_new_graph.load_dataset("my-data")
+    current_version = client_with_new_graph.datasets_provenance.get(dataset.identifier)
+    old_version = client_with_new_graph.datasets_provenance.get(dataset.original_identifier)
     path = os.path.join(DATA_DIR, "my-data", directory_tree.name, "file1")
 
     assert 1 == len(current_version.files)
@@ -1850,70 +1850,70 @@ def test_datasets_provenance_after_file_unlink(runner, client_with_datasets_prov
     assert 3 == len(old_version.files)
 
 
-def test_datasets_provenance_after_remove(runner, client_with_datasets_provenance, directory_tree):
+def test_datasets_provenance_after_remove(runner, client_with_new_graph, directory_tree):
     """Test datasets provenance is updated after removing a dataset."""
     assert 0 == runner.invoke(cli, ["dataset", "add", "my-data", "-c", str(directory_tree)]).exit_code
     assert 0 == runner.invoke(cli, ["dataset", "rm", "my-data"]).exit_code
 
-    datasets = client_with_datasets_provenance.datasets_provenance.get_by_name("my-data")
+    datasets = client_with_new_graph.datasets_provenance.get_by_name("my-data")
     current_version = next(d for d in datasets if d.identifier != d.original_identifier)
 
     assert current_version.date_deleted is not None
 
 
 @pytest.mark.serial
-def test_datasets_provenance_after_update(runner, client_with_datasets_provenance, directory_tree):
+def test_datasets_provenance_after_update(runner, client_with_new_graph, directory_tree):
     """Test datasets provenance is updated after updating a dataset."""
     assert 0 == runner.invoke(cli, ["dataset", "add", "-c", "--external", "my-data", str(directory_tree)]).exit_code
 
     directory_tree.joinpath("file1").write_text("some updates")
     assert 0 == runner.invoke(cli, ["dataset", "update", "--external"]).exit_code
 
-    dataset = client_with_datasets_provenance.load_dataset("my-data")
-    current_version = client_with_datasets_provenance.datasets_provenance.get(dataset.identifier)
+    dataset = client_with_new_graph.load_dataset("my-data")
+    current_version = client_with_new_graph.datasets_provenance.get(dataset.identifier)
 
     assert current_version.identifier != current_version.original_identifier
 
 
-def test_datasets_provenance_after_adding_tag(runner, client_with_datasets_provenance):
+def test_datasets_provenance_after_adding_tag(runner, client_with_new_graph):
     """Test datasets provenance is updated after tagging a dataset."""
     assert 0 == runner.invoke(cli, ["dataset", "create", "my-data"]).exit_code
 
     assert 0 == runner.invoke(cli, ["dataset", "tag", "my-data", "42.0"]).exit_code
 
-    datasets = client_with_datasets_provenance.datasets_provenance.get_by_name("my-data")
+    datasets = client_with_new_graph.datasets_provenance.get_by_name("my-data")
 
     assert 1 == len(datasets)
     assert "42.0" in [t.name for t in datasets[0].tags]
 
 
-def test_datasets_provenance_after_removing_tag(runner, client_with_datasets_provenance):
+def test_datasets_provenance_after_removing_tag(runner, client_with_new_graph):
     """Test datasets provenance is updated after removing a dataset's tag."""
     assert 0 == runner.invoke(cli, ["dataset", "create", "my-data"]).exit_code
     assert 0 == runner.invoke(cli, ["dataset", "tag", "my-data", "42.0"]).exit_code
 
     assert 0 == runner.invoke(cli, ["dataset", "rm-tags", "my-data", "42.0"]).exit_code
 
-    datasets = client_with_datasets_provenance.datasets_provenance.get_by_name("my-data")
+    datasets = client_with_new_graph.datasets_provenance.get_by_name("my-data")
 
     assert 1 == len(datasets)
     assert "42.0" not in [t.name for t in datasets[0].tags]
 
 
-def test_datasets_provenance_multiple(runner, client_with_datasets_provenance, directory_tree):
+def test_datasets_provenance_multiple(runner, client_with_new_graph, directory_tree):
     """Test datasets provenance is updated after multiple dataset operations."""
     assert 0 == runner.invoke(cli, ["dataset", "create", "my-data"]).exit_code
-    version_1 = client_with_datasets_provenance.load_dataset("my-data")
+    version_1 = client_with_new_graph.load_dataset("my-data")
     assert 0 == runner.invoke(cli, ["dataset", "edit", "my-data", "-k", "new-data"]).exit_code
-    version_2 = client_with_datasets_provenance.load_dataset("my-data")
+    version_2 = client_with_new_graph.load_dataset("my-data")
     assert 0 == runner.invoke(cli, ["dataset", "add", "my-data", str(directory_tree)]).exit_code
-    version_3 = client_with_datasets_provenance.load_dataset("my-data")
+    version_3 = client_with_new_graph.load_dataset("my-data")
     assert 0 == runner.invoke(cli, ["dataset", "tag", "my-data", "42.0"]).exit_code
-    version_4 = client_with_datasets_provenance.load_dataset("my-data")
+    version_4 = client_with_new_graph.load_dataset("my-data")
     assert 0 == runner.invoke(cli, ["dataset", "unlink", "my-data", "--include", "*/dir1/*"], input="y").exit_code
-    version_5 = client_with_datasets_provenance.load_dataset("my-data")
+    version_5 = client_with_new_graph.load_dataset("my-data")
 
-    datasets_provenance = client_with_datasets_provenance.datasets_provenance
+    datasets_provenance = client_with_new_graph.datasets_provenance
 
     assert datasets_provenance.get(version_1.identifier)
     assert datasets_provenance.get(version_2.identifier)

--- a/tests/cli/test_graph.py
+++ b/tests/cli/test_graph.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2020 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test ``graph`` command."""
+
+import pytest
+
+from renku.cli import cli
+from renku.core.management.repository import DEFAULT_DATA_DIR as DATA_DIR
+
+
+@pytest.mark.parametrize("format", ["json-ld", "jsonld"])
+def test_graph_export_validation(runner, client, directory_tree, run, format):
+    """Test graph validation when exporting."""
+    assert 0 == runner.invoke(cli, ["dataset", "add", "-c", "my-data", str(directory_tree)]).exit_code
+    assert 0 == runner.invoke(cli, ["graph", "generate"]).exit_code
+    file1 = client.path / DATA_DIR / "my-data" / directory_tree.name / "file1"
+    file2 = client.path / DATA_DIR / "my-data" / directory_tree.name / "dir1" / "file2"
+    assert 0 == run(["run", "head", str(file1)], stdout="out1")
+    assert 0 == run(["run", "tail", str(file2)], stdout="out2")
+
+    result = runner.invoke(cli, ["graph", "export", "--format", format, "--strict"])
+
+    assert 0 == result.exit_code, result.output

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -1402,18 +1402,18 @@ def test_import_returns_last_dataset_version(runner, client, url):
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_datasets_provenance_after_import(runner, client_with_datasets_provenance):
+def test_datasets_provenance_after_import(runner, client_with_new_graph):
     """Test dataset provenance is updated after importing a dataset."""
     assert 0 == runner.invoke(cli, ["dataset", "import", "-y", "--name", "my-data", "10.7910/DVN/F4NUMR"]).exit_code
 
-    dataset = client_with_datasets_provenance.datasets_provenance.get_by_name("my-data")
+    dataset = client_with_new_graph.datasets_provenance.get_by_name("my-data")
 
     assert dataset is not None
 
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_datasets_provenance_after_git_update(client_with_datasets_provenance, runner):
+def test_datasets_provenance_after_git_update(client_with_new_graph, runner):
     """Test dataset provenance is updated after an update."""
     url = "https://github.com/SwissDataScienceCenter/renku-jupyter.git"
 
@@ -1422,22 +1422,22 @@ def test_datasets_provenance_after_git_update(client_with_datasets_provenance, r
 
     assert 0 == runner.invoke(cli, ["dataset", "update"], catch_exceptions=False).exit_code
 
-    dataset = client_with_datasets_provenance.load_dataset("my-data")
-    current_version = client_with_datasets_provenance.datasets_provenance.get(dataset.identifier)
+    dataset = client_with_new_graph.load_dataset("my-data")
+    current_version = client_with_new_graph.datasets_provenance.get(dataset.identifier)
 
     assert current_version.identifier != current_version.original_identifier
 
 
 @pytest.mark.integration
 @flaky(max_runs=10, min_passes=1)
-def test_datasets_provenance_after_external_provider_update(client_with_datasets_provenance, runner):
+def test_datasets_provenance_after_external_provider_update(client_with_new_graph, runner):
     """Test dataset provenance is updated after an update from an external provider."""
     doi = "10.5281/zenodo.2658634"
     assert 0 == runner.invoke(cli, ["dataset", "import", "-y", "--name", "my-data", doi]).exit_code
 
     assert 0 == runner.invoke(cli, ["dataset", "update", "my-data"]).exit_code
 
-    dataset = client_with_datasets_provenance.load_dataset("my-data")
-    current_version = client_with_datasets_provenance.datasets_provenance.get(dataset.identifier)
+    dataset = client_with_new_graph.load_dataset("my-data")
+    current_version = client_with_new_graph.datasets_provenance.get(dataset.identifier)
 
     assert current_version.identifier != current_version.original_identifier

--- a/tests/core/commands/test_client.py
+++ b/tests/core/commands/test_client.py
@@ -83,6 +83,7 @@ def test_safe_class_attributes(tmpdir):
         "_CMD_STORAGE_UNTRACK",
         "_LFS_HEADER",
         "_datasets_provenance",
+        "_dependency_graph",
         "_global_config_dir",
         "_temporary_datasets_path",
     ]


### PR DESCRIPTION
# Description

Use `renku graph generate` to generate new graph metadata for both workflows and datasets. Use `renku graph export` to generate triples for workflows and datasets.
