### PR TITLE
chore: mock user home and fix renku config concurrency issues

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -83,7 +83,7 @@
                 "sha256:5311c5c1769d16f46a4270e68a72147f6141fe8b3a1e10c718ac9559925b6624",
                 "sha256:981db6ecd8483c48725bf505c1164d5a531b698c78b14b9e9e8be693f6c9d63f"
             ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.1'",
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
             "version": "==0.3.7"
         },
         "certifi": {
@@ -215,7 +215,7 @@
                 "sha256:161b841809860cc5b9212c23a5f70db8cac932895208c4bcdf1e4c11be2517f1",
                 "sha256:db6ef5018c84ccff1856bca06b4a6065e02a50b4b21363527c26f9d584cd3889"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==3.0.20210124104916"
         },
         "decorator": {
@@ -694,7 +694,7 @@
                 "sha256:13cdbb6b72798be9ef30caf460d3949bf057d9f073f73cc853908d50cc31229f",
                 "sha256:ca1008c18e91c2d0345764ddb871cc284feadc467241fbb468f14280b791388a"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==9.3.0"
         },
         "ruamel.yaml": {
@@ -823,7 +823,7 @@
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
                 "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.25.11"
         },
         "wcmatch": {
@@ -955,7 +955,7 @@
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
                 "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.25.11"
         },
         "websocket-client": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -83,7 +83,7 @@
                 "sha256:5311c5c1769d16f46a4270e68a72147f6141fe8b3a1e10c718ac9559925b6624",
                 "sha256:981db6ecd8483c48725bf505c1164d5a531b698c78b14b9e9e8be693f6c9d63f"
             ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.1'",
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
             "version": "==0.3.7"
         },
         "certifi": {
@@ -215,7 +215,7 @@
                 "sha256:161b841809860cc5b9212c23a5f70db8cac932895208c4bcdf1e4c11be2517f1",
                 "sha256:db6ef5018c84ccff1856bca06b4a6065e02a50b4b21363527c26f9d584cd3889"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==3.0.20210124104916"
         },
         "decorator": {
@@ -287,11 +287,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:24499ffde1b80be08284100393955842be4a59c7c16bbf2738aad0e464a8e0aa",
-                "sha256:c6af5dbf1126cd959c4a8d8efd61d4d3c83bddb0459a17e554284a077574b614"
+                "sha256:18d5ff601069f98d5d605b6a4b50c18a34811d655c55548adc833e687289acde",
+                "sha256:407d13f55dc6f2a844e62325d18ad7019a436c4bfcaee34cda35f2be6e7c3e34"
             ],
             "markers": "python_version == '3.7' and python_version < '3.8'",
