### PR TITLE
fix: rdflib.ConjunctiveGraph.bind API of 4.2.2

### DIFF
--- a/renku/core/models/provenance/provenance_graph.py
+++ b/renku/core/models/provenance/provenance_graph.py
@@ -138,7 +138,7 @@ class ProvenanceGraph:
         self._graph.bind("wfprov", "http://purl.org/wf4ever/wfprov#")
 
         for prefix, namespace in self._custom_bindings.items():
-            self._graph.bind(prefix, namespace, replace=True)
+            self._graph.bind(prefix, namespace)
 
     def get_latest_plans_usages(self):
         """Return a list of tuples with path and check of all Usage paths."""


### PR DESCRIPTION
# Description

If the ProvenanceGraph.custom_bindings property is being set, the `rdflib.ConjunctiveGraph.bind` function is called with `replace=True` function argument. This is only available in rdflib==5.0.0 or later.

Fixes #1882
