### PR TITLE
feat(core): renku login

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,7 @@
 import importlib
 
 CLI_FIXTURE_LOCATIONS = [
+    "tests.cli.fixtures.cli_gateway",
     "tests.cli.fixtures.cli_kg",
     "tests.cli.fixtures.cli_old_projects",
     "tests.cli.fixtures.cli_projects",

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -62,6 +62,13 @@ Renku Command Line
 
 .. automodule:: renku.cli.log
 
+.. _cli-login:
+
+``renku login``
+---------------
+
+.. automodule:: renku.cli.login
+
 .. _cli-status:
 
 ``renku status``

--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -80,7 +80,7 @@ from renku.cli.githooks import githooks as githooks_command
 from renku.cli.graph import graph
 from renku.cli.init import init as init_command
 from renku.cli.log import log
-from renku.cli.login import login, logout
+from renku.cli.login import login, logout, token
 from renku.cli.migrate import check_immutable_template_files, migrate, migrationscheck
 from renku.cli.move import move
 from renku.cli.remove import remove
@@ -212,6 +212,7 @@ cli.add_command(save)
 cli.add_command(show)
 cli.add_command(status)
 cli.add_command(storage)
+cli.add_command(token)
 cli.add_command(update)
 cli.add_command(workflow)
 cli.add_command(service)

--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -80,7 +80,7 @@ from renku.cli.githooks import githooks as githooks_command
 from renku.cli.graph import graph
 from renku.cli.init import init as init_command
 from renku.cli.log import log
-from renku.cli.login import login, logout, token
+from renku.cli.login import login, logout
 from renku.cli.migrate import check_immutable_template_files, migrate, migrationscheck
 from renku.cli.move import move
 from renku.cli.remove import remove
@@ -212,7 +212,6 @@ cli.add_command(save)
 cli.add_command(show)
 cli.add_command(status)
 cli.add_command(storage)
-cli.add_command(token)
 cli.add_command(update)
 cli.add_command(workflow)
 cli.add_command(service)

--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -80,6 +80,7 @@ from renku.cli.githooks import githooks as githooks_command
 from renku.cli.graph import graph
 from renku.cli.init import init as init_command
 from renku.cli.log import log
+from renku.cli.login import login, logout
 from renku.cli.migrate import check_immutable_template_files, migrate, migrationscheck
 from renku.cli.move import move
 from renku.cli.remove import remove
@@ -103,7 +104,7 @@ from renku.core.management.repository import default_path
 #: Monkeypatch Click application.
 click_completion.init()
 
-WARNING_UNPROTECTED_COMMANDS = ["init", "clone", "service", "help"]
+WARNING_UNPROTECTED_COMMANDS = ["clone", "init", "help", "login", "logout", "service"]
 
 
 def _uuid_representer(dumper, data):
@@ -198,6 +199,8 @@ cli.add_command(githooks_command)
 cli.add_command(graph)
 cli.add_command(init_command)
 cli.add_command(log)
+cli.add_command(login)
+cli.add_command(logout)
 cli.add_command(migrate)
 cli.add_command(migrationscheck)
 cli.add_command(check_immutable_template_files)

--- a/renku/cli/login.py
+++ b/renku/cli/login.py
@@ -19,7 +19,7 @@
 
 You can use ``renku login`` command to authenticate with a remote Renku
 deployment. This command will bring up a browser window where you can log in
-using your credentials. Renku CLI receives and stores a secure token where will
+using your credentials. Renku CLI receives and stores a secure token that will
 be used for future authentications.
 
 .. code-block:: console

--- a/renku/cli/login.py
+++ b/renku/cli/login.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2021 Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Logging in to a Renku deployment.
+
+TODO: Write Documentation
+"""
+
+import click
+
+from renku.cli.utils.callback import ClickCallback
+from renku.core.commands.login import login_command, logout_command
+
+
+@click.command()
+@click.argument("endpoint", required=False, default=None)
+def login(endpoint):
+    """Log in to the platform."""
+    communicator = ClickCallback()
+    login_command().with_communicator(communicator).build().execute(endpoint=endpoint)
+
+    # TODO: Print a warning that token is stored in plain-text
+
+
+@click.command()
+def logout():
+    """Logout from the platform and delete credentials."""
+    communicator = ClickCallback()
+    logout_command().with_communicator(communicator).build().execute()

--- a/renku/cli/login.py
+++ b/renku/cli/login.py
@@ -45,7 +45,10 @@ Logging out from Renku removes the secure token from your system:
 
 .. code-block:: console
 
-    $ renku logout
+    $ renku logout <endpoint>
+
+If you don't specify an endpoint when logging out, credentials for all
+endpoints are removed.
 """
 
 import click
@@ -64,8 +67,9 @@ def login(endpoint):
 
 
 @click.command()
-def logout():
+@click.argument("endpoint", required=False, default=None)
+def logout(endpoint):
     """Logout from the platform and delete credentials."""
     communicator = ClickCallback()
-    logout_command().with_communicator(communicator).build().execute()
+    logout_command().with_communicator(communicator).build().execute(endpoint=endpoint)
     click.secho("Successfully logged out.", fg="green")

--- a/renku/cli/login.py
+++ b/renku/cli/login.py
@@ -68,3 +68,4 @@ def logout():
     """Logout from the platform and delete credentials."""
     communicator = ClickCallback()
     logout_command().with_communicator(communicator).build().execute()
+    click.secho("Successfully logged out.", fg="green")

--- a/renku/cli/login.py
+++ b/renku/cli/login.py
@@ -17,13 +17,41 @@
 # limitations under the License.
 """Logging in to a Renku deployment.
 
-TODO: Write Documentation
+You can use ``renku login`` command to authenticate with a remote Renku
+deployment. This command will bring up a browser window where you can log in
+using your credentials. Renku CLI receives and stores a secure token where will
+be used for future authentications.
+
+.. code-block:: console
+
+    $ renku login <endpoint>
+
+Parameter ``endpoint`` is the URL of the Renku deployment that you want to
+authenticate with (e.g. ``renkulab.io``). You can either pass this parameter on
+the command-line or set it once in project's configuration:
+
+.. code-block:: console
+
+    $ renku config set endpoint <endpoint>
+
+.. note::
+
+    The secure token is stored in plain-text in Renku's global configuration
+    file on your home directory (``~/.renku/renku.ini``). Renku changes access
+    rights of this file to be readable only by you. This token exists only on
+    your system and won't be pushed to a remote server.
+
+Logging out from Renku removes the secure token from your system:
+
+.. code-block:: console
+
+    $ renku logout
 """
 
 import click
 
 from renku.cli.utils.callback import ClickCallback
-from renku.core.commands.login import login_command, logout_command, token_command
+from renku.core.commands.login import login_command, logout_command
 
 
 @click.command()
@@ -32,8 +60,7 @@ def login(endpoint):
     """Log in to the platform."""
     communicator = ClickCallback()
     login_command().with_communicator(communicator).build().execute(endpoint=endpoint)
-
-    # TODO: Print a warning that token is stored in plain-text
+    click.secho("Successfully logged in.", fg="green")
 
 
 @click.command()
@@ -41,11 +68,3 @@ def logout():
     """Logout from the platform and delete credentials."""
     communicator = ClickCallback()
     logout_command().with_communicator(communicator).build().execute()
-
-
-@click.command(hidden=True)
-@click.argument("command")
-def token(command):
-    """Logout from the platform and delete credentials."""
-    communicator = ClickCallback()
-    token_command().with_communicator(communicator).build().execute(command=command)

--- a/renku/cli/login.py
+++ b/renku/cli/login.py
@@ -23,7 +23,7 @@ TODO: Write Documentation
 import click
 
 from renku.cli.utils.callback import ClickCallback
-from renku.core.commands.login import login_command, logout_command
+from renku.core.commands.login import login_command, logout_command, token_command
 
 
 @click.command()
@@ -41,3 +41,11 @@ def logout():
     """Logout from the platform and delete credentials."""
     communicator = ClickCallback()
     logout_command().with_communicator(communicator).build().execute()
+
+
+@click.command(hidden=True)
+@click.argument("command")
+def token(command):
+    """Logout from the platform and delete credentials."""
+    communicator = ClickCallback()
+    token_command().with_communicator(communicator).build().execute(command=command)

--- a/renku/core/commands/login.py
+++ b/renku/core/commands/login.py
@@ -41,15 +41,15 @@ def login_command():
 
 def _login(client, endpoint):
     parsed_endpoint = _parse_endpoint(client, endpoint)
-    cli_token = str(uuid.uuid4())
+    cli_nonce = str(uuid.uuid4())
 
     communication.echo(f"Please log in at {parsed_endpoint.geturl()} on your browser.")
 
-    login_url = _get_url(parsed_endpoint, "/api/auth/login", cli_token=cli_token)
+    login_url = _get_url(parsed_endpoint, "/api/auth/login", cli_nonce=cli_nonce)
     webbrowser.open_new_tab(login_url)
 
-    user_code = communication.prompt("Once completed, enter the security code that you receive at the end")
-    info_url = _get_url(parsed_endpoint, "/api/auth/info", cli_token=cli_token, user_code=user_code)
+    server_nonce = communication.prompt("Once completed, enter the security code that you receive at the end")
+    info_url = _get_url(parsed_endpoint, "/api/auth/cli-token", cli_nonce=cli_nonce, server_nonce=server_nonce)
 
     try:
         response = requests.get(info_url)

--- a/renku/core/commands/login.py
+++ b/renku/core/commands/login.py
@@ -25,7 +25,6 @@ import uuid
 import webbrowser
 from pathlib import posixpath
 
-import git
 import requests
 
 from renku.core import errors
@@ -95,13 +94,6 @@ def _store_token(client, parsed_endpoint, token):
     client.set_value(section=CONFIG_SECTION, key=parsed_endpoint.netloc, value=token, global_only=True)
     os.chmod(client.global_config_path, 0o600)
 
-    if not client.repo:
-        communication.warn("Not inside a git repository: Cannot store credentials.")
-        return
-
-    value = f"Renku-Token: {token}"
-    client.repo.git.config("http.extraheader", value, local=True)
-
 
 def read_renku_token(client, endpoint):
     """Read renku token from renku config file."""
@@ -116,12 +108,3 @@ def logout_command():
 
 def _logout(client):
     client.remove_value(section=CONFIG_SECTION, key="*", global_only=True)
-
-    if not client.repo:
-        communication.warn("Not inside a git repository: Cannot remove credentials.")
-        return
-
-    try:
-        client.repo.git.config("http.extraheader", local=True, unset=True)
-    except git.exc.GitCommandError:  # NOTE: If already logged out, git config --unset raises an exception
-        pass

--- a/renku/core/commands/login.py
+++ b/renku/core/commands/login.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Logging in to a Renku deployment."""
+
+import sys
+import time
+import urllib
+import uuid
+import webbrowser
+from pathlib import posixpath
+
+import requests
+
+from renku.core import errors
+from renku.core.commands.config import read_config
+from renku.core.incubation.command import Command
+from renku.core.utils import communication
+
+
+def login_command():
+    """Return a command for logging in to the platform."""
+    return Command().command(_login)
+
+
+def _login(client, endpoint):
+    parsed_endpoint = _parse_endpoint(endpoint)
+    query = urllib.parse.urlencode({"cli_token": str(uuid.uuid4())})
+
+    login_url = _get_url(parsed_endpoint, "/api/auth/login", query)
+    webbrowser.open_new_tab(login_url)
+
+    info_url = _get_url(parsed_endpoint, "/api/auth/info", query)
+    access_token = None
+    wait_interval = 2
+    timeout = wait_interval * 30  # 60 seconds
+    while timeout > 0:
+        timeout -= wait_interval
+        time.sleep(wait_interval)
+
+        try:
+            response = requests.get(info_url)
+        except requests.RequestException:
+            pass
+        else:
+            if response.status_code == 200:
+                access_token = response.json().get("access_token")
+                print(response.json())  # TODO delete
+                break
+
+    if access_token is None:
+        communication.error(f"Cannot get access token from remote host: {parsed_endpoint.geturl()}")
+        sys.exit(1)
+
+    print(f"ACCESS TOKEN: {access_token}")  # TODO delete
+    print(f"REFRESH TOKEN: {response.json().get('refresh_token')}")  # TODO delete
+    _store_token(client, parsed_endpoint.netloc, access_token)
+
+
+def _parse_endpoint(endpoint):
+    if not endpoint:
+        try:
+            endpoint = read_config("endpoint")
+        except errors.ParameterError:
+            raise errors.ParameterError("`endpoint` parameter is missing.")
+
+    if not endpoint.startswith("http"):
+        endpoint = f"https://{endpoint}"
+
+    parsed_endpoint = urllib.parse.urlparse(endpoint)
+    if not parsed_endpoint.netloc:
+        raise errors.ParameterError(f"Invalid endpoint: {endpoint}.")
+
+    path = parsed_endpoint.path or "/"
+    return parsed_endpoint._replace(scheme="https", path=path, params="", query="", fragment="")
+
+
+def _get_url(parsed_endpoint, path, query):
+    path = posixpath.join(parsed_endpoint.path, path.lstrip("/"))
+    return parsed_endpoint._replace(path=path, query=query).geturl()
+
+
+def _store_token(client, endpoint_netloc, token):
+    client.set_value(section="tokens", key=endpoint_netloc, value=token, global_only=True)
+    # TODO git credential helper, chmod 600
+
+
+def logout_command():
+    """Return a command for logging out from the platform."""
+    return Command().command(_logout)
+
+
+def _logout(client):
+    client.remove_value(section="tokens", key="*", global_only=True)
+    # TODO git credential helper

--- a/renku/core/commands/login.py
+++ b/renku/core/commands/login.py
@@ -106,5 +106,11 @@ def logout_command():
     return Command().command(_logout)
 
 
-def _logout(client):
-    client.remove_value(section=CONFIG_SECTION, key="*", global_only=True)
+def _logout(client, endpoint):
+    if endpoint:
+        parsed_endpoint = parse_authentication_endpoint(client=client, endpoint=endpoint)
+        key = parsed_endpoint.netloc
+    else:
+        key = "*"
+
+    client.remove_value(section=CONFIG_SECTION, key=key, global_only=True)

--- a/renku/core/commands/options.py
+++ b/renku/core/commands/options.py
@@ -19,49 +19,9 @@
 
 import click
 
-from renku.core.errors import RenkuException, UsageError
+from renku.core.errors import RenkuException
 
 from .git import set_git_isolation
-
-
-class Endpoint(str):
-    """Track endpoint source."""
-
-    def __new__(cls, content, default=None, project=None, option=None):
-        """Set endpoint sources."""
-        endpoint = str.__new__(cls, content)
-        endpoint.default = default
-        endpoint.project = project
-        endpoint.option = option
-        return endpoint
-
-
-def default_endpoint_from_config(config, option=None):
-    """Return a default endpoint."""
-    default_endpoint = config.get("core", {}).get("default")
-    project_endpoint = config.get("project", {}).get("core", {}).get("default", default_endpoint)
-    return Endpoint(
-        option or project_endpoint or default_endpoint,
-        default=default_endpoint,
-        project=project_endpoint,
-        option=option,
-    )
-
-
-def password_prompt(ctx, param, value):
-    """Prompt for password if ``--password-stdin`` is not used."""
-    if ctx.resilient_parsing:
-        return
-
-    if not value:
-        if "password_stdin" in ctx.params:
-            with click.open_file("-") as fp:
-                value = fp.read().strip("\n")
-        else:
-            value = click.prompt("Password", hide_input=True)
-
-    click.echo(value)
-    return value
 
 
 def install_completion(ctx, attr, value):  # pragma: no cover
@@ -75,38 +35,6 @@ def install_completion(ctx, attr, value):  # pragma: no cover
     click.secho("{0} completion installed in {1}".format(shell, path), fg="green")
     ctx.exit()
 
-
-def default_endpoint(ctx, param, value):
-    """Return default endpoint if specified."""
-    if ctx.resilient_parsing:
-        return
-
-    config = ctx.obj["config"]
-    endpoint = default_endpoint_from_config(config, option=value)
-
-    if endpoint is None:
-        raise UsageError("No default endpoint found.")
-
-    return endpoint
-
-
-def validate_endpoint(ctx, param, value):
-    """Validate endpoint."""
-    try:
-        config = ctx.obj["config"]
-    except Exception:
-        return
-
-    endpoint = default_endpoint(ctx, param, value)
-
-    if endpoint not in config.get("endpoints", {}):
-        raise UsageError("Unknown endpoint: {0}".format(endpoint))
-
-    return endpoint
-
-
-argument_endpoint = click.argument("endpoint", required=False, callback=validate_endpoint,)
-option_endpoint = click.option("--endpoint", default=None, callback=validate_endpoint, help=validate_endpoint.__doc__,)
 
 option_isolation = click.option(
     "--isolation",

--- a/renku/core/commands/providers/renku.py
+++ b/renku/core/commands/providers/renku.py
@@ -187,7 +187,7 @@ class RenkuProvider(ProviderApi):
     def _read_renku_token(self, client, uri):
         """Read renku token from renku config file."""
         try:
-            parsed_endpoint = parse_authentication_endpoint(client=client, endpoint=uri)
+            parsed_endpoint = parse_authentication_endpoint(client=client, endpoint=uri, use_remote=True)
         except errors.ParameterError:
             return
         self._authentication_endpoint = parsed_endpoint.netloc

--- a/renku/core/commands/providers/renku.py
+++ b/renku/core/commands/providers/renku.py
@@ -158,6 +158,9 @@ class RenkuProvider(ProviderApi):
         return project_id, dataset_name_or_id
 
     def _query_knowledge_graph(self, url):
+        if self._authorization_header:
+            # NOTE: Authorization requires going through the gateway route
+            url = url.replace("/knowledge-graph/", "/api/kg/")
         try:
             response = requests.get(url, headers=self._authorization_header)
         except urllib.error.HTTPError as e:

--- a/renku/core/management/config.py
+++ b/renku/core/management/config.py
@@ -158,7 +158,7 @@ class ConfigManagerMixin:
         self.store_config(config, global_only=global_only)
 
     def remove_value(self, section, key, global_only=False):
-        """Remove key from specified section."""
+        """Remove key from specified section or remove the whole section if key is "*"."""
         config_filter = ConfigFilter.GLOBAL_ONLY
 
         if not global_only:
@@ -167,10 +167,13 @@ class ConfigManagerMixin:
 
         config = self.load_config(config_filter=config_filter)
         if section in config:
-            value = config[section].pop(key, None)
+            if key == "*":
+                value = config.pop(section)
+            else:
+                value = config[section].pop(key, None)
 
-            if not config[section].keys():
-                config.pop(section)
+                if not config[section].keys():
+                    config.pop(section)
 
             self.store_config(config, global_only=global_only)
             return value

--- a/renku/core/utils/urls.py
+++ b/renku/core/utils/urls.py
@@ -82,8 +82,7 @@ def parse_authentication_endpoint(client, endpoint):
     if not parsed_endpoint.netloc:
         raise errors.ParameterError(f"Invalid endpoint: `{endpoint}`.")
 
-    path = parsed_endpoint.path or "/"
-    return parsed_endpoint._replace(scheme="https", path=path, params="", query="", fragment="")
+    return parsed_endpoint._replace(scheme="https", path="/", params="", query="", fragment="")
 
 
 def get_remote(repo):

--- a/renku/core/utils/urls.py
+++ b/renku/core/utils/urls.py
@@ -70,7 +70,6 @@ def parse_authentication_endpoint(client, endpoint, use_remote=False):
     if not endpoint:
         endpoint = client.get_value(section="renku", key="endpoint")
         if not endpoint:
-            print("NO ENDPOINT", use_remote)
             if not use_remote:
                 return
             remote_url = get_remote(client.repo)

--- a/renku/core/utils/urls.py
+++ b/renku/core/utils/urls.py
@@ -61,7 +61,7 @@ def get_host(client):
     return os.environ.get("RENKU_DOMAIN") or host
 
 
-def parse_authentication_endpoint(client, endpoint):
+def parse_authentication_endpoint(client, endpoint, use_remote=False):
     """Return a parsed url.
 
     If an endpoint is provided then use it, otherwise, look for a configured endpoint. If no configured endpoint exists
@@ -70,6 +70,9 @@ def parse_authentication_endpoint(client, endpoint):
     if not endpoint:
         endpoint = client.get_value(section="renku", key="endpoint")
         if not endpoint:
+            print("NO ENDPOINT", use_remote)
+            if not use_remote:
+                return
             remote_url = get_remote(client.repo)
             if not remote_url:
                 return
@@ -90,6 +93,6 @@ def get_remote(repo):
     if not repo or not repo.remotes:
         return
     elif len(repo.remotes) == 1:
-        return repo.remotes[0]
+        return repo.remotes[0].url
     elif repo.active_branch.tracking_branch():
-        return repo.remotes[repo.active_branch.tracking_branch().remote_name]
+        return repo.remotes[repo.active_branch.tracking_branch().remote_name].url

--- a/tests/cli/fixtures/cli_gateway.py
+++ b/tests/cli/fixtures/cli_gateway.py
@@ -42,6 +42,8 @@ def mock_login():
 
                 return func
 
+            requests_mock.add_passthru("https://pypi.org/")
+
             requests_mock.add_callback(
                 responses.GET, "https://renku.deployment.ch/api/auth/cli-token", callback=callback("jwt-token")
             )

--- a/tests/cli/fixtures/cli_gateway.py
+++ b/tests/cli/fixtures/cli_gateway.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renku CLI fixtures for Gateway."""
+import json
+
+import pytest
+import responses
+from _pytest.monkeypatch import MonkeyPatch
+
+
+@pytest.fixture(scope="module")
+def mock_login():
+    """Monkey patch webbrowser module for renku login."""
+    import webbrowser
+
+    with MonkeyPatch().context() as monkey_patch:
+        monkey_patch.setattr(webbrowser, "open_new_tab", lambda _: None)
+
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as requests_mock:
+
+            def callback(token):
+                def func(request):
+                    if request.params.get("user_code") == "valid_user_code":
+                        return 200, {"Content-Type": "application/json"}, json.dumps({"access_token": token})
+
+                    return 404, {"Content-Type": "application/json"}, ""
+
+                return func
+
+            requests_mock.add_callback(
+                responses.GET, "https://renku.deployment.ch/api/auth/info", callback=callback("jwt-token")
+            )
+            requests_mock.add_callback(
+                responses.GET, "https://other.deployment/api/auth/info", callback=callback("other-token")
+            )
+
+            yield requests_mock

--- a/tests/cli/fixtures/cli_gateway.py
+++ b/tests/cli/fixtures/cli_gateway.py
@@ -35,7 +35,7 @@ def mock_login():
 
             def callback(token):
                 def func(request):
-                    if request.params.get("user_code") == "valid_user_code":
+                    if request.params.get("server_nonce") == "valid_user_code":
                         return 200, {"Content-Type": "application/json"}, json.dumps({"access_token": token})
 
                     return 404, {"Content-Type": "application/json"}, ""
@@ -43,10 +43,10 @@ def mock_login():
                 return func
 
             requests_mock.add_callback(
-                responses.GET, "https://renku.deployment.ch/api/auth/info", callback=callback("jwt-token")
+                responses.GET, "https://renku.deployment.ch/api/auth/cli-token", callback=callback("jwt-token")
             )
             requests_mock.add_callback(
-                responses.GET, "https://other.deployment/api/auth/info", callback=callback("other-token")
+                responses.GET, "https://other.deployment/api/auth/cli-token", callback=callback("other-token")
             )
 
             yield requests_mock

--- a/tests/cli/fixtures/cli_kg.py
+++ b/tests/cli/fixtures/cli_kg.py
@@ -55,6 +55,7 @@ def mock_kg():
             return status_code, {"Content-Type": "application/json"}, ""
 
         response.add_passthru("https://pypi.org/")
+        response.add_callback(responses.GET, re.compile("http(s)*://renku.ch/api/kg/.*"), callback=callback)
         response.add_callback(responses.GET, re.compile("http(s)*://renku.ch/knowledge-graph/.*"), callback=callback)
 
         yield response

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -38,7 +38,7 @@ def test_login_no_endpoint(runner, client):
     result = runner.invoke(cli, ["login"])
 
     assert 2 == result.exit_code
-    assert "Parameter `endpoint` is missing." in result.output
+    assert "Parameter 'endpoint' is missing." in result.output
 
 
 def test_login_with_config_endpoint(runner, client):
@@ -66,9 +66,11 @@ def test_logout(runner, client, mock_login):
     """Test logout removes all credentials."""
     assert 0 == runner.invoke(cli, ["login", ENDPOINT]).exit_code
 
-    assert 0 == runner.invoke(cli, ["logout"]).exit_code
+    result = runner.invoke(cli, ["logout"])
 
+    assert 0 == result.exit_code
     assert read_renku_token(client, ENDPOINT) is None
+    assert "Successfully logged out." in result.output
     assert "" == client.repo.config_reader().get_value("http", "extraheader", default="")
 
 

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -19,9 +19,7 @@
 
 from renku.cli import cli
 from renku.core.commands.login import read_renku_token
-
-ENDPOINT = "renku.deployment.ch"
-USER_CODE = "valid_user_code"
+from tests.cli.fixtures.cli_gateway import ACCESS_TOKEN, ENDPOINT, USER_CODE
 
 
 def test_login(runner, client, mock_login):
@@ -29,7 +27,7 @@ def test_login(runner, client, mock_login):
     result = runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE)
 
     assert 0 == result.exit_code
-    assert "jwt-token" == read_renku_token(client, ENDPOINT)
+    assert ACCESS_TOKEN == read_renku_token(client, ENDPOINT)
 
 
 def test_login_no_endpoint(runner, client, mock_login):
@@ -92,7 +90,7 @@ def test_repeated_login(runner, client, mock_login):
     assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
 
     assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
-    assert "jwt-token" == read_renku_token(client, ENDPOINT)
+    assert ACCESS_TOKEN == read_renku_token(client, ENDPOINT)
 
 
 def test_repeated_logout(runner, client, mock_login):
@@ -107,12 +105,15 @@ def test_repeated_logout(runner, client, mock_login):
 
 def test_login_to_multiple_endpoints(runner, client, mock_login):
     """Test login to multiple endpoints."""
+    second_endpoint, second_token = "second.endpoint", "second-token"
+    mock_login.add_endpoint_token(second_endpoint, second_token)
+
     assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
 
-    assert 0 == runner.invoke(cli, ["login", "other.deployment"], input=USER_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", second_endpoint], input=USER_CODE).exit_code
 
-    assert "jwt-token" == read_renku_token(client, ENDPOINT)
-    assert "other-token" == read_renku_token(client, "other.deployment")
+    assert ACCESS_TOKEN == read_renku_token(client, ENDPOINT)
+    assert second_token == read_renku_token(client, second_endpoint)
 
 
 def test_logout_all(runner, client, mock_login):

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test ``login`` command."""
+
+from renku.cli import cli
+
+
+def test_login(runner, client, mock_login):
+    """Test login command with no endpoint."""
+    result = runner.invoke(cli, ["login", "renku.deployment.ch"])
+
+    assert 0 == result.exit_code
+    assert "jwt-token" in client.get_value(section="tokens", key="renku.deployment.ch")
+
+
+def test_login_no_endpoint(runner):
+    """Test login command with no endpoint."""
+    result = runner.invoke(cli, ["login"])
+
+    assert 2 == result.exit_code
+    assert "`endpoint` parameter is missing." in result.output
+
+
+def test_logout(runner, client, mock_login):
+    """Test logout removes all credentials."""
+    assert 0 == runner.invoke(cli, ["login", "renku.deployment.ch"]).exit_code
+
+    assert 0 == runner.invoke(cli, ["logout"]).exit_code
+
+    assert client.get_value(section="tokens", key="renku.deployment.ch") is None

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -21,12 +21,12 @@ from renku.cli import cli
 from renku.core.commands.login import read_renku_token
 
 ENDPOINT = "renku.deployment.ch"
-USE_CODE = "valid_user_code"
+USER_CODE = "valid_user_code"
 
 
 def test_login(runner, client, mock_login):
     """Test login command."""
-    result = runner.invoke(cli, ["login", ENDPOINT], input=USE_CODE)
+    result = runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE)
 
     assert 0 == result.exit_code
     assert "jwt-token" == read_renku_token(client, ENDPOINT)
