### PR TITLE
chore: add better user messaging on service api start error

### DIFF
--- a/renku/cli/service.py
+++ b/renku/cli/service.py
@@ -182,6 +182,10 @@ def service(ctx, env):
         import rq  # noqa: F401
         from dotenv import load_dotenv
 
+        from renku.service.cache.base import BaseCache
+
+        BaseCache.cache.ping()
+
         load_dotenv(dotenv_path=env)
     except ImportError:
         # NOTE: Service dependency is missing.
@@ -190,6 +194,13 @@ def service(ctx, env):
             ERROR + "Dependency not found! "
             "Please install `pip install renku[service]` to enable service component control."
         )
+
+        ctx.exit(1)
+
+    except redis.exceptions.ConnectionError:
+        # NOTE: Cannot connect to the service dependencies, ie. Redis.
+
+        click.echo(ERROR + "Cannot connect to Redis")
 
         ctx.exit(1)
 

--- a/tests/cli/test_service.py
+++ b/tests/cli/test_service.py
@@ -27,7 +27,7 @@ from renku.cli.service import list_renku_processes
 
 @pytest.mark.serial
 @flaky(max_runs=10, min_passes=1)
-def test_service_up_down(runner):
+def test_service_up_down(runner, svc_client_cache):
     """Check bringing service components up and down in daemon mode."""
     result = runner.invoke(cli, ["service", "up", "--daemon"], catch_exceptions=False)
 
@@ -46,7 +46,7 @@ def test_service_up_down(runner):
 
 
 @flaky(max_runs=10, min_passes=1)
-def test_service_up_restart(runner):
+def test_service_up_restart(runner, svc_client_cache):
     """Check bringing service components up in daemon mode and restarting them."""
     result = runner.invoke(cli, ["service", "up", "--daemon"], catch_exceptions=False)
     assert 0 == result.exit_code
@@ -75,7 +75,7 @@ def test_service_up_restart(runner):
 
 
 @flaky(max_runs=10, min_passes=1)
-def test_service_ps(runner):
+def test_service_ps(runner, svc_client_cache):
     """Check bringing service components up and listing them."""
     result = runner.invoke(cli, ["service", "up", "--daemon"], catch_exceptions=False)
     assert 0 == result.exit_code
@@ -97,7 +97,7 @@ def test_service_ps(runner):
 
 
 @flaky(max_runs=10, min_passes=1)
-def test_service_logs(runner):
+def test_service_logs(runner, svc_client_cache):
     """Check service component logs."""
     result = runner.invoke(cli, ["service", "up", "--daemon"], catch_exceptions=False)
     assert 0 == result.exit_code


### PR DESCRIPTION
Adds a ping check before executing service commands through the CLI. In case redis is not found running, we show nice message to the user instead of panicking.

