### PR TITLE
feat(core): exclude renku metadata from lfs

### DIFF
--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -41,10 +41,6 @@ from renku.core.utils.git import add_to_git, run_command
 from .git import _expand_directories
 from .repository import RepositoryApiMixin
 
-# Batch size for when renku is expanding a large list
-# of files into an argument string.
-ARGUMENT_BATCH_SIZE = 100
-
 
 def check_external_storage_wrapper(fn):
     """Check availability of external storage on methods that need it.

--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -121,7 +121,7 @@ class StorageApiMixin(RepositoryApiMixin):
     def renku_lfs_ignore(self):
         """Gets pathspec for files to not add to LFS."""
         ignore_path = self.path / self.RENKU_LFS_IGNORE_PATH
-        renku_protected_paths = [".renku"]
+        renku_protected_paths = ["/.renku"]
 
         if not os.path.exists(ignore_path):
             return pathspec.PathSpec.from_lines("renku_gitwildmatch", renku_protected_paths)

--- a/renku/core/utils/git.py
+++ b/renku/core/utils/git.py
@@ -63,8 +63,8 @@ def add_to_git(git, *paths, **kwargs):
 
 def split_paths(*paths):
     """Return a generator with split list of paths."""
-    batch_size = math.ceil(len(paths) / ARGUMENT_BATCH_SIZE)
-    batch_size = max(batch_size, 1)
+    batch_count = math.ceil(len(paths) / ARGUMENT_BATCH_SIZE)
+    batch_count = max(batch_count, 1)
 
-    for index in range(batch_size):
+    for index in range(batch_count):
         yield paths[index * ARGUMENT_BATCH_SIZE : (index + 1) * ARGUMENT_BATCH_SIZE]

--- a/renku/core/utils/git.py
+++ b/renku/core/utils/git.py
@@ -35,11 +35,8 @@ def run_command(command, *paths, separator=None, **kwargs):
     :returns: Result of last invocation.
     """
     result = None
-    batch_size = math.ceil(len(paths) / ARGUMENT_BATCH_SIZE)
-    n_executions = max(batch_size, 1)
 
-    for index in range(n_executions):
-        batch = paths[index * ARGUMENT_BATCH_SIZE : (index + 1) * ARGUMENT_BATCH_SIZE]
+    for batch in split_paths(*paths):
         if separator:
             batch = [separator.join(batch)]
 
@@ -60,8 +57,14 @@ def run_command(command, *paths, separator=None, **kwargs):
 
 def add_to_git(git, *paths, **kwargs):
     """Split `paths` and add them to git to make sure that argument list will be within os limits."""
+    for batch in split_paths(*paths):
+        git.add(*batch, **kwargs)
+
+
+def split_paths(*paths):
+    """Return a generator with split list of paths."""
     batch_size = math.ceil(len(paths) / ARGUMENT_BATCH_SIZE)
+    batch_size = max(batch_size, 1)
 
     for index in range(batch_size):
-        batch = paths[index * ARGUMENT_BATCH_SIZE : (index + 1) * ARGUMENT_BATCH_SIZE]
-        git.add(*batch, **kwargs)
+        yield paths[index * ARGUMENT_BATCH_SIZE : (index + 1) * ARGUMENT_BATCH_SIZE]

--- a/tests/core/management/test_storage.py
+++ b/tests/core/management/test_storage.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Storage tests."""
+
+import pytest
+
+
+@pytest.mark.parametrize("path", [".", "datasets"])
+def test_no_renku_metadata_in_lfs(client_with_datasets, no_lfs_size_limit, path):
+    """Test .renku directory and its content are not included in the LFS."""
+    # Explicitly set .renku to not being ignored
+    (client_with_datasets.path / ".renkulfsignore").write_text("!.renku")
+
+    file1 = client_with_datasets.path / "file1"
+    file1.write_text("123")
+    path_in_renku_metadata_directory = client_with_datasets.renku_metadata_path.parent / path
+    file2 = path_in_renku_metadata_directory / "file2"
+    file2.write_text("123")
+
+    client_with_datasets.track_paths_in_storage(file1, file2, path_in_renku_metadata_directory)
+
+    attributes = (client_with_datasets.path / ".gitattributes").read_text()
+    assert "file1" in attributes
+    assert "file2" not in attributes
+    assert ".renku" not in attributes
+
+
+def test_renku_in_lfs_migrate_exclude_filter(client):
+    """Test .renku directory is in exclude filter of `lfs migrate info`."""
+    _, excludes, _ = client.get_lfs_migrate_filters()
+
+    assert excludes[1].endswith(".renku")

--- a/tests/core/management/test_storage.py
+++ b/tests/core/management/test_storage.py
@@ -21,7 +21,7 @@ import pytest
 
 
 @pytest.mark.parametrize("path", [".", "datasets"])
-def test_no_renku_metadata_in_lfs(client_with_datasets, no_lfs_size_limit, path):
+def test_no_renku_metadata_in_lfs(client_with_datasets, no_lfs_size_limit, path, subdirectory):
     """Test .renku directory and its content are not included in the LFS."""
     # Explicitly set .renku to not being ignored
     (client_with_datasets.path / ".renkulfsignore").write_text("!.renku")


### PR DESCRIPTION
# Description

Prevents `.renku` directory from being tracked in LFS.

Fixes #1866 