@@ -70,7 +70,7 @@ def test_login_with_config_endpoint(runner, client, mock_login):
     """Test login command with endpoint in config file."""
     assert 0 == runner.invoke(cli, ["config", "set", "endpoint", ENDPOINT]).exit_code
 
-    result = runner.invoke(cli, ["login"], input=USE_CODE)
+    result = runner.invoke(cli, ["login"], input=USER_CODE)
 
     assert 0 == result.exit_code
     assert "Successfully logged in." in result.output
@@ -78,7 +78,7 @@ def test_login_with_config_endpoint(runner, client, mock_login):
 
 def test_logout(runner, client, mock_login):
     """Test logout removes all credentials."""
-    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USE_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
 
     result = runner.invoke(cli, ["logout"])
 
@@ -89,15 +89,15 @@ def test_logout(runner, client, mock_login):
 
 def test_repeated_login(runner, client, mock_login):
     """Test multiple logins."""
-    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USE_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
 
-    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USE_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
     assert "jwt-token" == read_renku_token(client, ENDPOINT)
 
 
 def test_repeated_logout(runner, client, mock_login):
     """Test multiple logouts."""
-    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USE_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
 
     assert 0 == runner.invoke(cli, ["logout"]).exit_code
 
@@ -107,9 +107,9 @@ def test_repeated_logout(runner, client, mock_login):
 
 def test_login_to_multiple_endpoints(runner, client, mock_login):
     """Test login to multiple endpoints."""
