### PR TITLE
fix(service): sync cache with remote before operations to prevent cache getting out of sync

### DIFF
--- a/renku/core/commands/save.py
+++ b/renku/core/commands/save.py
@@ -151,8 +151,18 @@ def repo_sync(repo, message=None, remote=None, paths=None):
                 else:
                     raise
 
+        failed_push = None
+
         if not merge_conflict:
             result = origin.push(repo.active_branch)
+            failed_push = [
+                push_info
+                for push_info in result
+                if push_info.flags & git.PushInfo.ERROR
+                or push_info.flags & git.PushInfo.REJECTED
+                or push_info.flags & git.PushInfo.REMOTE_REJECTED
+                or push_info.flags & git.PushInfo.REMOTE_FAILURE
+            ]
 
         if merge_conflict or (result and "[remote rejected] (pre-receive hook declined)" in result[0].summary):
             # NOTE: Push to new remote branch if original one is protected and reset the cache.
@@ -167,9 +177,9 @@ def repo_sync(repo, message=None, remote=None, paths=None):
                 repo.git.checkout(old_active_branch)
                 ref = f"{origin}/{old_pushed_branch}"
                 repo.index.reset(commit=ref, head=True, working_tree=True)
-        elif result and " failed to push some refs" in result[0].summary:
+        elif result and failed_push:
             # NOTE: Couldn't push for some reason
-            msg = result[0].summary
+            msg = "\n".join(info.summary for info in failed_push)
             raise errors.GitError(f"Couldn't push changes. Reason:\n{msg}")
 
     except git.exc.GitCommandError as e:

--- a/renku/core/models/git.py
+++ b/renku/core/models/git.py
@@ -51,7 +51,7 @@ _RE_PATHNAME_WITH_GITLAB = (
     r"(?P<name>[\w\-\.]+)(\.git)?)?)"
 )
 
-_RE_UNIXPATH = r"(file\://)?(?P<pathname>\/$|((?=\/)|\.|\.\.)(\/(?=[^/\0])[^/\0]+)*\/?(?P<owner>([\w\-\.]+/)*[\w\-\.]+)/)?(?P<name>[\w\-\.]+)(\.git)?"
+_RE_UNIXPATH = r"(file\://)?(?P<pathname>\/$|((?=\/)|\.|\.\.)(\/(?=[^/\0])[^/\0]+)*\/?)"
 
 
 def _build(*parts):

--- a/renku/core/models/git.py
+++ b/renku/core/models/git.py
@@ -51,7 +51,7 @@ _RE_PATHNAME_WITH_GITLAB = (
     r"(?P<name>[\w\-\.]+)(\.git)?)?)"
 )
 
-_RE_UNIXPATH = r"(file\://)?(?P<pathname>\/$|((?=\/)|\.|\.\.)(\/(?=[^/\0])[^/\0]+)*\/?)"
+_RE_UNIXPATH = r"(file\://)?(?P<pathname>\/$|((?=\/)|\.|\.\.)(\/(?=[^/\0])[^/\0]+)*\/?(?P<owner>([\w\-\.]+/)*[\w\-\.]+)/)?(?P<name>[\w\-\.]+)(\.git)?"
 
 
 def _build(*parts):

--- a/renku/service/controllers/api/mixins.py
+++ b/renku/service/controllers/api/mixins.py
@@ -20,7 +20,7 @@ from abc import ABCMeta, abstractmethod
 from functools import wraps
 from pathlib import Path
 
-import git
+from git import Repo
 
 from renku.core.errors import RenkuException, UninitializedProject
 from renku.core.management.config import RENKU_HOME
@@ -83,7 +83,7 @@ class ReadOperationMixin(metaclass=ABCMeta):
 
     def reset_local_repo(self, project):
         """Reset the local repo to be up to date with the remote."""
-        repo = git.Repo(self.project_path)
+        repo = Repo(self.project_path)
         origin = None
         if repo.active_branch.tracking_branch():
             origin = repo.remotes[repo.active_branch.tracking_branch().remote_name]
@@ -138,7 +138,7 @@ class ReadWithSyncOperation(ReadOperationMixin, metaclass=ABCMeta):
         if self.project_path is None:
             raise RenkuException("unable to sync with remote since no operation has been executed")
 
-        _, remote_branch = repo_sync(git.Repo(self.project_path), remote=remote)
+        _, remote_branch = repo_sync(Repo(self.project_path), remote=remote)
         return remote_branch
 
     def execute_and_sync(self, remote="origin"):

--- a/renku/service/controllers/api/mixins.py
+++ b/renku/service/controllers/api/mixins.py
@@ -91,7 +91,7 @@ class ReadOperationMixin(metaclass=ABCMeta):
             origin = repo.remotes[0]
 
         if origin:
-            origin.fetch(depth=project.clone_depth)
+            origin.fetch()
             repo.git.reset("--hard", origin)
 
     @local_identity

--- a/tests/service/jobs/test_project.py
+++ b/tests/service/jobs/test_project.py
@@ -30,7 +30,7 @@ from renku.service.serializers.headers import JWT_TOKEN_SECRET, encode_b64
 @pytest.mark.integration
 def test_migrations_job(svc_client_setup):
     """Check migrations job for successful execution of migrations."""
-    svc_client, headers, project_id, _ = svc_client_setup
+    svc_client, headers, project_id, _, _ = svc_client_setup
 
     decoded = jwt.decode(headers["Renku-User"], JWT_TOKEN_SECRET, algorithms=["HS256"], audience="renku",)
     user_data = {

--- a/tests/service/views/test_cache_views.py
+++ b/tests/service/views/test_cache_views.py
@@ -650,7 +650,7 @@ def test_check_migrations_local(svc_client_setup):
 @pytest.mark.integration
 def test_check_migrations_remote(svc_client_setup, it_remote_repo_url):
     """Check if migrations are required for a remote project."""
-    svc_client, headers, _, _ = svc_client_setup
+    svc_client, headers, _, _, _ = svc_client_setup
 
     response = svc_client.get("/cache.migrations_check", query_string=dict(git_url=it_remote_repo_url), headers=headers)
     assert 200 == response.status_code

--- a/tests/service/views/test_exceptions.py
+++ b/tests/service/views/test_exceptions.py
@@ -66,7 +66,7 @@ def test_auth_headers_exc(service_allowed_endpoint):
 @flaky(max_runs=30, min_passes=1)
 def test_migration_required_flag(svc_client_setup):
     """Check migration required failure."""
-    svc_client, headers, project_id, _ = svc_client_setup
+    svc_client, headers, project_id, _, _ = svc_client_setup
 
     payload = {
         "project_id": project_id,


### PR DESCRIPTION
Tries to do a `git fetch && git reset --hard origin` before executing an operation on the cache to ensure the cache is in sync.

Meant as a band-aid until porcelain commands are done and the UI switched over to them.