-            "version": "==3.7.0"
+            "version": "==3.7.2"
         },
         "isodate": {
             "hashes": [
@@ -513,6 +513,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
+        "portalocker": {
+            "hashes": [
+                "sha256:afa66c85041d7bac1532acb74ff26cc2406472dcf7145c90c31ff8ca4f1cc146",
+                "sha256:e5f6ffb2f360e9aef615a7c284143d2a93bb640c62e8e45a703e6083fc5aa114"
+            ],
+            "version": "==2.2.1"
+        },
         "prov": {
             "hashes": [
                 "sha256:5c930cbbd05424aa3066d336dc31d314dd9fa0280caeab064288e592ed716bea",
@@ -573,11 +580,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:37a13ba168a02ac54cc5891a42b1caec333e59b66addb7fa633ea8a6d73445c0",
-                "sha256:b21b072d0ccdf29297a82a2363359d99623597b8a265b8081760e4d0f7153c88"
+                "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94",
+                "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.8.0"
+            "version": "==2.8.1"
         },
         "pyjwt": {
             "hashes": [
@@ -687,7 +694,7 @@
                 "sha256:13cdbb6b72798be9ef30caf460d3949bf057d9f073f73cc853908d50cc31229f",
                 "sha256:ca1008c18e91c2d0345764ddb871cc284feadc467241fbb468f14280b791388a"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==9.3.0"
         },
         "ruamel.yaml": {
@@ -736,11 +743,11 @@
         },
         "schema-salad": {
             "hashes": [
-                "sha256:a73f936210aac0a8ab8cb5050b38bf1c8323fe296f7b7c8c01fb3fe5b0090600",
-                "sha256:fed287837e28fbdb61b78899f0c422bf44a9177d44dc70487e031f0a76a16c09"
+                "sha256:2593129052324bb1406c039d36e84ed01447d610748193bbe8de4d61ff4d9d97",
+                "sha256:cd476fcf773096ebfa73ebe4bcd92eacd0eed2b29e4a5a3408412deecdde582e"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==7.0.20210124093443"
+            "version": "==7.1.20210309094900"
         },
         "setuptools-scm": {
             "hashes": [
@@ -816,7 +823,7 @@
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
                 "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.25.11"
         },
         "wcmatch": {
@@ -837,11 +844,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
-                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
+                "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
+                "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.4.0"
+            "version": "==3.4.1"
         }
     },
     "develop": {
@@ -948,15 +955,16 @@
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
                 "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.25.11"
         },
         "websocket-client": {
             "hashes": [
-                "sha256:0fc45c961324d79c781bab301359d5a1b00b13ad1b10415a4780229ef71a5549",
-                "sha256:d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010"
+                "sha256:44b5df8f08c74c3d82d28100fdc81f4536809ce98a17f0757557813275fbb663",
+                "sha256:63509b41d158ae5b7f67eb4ad20fecbb4eee99434e73e140354dc3ff8e09716f"
             ],
-            "version": "==0.57.0"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.58.0"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -83,7 +83,7 @@
                 "sha256:5311c5c1769d16f46a4270e68a72147f6141fe8b3a1e10c718ac9559925b6624",
                 "sha256:981db6ecd8483c48725bf505c1164d5a531b698c78b14b9e9e8be693f6c9d63f"
             ],
-            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
+            "markers": "python_version < '4' and python_full_version >= '3.6.1'",
             "version": "==0.3.7"
         },
         "certifi": {
@@ -215,7 +215,7 @@
                 "sha256:161b841809860cc5b9212c23a5f70db8cac932895208c4bcdf1e4c11be2517f1",
                 "sha256:db6ef5018c84ccff1856bca06b4a6065e02a50b4b21363527c26f9d584cd3889"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==3.0.20210124104916"
         },
         "decorator": {
@@ -694,7 +694,7 @@
                 "sha256:13cdbb6b72798be9ef30caf460d3949bf057d9f073f73cc853908d50cc31229f",
                 "sha256:ca1008c18e91c2d0345764ddb871cc284feadc467241fbb468f14280b791388a"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==9.3.0"
         },
         "ruamel.yaml": {
@@ -823,7 +823,7 @@
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
                 "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.11"
         },
         "wcmatch": {
@@ -955,7 +955,7 @@
                 "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
                 "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.11"
         },
         "websocket-client": {

--- a/renku/cli/exception_handler.py
+++ b/renku/cli/exception_handler.py
@@ -59,6 +59,7 @@ from urllib.parse import urlencode
 
 import click
 import filelock
+import portalocker
 
 from renku.core.errors import MigrationRequired, ParameterError, ProjectNotSupported, RenkuException, UsageError
 
@@ -121,7 +122,7 @@ class IssueFromTraceback(RenkuExceptionsHandler):
             result = super().main(*args, **kwargs)
             return result
 
-        except filelock.Timeout:
+        except (filelock.Timeout, portalocker.LockException, portalocker.AlreadyLocked):
             click.echo(
                 (
                     click.style("Unable to acquire lock.\n", fg="red",) + "Hint: Please wait for another renku "

--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,7 @@ install_requires = [
     "pathspec>=0.7.0,<=0.8.0",
     "patool==1.12",
     "pluggy==0.13.1",
+    "portalocker>=2.2.1,<2.3",
     "psutil>=5.4.7,<=5.7.2",
     "pyasn1>=0.4.5,<=0.4.8",
     "pyjwt==2.0.0",

--- a/tests/cli/fixtures/cli_kg.py
+++ b/tests/cli/fixtures/cli_kg.py
@@ -54,6 +54,7 @@ def mock_kg():
             status_code = 404 if authorization == "Bearer renku-token" else 401
             return status_code, {"Content-Type": "application/json"}, ""
 
+        response.add_passthru("https://pypi.org/")
         response.add_callback(
             responses.GET, re.compile("http(s)*://renku.ch/knowledge-graph/datasets/.*"), callback=callback
         )

--- a/tests/cli/fixtures/cli_repository.py
+++ b/tests/cli/fixtures/cli_repository.py
@@ -64,15 +64,35 @@ def instance_path(renku_path, monkeypatch):
 def repository(tmpdir):
     """Yield a Renku repository."""
     from click.testing import CliRunner
+    from git.config import GitConfigParser, get_config_path
 
     from renku.cli import cli
 
     runner = CliRunner()
     with _isolated_filesystem(tmpdir, delete=True) as project_path:
-        result = runner.invoke(cli, ["init", ".", "--template-id", "python-minimal"], "\n", catch_exceptions=False)
-        assert 0 == result.exit_code
+        home = tmpdir.mkdir("user_home")
+        old_home = os.environ.get("HOME", "")
+        old_xdg_home = os.environ.get("XDG_CONFIG_HOME", "")
 
-        yield os.path.realpath(project_path)
+        try:
+            # NOTE: fake user home directory
+            os.environ["HOME"] = str(home)
+            os.environ["XDG_CONFIG_HOME"] = str(home)
+            with GitConfigParser(get_config_path("global"), read_only=False) as global_config:
+                global_config.set_value("user", "name", "Renku @ SDSC")
+                global_config.set_value("user", "email", "renku@datascience.ch")
+
+            result = runner.invoke(cli, ["init", ".", "--template-id", "python-minimal"], "\n", catch_exceptions=False)
+            assert 0 == result.exit_code
+
+            yield os.path.realpath(project_path)
+        finally:
+            os.environ["HOME"] = old_home
+            os.environ["XDG_CONFIG_HOME"] = old_xdg_home
+            try:
+                shutil.rmtree(home)
+            except OSError:  # noqa: B014
+                pass
 
 
 @pytest.fixture


### PR DESCRIPTION
Set `$HOME` to a temporary directory on the `repository` fixture. Adds exclusive write, shared read locking for the `~/.renku/renku.ini` file.

closes #1936 