-    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USE_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
 
-    assert 0 == runner.invoke(cli, ["login", "other.deployment"], input=USE_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", "other.deployment"], input=USER_CODE).exit_code
 
     assert "jwt-token" == read_renku_token(client, ENDPOINT)
     assert "other-token" == read_renku_token(client, "other.deployment")
@@ -117,8 +117,8 @@ def test_login_to_multiple_endpoints(runner, client, mock_login):
 
 def test_logout_all(runner, client, mock_login):
     """Test logout with no endpoint removes multiple credentials."""
-    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USE_CODE).exit_code
-    assert 0 == runner.invoke(cli, ["login", "other.deployment"], input=USE_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", "other.deployment"], input=USER_CODE).exit_code
 
     assert 0 == runner.invoke(cli, ["logout"]).exit_code
 
@@ -128,8 +128,8 @@ def test_logout_all(runner, client, mock_login):
 
 def test_logout_one_endpoint(runner, client, mock_login):
     """Test logout from an endpoint removes credentials for that endpoint only."""
-    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USE_CODE).exit_code
-    assert 0 == runner.invoke(cli, ["login", "other.deployment"], input=USE_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", "other.deployment"], input=USER_CODE).exit_code
 
     assert 0 == runner.invoke(cli, ["logout", ENDPOINT]).exit_code
 
@@ -139,7 +139,7 @@ def test_logout_one_endpoint(runner, client, mock_login):
 
 def test_logout_non_existing_endpoint(runner, client, mock_login):
     """Test logout from a non-existing endpoint does nothing."""
-    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USE_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
 
     assert 0 == runner.invoke(cli, ["logout", "non.existing"]).exit_code
 

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -40,6 +40,15 @@ def test_login_no_endpoint(runner, client, mock_login):
     assert "Parameter 'endpoint' is missing." in result.output
 
 
+def test_login_no_endpoint_and_remote(runner, client, mock_login):
+    """Test login command with no endpoint and with project remote."""
+    client.repo.create_remote("test_remote", url="https://example.com/")
+    result = runner.invoke(cli, ["login"], input="invalid_user_code")
+
+    assert 2 == result.exit_code, result.output
+    assert "Parameter 'endpoint' is missing." in result.output
+
+
 def test_login_invalid_endpoint(runner, client, mock_login):
     """Test login with and invalid endpoint."""
     result = runner.invoke(cli, ["login", "http: //example.com"])

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -107,7 +107,6 @@ def test_login_to_multiple_endpoints(runner, client, mock_login):
     """Test login to multiple endpoints."""
     second_endpoint, second_token = "second.endpoint", "second-token"
     mock_login.add_endpoint_token(second_endpoint, second_token)
-
     assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
 
     assert 0 == runner.invoke(cli, ["login", second_endpoint], input=USER_CODE).exit_code
@@ -118,24 +117,28 @@ def test_login_to_multiple_endpoints(runner, client, mock_login):
 
 def test_logout_all(runner, client, mock_login):
     """Test logout with no endpoint removes multiple credentials."""
+    second_endpoint, second_token = "second.endpoint", "second-token"
+    mock_login.add_endpoint_token(second_endpoint, second_token)
     assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
-    assert 0 == runner.invoke(cli, ["login", "other.deployment"], input=USER_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", second_endpoint], input=USER_CODE).exit_code
 
     assert 0 == runner.invoke(cli, ["logout"]).exit_code
 
     assert read_renku_token(client, ENDPOINT) is None
-    assert read_renku_token(client, "other.deployment") is None
+    assert read_renku_token(client, second_endpoint) is None
 
 
 def test_logout_one_endpoint(runner, client, mock_login):
     """Test logout from an endpoint removes credentials for that endpoint only."""
+    second_endpoint, second_token = "second.endpoint", "second-token"
+    mock_login.add_endpoint_token(second_endpoint, second_token)
     assert 0 == runner.invoke(cli, ["login", ENDPOINT], input=USER_CODE).exit_code
-    assert 0 == runner.invoke(cli, ["login", "other.deployment"], input=USER_CODE).exit_code
+    assert 0 == runner.invoke(cli, ["login", second_endpoint], input=USER_CODE).exit_code
 
     assert 0 == runner.invoke(cli, ["logout", ENDPOINT]).exit_code
 
     assert read_renku_token(client, ENDPOINT) is None
-    assert read_renku_token(client, "other.deployment") is not None
+    assert second_token == read_renku_token(client, second_endpoint)
 
 
 def test_logout_non_existing_endpoint(runner, client, mock_login):


### PR DESCRIPTION
# Description

Adds a `renku login` command that communicates with Renku's gateway and receives and stores an oauth access token. ATM, this token is used when sending request to access KG.

Fixes #677 
