### PR TITLE
fix(core): fixes save and push to correctly handle merge conflicts

### DIFF
--- a/renku/cli/save.py
+++ b/renku/cli/save.py
@@ -71,6 +71,7 @@ You can also specify which paths to save:
 
 import click
 
+from renku.cli.utils.callback import ClickCallback
 from renku.core.commands.save import save_and_push_command
 
 
@@ -85,16 +86,19 @@ from renku.core.commands.save import save_and_push_command
     ),
 )
 @click.argument("paths", type=click.Path(exists=False, dir_okay=True), nargs=-1)
-@click.pass_context
-def save(ctx, message, destination, paths):
+def save(message, destination, paths):
     """Save and push local changes."""
-
+    communicator = ClickCallback()
     saved_paths, branch = (
-        save_and_push_command().build().execute(message=message, remote=destination, paths=paths).output
+        save_and_push_command()
+        .with_communicator(communicator)
+        .build()
+        .execute(message=message, remote=destination, paths=paths)
+        .output
     )
 
     if saved_paths:
-        click.echo("Successfully saved to branch {}: \n\t{}".format(branch, "\n\t".join(saved_paths)))
+        click.echo("Successfully saved to remote branch {}: \n\t{}".format(branch, "\n\t".join(saved_paths)))
     else:
         click.echo("There were no changes to save.")
 


### PR DESCRIPTION
closes #1726 

Draft for now. needs the command builder refactoring so we can use the communication library to prompt for resolving merge conflicts.