### PR TITLE
feat(dataset): mv command

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -427,7 +427,7 @@ def dataset():
     show_default=True,
 )
 def list_dataset(revision, format, columns):
-    """Handle datasets."""
+    """List datasets."""
     result = list_datasets().build().execute(revision=revision, format=format, columns=columns)
     click.echo(result.output)
 
@@ -513,7 +513,7 @@ def edit(name, title, description, creators, keyword):
 @dataset.command("show")
 @click.argument("name")
 def show(name):
-    """Handle datasets."""
+    """Show metadata of a dataset."""
     result = show_dataset().build().execute(name=name)
     ds = result.output
 

--- a/renku/cli/exception_handler.py
+++ b/renku/cli/exception_handler.py
@@ -61,6 +61,7 @@ import click
 import filelock
 import portalocker
 
+from renku.core.commands.echo import ERROR
 from renku.core.errors import MigrationRequired, ParameterError, ProjectNotSupported, RenkuException, UsageError
 
 _BUG = click.style("Ahhhhhhhh! You have found a bug. 🐞\n\n", fg="red", bold=True,)
@@ -87,7 +88,7 @@ class RenkuExceptionsHandler(click.Group):
         try:
             return super().main(*args, **kwargs)
         except RenkuException as e:
-            click.echo(f"Error: {e}", err=True)
+            click.echo(ERROR + str(e), err=True)
             if e.__cause__ is not None:
                 click.echo(f"\n{traceback.format_exc()}")
             exit_code = 1

--- a/renku/core/commands/move.py
+++ b/renku/core/commands/move.py
@@ -19,101 +19,165 @@
 
 import os
 from pathlib import Path
-from subprocess import run
 
+import git
+
+from renku.core import errors
 from renku.core.incubation.command import Command
 from renku.core.utils import communication
-
-
-def _move(client, sources, destination, edit_command):
-    """Move files and check repository for potential problems."""
-    from renku.core.management.git import _expand_directories
-
-    dst = Path(destination)
-
-    def fmt_path(path):
-        """Format path as relative to the client path."""
-        return str(Path(path).absolute().relative_to(client.path))
-
-    files = {
-        fmt_path(source): fmt_path(file_or_dir)
-        for file_or_dir in sources
-        for source in _expand_directories((file_or_dir,))
-    }
-
-    def fmt_dst(path):
-        """Build a destination path for a source path."""
-        return str(dst / os.path.relpath(path, start=files[path]))
-
-    destinations = {source: fmt_dst(source) for source in files}
-
-    # 1. Check .gitignore.
-    ignored = client.find_ignored_paths(*destinations.values())
-    if ignored:
-        communication.warn("Renamed files match .gitignore.\n")
-        if communication.confirm('Do you want to edit ".gitignore" now?'):
-            edit_command(filename=str(client.path / ".gitignore"))
-
-    # 2. Update dataset metadata files.
-    progress_text = "Updating dataset metadata"
-    communication.start_progress(progress_text, total=len(client.datasets))
-    try:
-        for (path, dataset) in client.datasets.items():
-            renames = {}
-
-            for file_ in dataset.files:
-                filepath = fmt_path(file_.path)
-
-                if filepath in files:
-                    renames[file_.path] = destinations[filepath]
-
-            if renames:
-                dataset.rename_files(lambda key: renames.get(key, key))
-
-                dataset.to_yaml()
-            communication.update_progress(progress_text, amount=1)
-    finally:
-        communication.finalize_progress(progress_text)
-
-    # 3. Manage .gitattributes for external storage.
-    tracked = tuple()
-    if client.check_external_storage():
-        tracked = tuple(path for path, attr in client.find_attr(*files).items() if attr.get("filter") == "lfs")
-        client.untrack_paths_from_storage(*tracked)
-
-        if client.find_attr(*tracked):
-            communication.warn("There are custom .gitattributes.\n")
-            if communication.confirm('Do you want to edit ".gitattributes" now?'):
-                edit_command(filename=str(client.path / ".gitattributes"))
-
-        if tracked:
-            lfs_paths = client.track_paths_in_storage(*(destinations[path] for path in tracked))
-            show_message = client.get_value("renku", "show_lfs_message")
-            if lfs_paths and (show_message is None or show_message == "True"):
-                communication.info(
-                    "Adding these files to Git LFS:\n"
-                    + "\t{}".format("\n\t".join(lfs_paths))
-                    + "\nTo disable this message in the future, run:"
-                    + "\n\trenku config set show_lfs_message False"
-                )
-
-    # 4. Handle symlinks.
-    dst.parent.mkdir(parents=True, exist_ok=True)
-
-    for source, target in destinations.items():
-        src = Path(source)
-        if src.is_symlink():
-            Path(target).parent.mkdir(parents=True, exist_ok=True)
-            Path(target).symlink_to(os.path.relpath(str(src.resolve()), start=os.path.dirname(target)))
-            src.unlink()
-            del files[source]
-
-    # Finally move the files.
-    final_sources = list(set(files.values()))
-    if final_sources:
-        run(["git", "mv"] + final_sources + [destination], check=True)
+from renku.core.utils.git import add_to_git
 
 
 def move_command():
     """Command to move or rename a file, a directory, or a symlink."""
     return Command().command(_move).require_migration().require_clean().with_commit()
+
+
+def _move(client, sources, destination, force, verbose, to_dataset):
+    """Move files and check repository for potential problems."""
+    if to_dataset:
+        client.load_dataset(to_dataset, strict=True)
+
+    absolute_destination = _get_absolute_path(client, destination)
+    absolute_sources = [_get_absolute_path(client, src) for src in sources]
+
+    is_rename = len(absolute_sources) == 1 and (
+        not absolute_destination.exists() or (absolute_destination.is_file() and absolute_sources[0].is_file())
+    )
+
+    files = {
+        path: _get_dst(path, src, absolute_destination, is_rename)
+        for src in absolute_sources
+        for path in _traverse_path(src)
+        if not path.is_dir()
+    }
+
+    if not files:
+        raise errors.ParameterError("There are no files to move.")
+    if not force:
+        _check_existing_destinations(files.values())
+
+    # NOTE: we don't check if source and destination are the same or if multiple sources are moved to the same
+    # destination; git mv will check those and we raise if git mv fails.
+
+    _warn_about_ignored_destinations(client, files.values())
+
+    if not absolute_destination.exists() and not absolute_destination.is_symlink():
+        if is_rename:
+            absolute_destination.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            absolute_destination.mkdir(parents=True, exist_ok=True)
+
+    try:
+        client.repo.git.mv([str(src) for src in sources] + [str(destination)], force=force)
+    except git.GitError as e:
+        raise errors.OperationError(f"Git operation failed: {e}")
+
+    # Handle symlinks
+    for src, dst in files.items():
+        if dst.is_symlink():
+            target = src.parent / os.readlink(dst)
+            dst.unlink()
+            Path(dst).symlink_to(os.path.relpath(target, start=os.path.dirname(dst)))
+
+    files_to_untrack = (str(src.relative_to(client.path)) for src in files)
+    client.untrack_paths_from_storage(*files_to_untrack)
+    # NOTE: Warn about filter after untracking from LFS to avoid warning about LFS filters
+    _warn_about_git_filters(client, files)
+    client.track_paths_in_storage(*[dst for dst in files.values() if not dst.is_dir()])
+
+    # NOTE: Force-add to include possible ignored files
+    add_to_git(client.repo.git, *files.values(), force=True)
+    commit = client.repo.index.commit(f"renku mv: committing {len(files)} moved files")
+
+    client.move_files(files=files, to_dataset=to_dataset, commit=commit)
+
+    if verbose:
+        _show_moved_files(client, files)
+
+
+def _traverse_path(path):
+    """Recursively yield all files and directories within a path."""
+    path = Path(path)
+
+    if path.is_dir():
+        yield from path.rglob("*")
+    else:
+        yield path
+
+
+def _get_dst(path, src_root, dst_root, is_rename):
+    parent = "." if is_rename else src_root.name
+    return dst_root / parent / os.path.relpath(path, start=src_root)
+
+
+def _get_absolute_path(client, path):
+    """Resolve path and raise if path is outside the repo or is protected."""
+    abs_path = Path(os.path.abspath(path))
+
+    if client.is_protected_path(abs_path):
+        raise errors.ParameterError(f"Path '{path}' is protected.")
+
+    try:
+        abs_path.relative_to(client.path)
+    except ValueError:
+        raise errors.ParameterError(f"Path '{path}' is outside the project.")
+
+    return abs_path
+
+
+def _check_existing_destinations(destinations):
+    existing = set()
+    for dst in destinations:
+        if dst.exists() or dst.is_symlink():
+            existing.add(str(dst.relative_to(os.getcwd())))
+
+    if not existing:
+        return
+
+    existing = "\n\t".join(existing)
+    raise errors.ParameterError(f"The following move target exist, use '--force' flag to overwrite them:\n\t{existing}")
+
+
+def _warn_about_ignored_destinations(client, destinations):
+    ignored = client.find_ignored_paths(*destinations)
+    if ignored:
+        ignored = "\n\t".join((str(Path(p).relative_to(client.path)) for p in ignored))
+        communication.warn(f"The following renamed path match .gitignore:\n\t{ignored}")
+
+
+def _warn_about_git_filters(client, files):
+    """Check if there are any git attributes for files including LFS."""
+    src_attrs = []
+    dst_attrs = []
+
+    for path, attrs in client.find_attr(*files).items():
+        src = Path(path)
+        dst = files[src].relative_to(client.path)
+        src = src.relative_to(client.path)
+        attrs_text = ""
+        for name, value in attrs.items():
+            if value == "unset":
+                attrs_text += f" -{name}"
+            elif value == "set":
+                attrs_text += f" {name}"
+            else:
+                attrs_text += f" {name}={value}"
+
+        src_attrs.append(f"{str(src)}{attrs_text}")
+        dst_attrs.append(f"{str(dst)}{attrs_text}")
+
+    if src_attrs:
+        src_attrs = "\n\t".join(src_attrs)
+        dst_attrs = "\n\t".join(dst_attrs)
+        communication.warn(
+            f"There were custom git attributes for the following files:\n\t{src_attrs}\n"
+            f"You need to edit .gitattributes and add the following:\n\t{dst_attrs}"
+        )
+
+
+def _show_moved_files(client, files):
+    for path in sorted(files):
+        src = path.relative_to(client.path)
+        dst = files[path].relative_to(client.path)
+        communication.echo(f"{src} -> {dst}")

--- a/renku/core/commands/move.py
+++ b/renku/core/commands/move.py
@@ -143,7 +143,7 @@ def _warn_about_ignored_destinations(client, destinations):
     ignored = client.find_ignored_paths(*destinations)
     if ignored:
         ignored = "\n\t".join((str(Path(p).relative_to(client.path)) for p in ignored))
-        communication.warn(f"The following renamed path match .gitignore:\n\t{ignored}")
+        communication.warn(f"The following moved path match .gitignore:\n\t{ignored}")
 
 
 def _warn_about_git_filters(client, files):
@@ -171,8 +171,8 @@ def _warn_about_git_filters(client, files):
         src_attrs = "\n\t".join(src_attrs)
         dst_attrs = "\n\t".join(dst_attrs)
         communication.warn(
-            f"There were custom git attributes for the following files:\n\t{src_attrs}\n"
-            f"You need to edit .gitattributes and add the following:\n\t{dst_attrs}"
+            f"There are custom git attributes for the following files:\n\t{src_attrs}\n"
+            f"You need to edit '.gitattributes' and add the following:\n\t{dst_attrs}"
         )
 
 

--- a/renku/core/management/git.py
+++ b/renku/core/management/git.py
@@ -90,7 +90,7 @@ def _expand_directories(paths):
     """Expand directory with all files it contains."""
     processed_paths = set()
     for path in paths:
-        for matched_path in glob.glob(path, recursive=True):
+        for matched_path in glob.iglob(str(path), recursive=True):
             if matched_path in processed_paths:
                 continue
             path_ = Path(matched_path)
@@ -147,11 +147,14 @@ class GitCore:
         """Return ignored paths matching ``.gitignore`` file."""
         from git.exc import GitCommandError
 
+        ignored = []
         for batch in split_paths(*paths):
             try:
-                return self.repo.git.check_ignore(*batch).split()
+                ignored.extend(self.repo.git.check_ignore(*batch).split(os.linesep))
             except GitCommandError:
                 pass
+
+        return ignored
 
     def find_attr(self, *paths):
         """Return map with path and its attributes."""

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -121,14 +121,18 @@ class RepositoryApiMixin(GitCore):
     TEMPLATE_CHECKSUMS = "template_checksums.json"
 
     RENKU_PROTECTED_PATHS = [
-        "\\.renku/.*",
+        ".dockerignore",
+        ".git",
+        ".git/*",
+        ".gitattributes",
+        ".gitignore",
+        ".gitlab-ci.yml",
+        ".renku",
+        ".renku/*",
+        ".renkulfsignore",
         "Dockerfile",
-        "\\.dockerignore",
-        "\\.gitignore",
-        "\\.gitattributes",
-        "\\.gitlab-ci\\.yml",
-        "environment\\.yml",
-        "requirements\\.txt",
+        "environment.yml",
+        "requirements.txt",
     ]
 
     _commit_activity_cache = attr.ib(factory=dict)

--- a/renku/core/models/cwl/command_line_tool.py
+++ b/renku/core/models/cwl/command_line_tool.py
@@ -30,7 +30,6 @@ import yaml
 from git import Actor
 
 from renku.core import errors
-from renku.core.commands.echo import INFO
 from renku.core.utils.git import add_to_git
 from renku.core.utils.scm import git_unicode_unescape
 from renku.version import __version__, version_url
@@ -220,17 +219,7 @@ class CommandLineToolFactory(object):
                 raise errors.OutputsNotFound(repo, inputs.values())
 
             if client.check_external_storage():
-                lfs_paths = client.track_paths_in_storage(*output_paths)
-
-                show_message = client.get_value("renku", "show_lfs_message")
-                if lfs_paths and (show_message is None or show_message == "True"):
-                    self.messages = (
-                        INFO
-                        + "Adding these files to Git LFS:\n"
-                        + "\t{}".format("\n\t".join(lfs_paths))
-                        + "\nTo disable this message in the future, run:"
-                        + "\n\trenku config set show_lfs_message False"
-                    )
+                client.track_paths_in_storage(*output_paths)
 
             add_to_git(repo.git, *output_paths)
 

--- a/tests/cli/test_move.py
+++ b/tests/cli/test_move.py
@@ -112,7 +112,7 @@ def test_move_to_ignored_file(runner, client):
     result = runner.invoke(cli, ["mv", "README.md", "ignored.so"])
 
     assert 0 == result.exit_code
-    assert "The following renamed path match .gitignore" in result.output
+    assert "The following moved path match .gitignore" in result.output
     assert "ignored.so" in result.output
 
 

--- a/tests/cli/test_move.py
+++ b/tests/cli/test_move.py
@@ -18,6 +18,8 @@
 """Test ``move`` command."""
 
 import os
+import shutil
+from pathlib import Path
 
 import pytest
 
@@ -25,77 +27,264 @@ from renku.cli import cli
 from renku.core.management.repository import DEFAULT_DATA_DIR as DATA_DIR
 
 
-def test_move_dataset_file(tmpdir, runner, client):
+def test_move(runner, client):
+    """Test move of files."""
+    src1 = Path("src1") / "sub" / "src1.txt"
+    src1.parent.mkdir(parents=True, exist_ok=True)
+    src1.touch()
+    src2 = Path("src2") / "sub" / "src2.txt"
+    src2.parent.mkdir(parents=True, exist_ok=True)
+    src2.touch()
+    client.repo.git.add("--all")
+    client.repo.index.commit("Add some files")
+
+    result = runner.invoke(cli, ["mv", "-v", "src1", "src2", "dst/sub"])
+
+    assert 0 == result.exit_code, result.output
+    assert not src1.exists()
+    assert not src2.exists()
+    dst1 = Path("dst") / "sub" / "src1" / "sub" / "src1.txt"
+    assert dst1.exists()
+    dst2 = Path("dst") / "sub" / "src2" / "sub" / "src2.txt"
+    assert dst2.exists()
+    assert f"{src1} -> {dst1}" in result.output
+    assert f"{src2} -> {dst2}" in result.output
+
+
+def test_move_outside_paths(runner, client, directory_tree):
+    """Test move from/to outside paths is not possible."""
+    result = runner.invoke(cli, ["mv", str(directory_tree), "data"])
+
+    assert 2 == result.exit_code
+    assert f"Error: Invalid parameter value - Path '{directory_tree}' is outside the project" in result.output
+
+    result = runner.invoke(cli, ["mv", "data", str(directory_tree)])
+
+    assert 2 == result.exit_code
+    assert f"Error: Invalid parameter value - Path '{directory_tree}' is outside the project" in result.output
+
+
+def test_move_non_existing_sources(runner, client):
+    """Test move from non-existing sources is not possible."""
+    result = runner.invoke(cli, ["mv", "non-existing", "data"])
+
+    assert 2 == result.exit_code
+    assert "Path 'non-existing' does not exist" in result.output
+
+
+@pytest.mark.parametrize("path", [".renku", ".renku/metadata.yml", ".gitignore", "Dockerfile"])
+def test_move_protected_paths(runner, client, path):
+    """Test move from/to protected paths is not possible."""
+    result = runner.invoke(cli, ["mv", path, "README.md"])
+
+    assert 2 == result.exit_code, result.output
+    assert f"Invalid parameter value - Path '{path}' is protected." in result.output
+
+    result = runner.invoke(cli, ["mv", "README.md", path])
+
+    assert 2 == result.exit_code
+    assert f"Invalid parameter value - Path '{path}' is protected." in result.output
+
+
+def test_move_existing_destination(runner, client):
+    """Test move to existing destination."""
+    (client.path / "source").write_text("123")
+    client.repo.git.add(all=True)
+    client.repo.index.commit("source file")
+
+    result = runner.invoke(cli, ["mv", "source", "README.md"])
+
+    assert 2 == result.exit_code, result.output
+    assert "The following move target exist" in result.output
+    assert "README.md" in result.output
+
+    # Use ``--force``
+    result = runner.invoke(cli, ["mv", "--force", "-v", "source", "README.md"])
+
+    assert 0 == result.exit_code, result.output
+    assert "source -> README.md" in result.output
+    assert not Path("source").exists()
+    assert "123" == Path("README.md").read_text()
+
+
+def test_move_to_ignored_file(runner, client):
+    """Test move to an ignored pattern."""
+    result = runner.invoke(cli, ["mv", "README.md", "ignored.so"])
+
+    assert 0 == result.exit_code
+    assert "The following renamed path match .gitignore" in result.output
+    assert "ignored.so" in result.output
+
+
+def test_move_empty_source(runner, client):
+    """Test move from empty directory."""
+    (client.path / "empty").mkdir()
+
+    result = runner.invoke(cli, ["mv", "empty", "data"])
+
+    assert 2 == result.exit_code, result.output
+    assert "Invalid parameter value - There are no files to move" in result.output
+
+
+def test_move_dataset_file(runner, client_with_datasets, directory_tree_files):
     """Test move of a file that belongs to a dataset."""
-    # create a dataset
-    result = runner.invoke(cli, ["dataset", "create", "testing"])
-    assert 0 == result.exit_code
+    for path in directory_tree_files:
+        src = Path("data") / "dataset-2" / path
+        assert src.exists()
 
-    source = tmpdir.join("source")
-    source.write("Source file")
+    dataset_before = client_with_datasets.load_dataset("dataset-2")
 
-    result = runner.invoke(cli, ["dataset", "add", "testing", source.strpath], catch_exceptions=False,)
-    assert 0 == result.exit_code
+    assert 0 == runner.invoke(cli, ["mv", "data", "files"], catch_exceptions=False).exit_code
 
-    assert (client.path / client.data_dir / "testing" / "source").exists()
+    assert 0 == runner.invoke(cli, ["doctor"], catch_exceptions=False).exit_code
+
+    # Check immutability
+    dataset_after = client_with_datasets.load_dataset("dataset-2")
+    assert dataset_before._id != dataset_after._id
+    assert dataset_before.identifier != dataset_after.identifier
+
+    for path in directory_tree_files:
+        src = Path("data") / "dataset-2" / path
+        assert not src.exists()
+        dst = Path("files") / "dataset-2" / path
+        assert dst.exists()
+
+        file = dataset_after.find_file(dst)
+        assert file
+        assert str(dst) in file._id
+        assert not file.external
+
+
+@pytest.mark.parametrize("args", [[], ["--to-dataset", "dataset-2"]])
+def test_move_in_the_same_dataset(runner, client_with_datasets, args):
+    """Test move and overwrite a file in the same dataset."""
+    src = os.path.join("data", "dataset-2", "file1")
+    dst = os.path.join("data", "dataset-2", "dir1", "file2")
+    file_before = client_with_datasets.load_dataset("dataset-2").find_file(dst)
+
+    result = runner.invoke(cli, ["mv", "-f", src, dst] + args)
+    assert 0 == result.exit_code, result.output
+
+    dataset = client_with_datasets.load_dataset("dataset-2")
+    assert {dst, dst.replace("file2", "file3")} == {f.path for f in dataset.files}
+    assert not (client_with_datasets.path / src).exists()
+    file_after = dataset.find_file(dst)
+    assert file_after._label != file_before._label
+    assert dst in file_after._label
+    assert "123" == Path(dst).read_text()
 
     result = runner.invoke(cli, ["doctor"], catch_exceptions=False)
-    assert 0 == result.exit_code
+    assert 0 == result.exit_code, result.output
+    assert not client_with_datasets.repo.is_dirty()
 
-    result = runner.invoke(cli, ["mv", "data", "files"])
-    assert 0 == result.exit_code
 
-    assert not (client.path / client.data_dir / "testing" / "source").exists()
-    assert (client.path / "files" / "testing" / "source").exists()
+def test_move_to_existing_destination_in_a_dataset(runner, client_with_datasets):
+    """Test move to a file in dataset will update file's metadata."""
+    (client_with_datasets.path / "source").write_text("new-content")
+    client_with_datasets.repo.git.add(all=True)
+    client_with_datasets.repo.index.commit("source file")
+
+    dst = os.path.join("data", "dataset-2", "file1")
+
+    dataset_before = client_with_datasets.load_dataset("dataset-2")
+    file_before = dataset_before.find_file(dst)
+
+    result = runner.invoke(cli, ["mv", "-f", "source", dst])
+    assert 0 == result.exit_code, result.output
+
+    dataset_after = client_with_datasets.load_dataset("dataset-2")
+    file_after = dataset_after.find_file(dst)
+
+    # Check dataset immutability
+    assert dataset_after.identifier != dataset_before.identifier
+
+    assert file_after._label != file_before._label
+    assert dst in file_after._label
+    assert {"data/dataset-2/file1", "data/dataset-2/dir1/file2", "data/dataset-2/dir1/file3"} == {
+        f.path for f in dataset_after.files
+    }
 
     result = runner.invoke(cli, ["doctor"], catch_exceptions=False)
-
-    assert 0 == result.exit_code
-
-    src = os.path.join("files", "testing", "source")
-    dst = os.path.join("files", "testing", "newname")
-
-    result = runner.invoke(cli, ["mv", src, dst], catch_exceptions=False)
-    assert 0 == result.exit_code
-
-    assert not (client.path / src).exists()
-    assert (client.path / dst).exists()
-
-    result = runner.invoke(cli, ["doctor"], catch_exceptions=False)
-    assert 0 == result.exit_code
+    assert 0 == result.exit_code, result.output
+    assert not client_with_datasets.repo.is_dirty()
 
 
 @pytest.mark.parametrize(
     "destination",
     (
-        "destination",  # root
+        "destination",
         os.path.join("dir", "subdir", "destination"),
         os.path.join(DATA_DIR, "destination"),
-        os.path.join(DATA_DIR, "dataset", "destination"),  # change name
-        os.path.join(DATA_DIR, "dataset", "subdir", "destination"),
+        os.path.join(DATA_DIR, "dataset", "destination"),
+        os.path.join(DATA_DIR, "dataset", "subdir", "subdir", "destination"),
     ),
 )
-def test_move_symlinks(data_repository, runner, project, client, destination):
-    """Test importing data into a dataset."""
-    # create a dataset
-    name = "dataset"
-    result = runner.invoke(cli, ["dataset", "create", name])
-    assert 0 == result.exit_code
-    assert "OK" in result.output
+def test_move_external_files(data_repository, runner, client, destination, directory_tree, directory_tree_files):
+    """Test move of external files (symlinks)."""
+    assert 0 == runner.invoke(cli, ["dataset", "add", "-c", "--external", "my-dataset", str(directory_tree)]).exit_code
 
-    with client.with_dataset(name) as dataset:
-        assert dataset.title == "dataset"
+    assert 0 == runner.invoke(cli, ["mv", os.path.join(DATA_DIR, "my-dataset"), destination]).exit_code
 
-    # add data from local git repo
-    filepath = os.path.join(data_repository.working_dir, "file1")
-    result = runner.invoke(cli, ["dataset", "add", "dataset", filepath], catch_exceptions=False)
-    assert 0 == result.exit_code, result.output
+    for path in directory_tree_files:
+        dst = Path(destination) / directory_tree.name / path
+        assert dst.exists()
+        assert dst.is_symlink()
+        assert directory_tree / path == dst.resolve()
 
-    src = client.path / client.data_dir / "dataset" / "file1"
-    assert src.exists()
+        file = client.load_dataset("my-dataset").find_file(dst)
+        assert file
+        assert str(dst) in file._id
+        assert file.external
 
-    result = runner.invoke(cli, ["mv", str(src), destination], catch_exceptions=False)
-    assert 0 == result.exit_code
+    assert 0 == runner.invoke(cli, ["doctor"], catch_exceptions=False).exit_code
+    assert not client.repo.is_dirty()
 
-    dst = client.path / destination
-    assert dst.exists()
+
+def test_move_between_datasets(runner, client, directory_tree, large_file, directory_tree_files):
+    """Test move files between datasets."""
+    shutil.copy(large_file, directory_tree / "file1")
+    shutil.copy(large_file, directory_tree / "dir1" / "file2")
+    assert 0 == runner.invoke(cli, ["dataset", "add", "-c", "dataset-1", str(directory_tree)]).exit_code
+    file1 = Path("data") / "dataset-1" / directory_tree.name / "file1"
+    assert 0 == runner.invoke(cli, ["dataset", "add", "-c", "dataset-2", str(file1)]).exit_code
+    assert 0 == runner.invoke(cli, ["dataset", "create", "dataset-3"]).exit_code
+
+    source = Path("data") / "dataset-1"
+    destination = Path("data") / "dataset-3"
+    assert 0 == runner.invoke(cli, ["mv", str(source), str(destination), "--to-dataset", "dataset-3"]).exit_code
+
+    assert not source.exists()
+    assert 0 == len(client.load_dataset("dataset-1").files)
+    assert 0 == len(client.load_dataset("dataset-2").files)
+
+    dataset = client.load_dataset("dataset-3")
+    assert 3 == len(dataset.files)
+
+    for path in directory_tree_files:
+        path = destination / directory_tree.name / path
+        assert path.exists()
+        assert dataset.find_file(path)
+
+    tracked = set(client.repo.git.lfs("ls-files", "--name-only").split("\n"))
+    assert {"data/dataset-3/directory_tree/file1", "data/dataset-3/directory_tree/dir1/file2"} == tracked
+
+    # Some more moves and dataset operations
+    assert 0 == runner.invoke(cli, ["dataset", "add", "dataset-3", str(large_file)]).exit_code
+    src1 = os.path.join("data", "dataset-3", directory_tree.name, "dir1")
+    dst1 = os.path.join("data", "dataset-1")
+    shutil.rmtree(dst1, ignore_errors=True)  # NOTE: Remove directory to force a rename
+    assert 0 == runner.invoke(cli, ["mv", src1, dst1, "--to-dataset", "dataset-1"]).exit_code
+    src2 = os.path.join("data", "dataset-3", directory_tree.name, "file1")
+    dst2 = os.path.join("data", "dataset-2")
+    (client.path / dst2).mkdir(parents=True, exist_ok=True)
+    assert 0 == runner.invoke(cli, ["mv", src2, dst2, "--to-dataset", "dataset-2"]).exit_code
+
+    assert {"data/dataset-1/file2", "data/dataset-1/file3"} == {f.path for f in client.load_dataset("dataset-1").files}
+    assert {"data/dataset-2/file1"} == {f.path for f in client.load_dataset("dataset-2").files}
+    assert {"data/dataset-3/large-file"} == {f.path for f in client.load_dataset("dataset-3").files}
+
+    tracked = set(client.repo.git.lfs("ls-files", "--name-only").split("\n"))
+    assert {"data/dataset-1/file2", "data/dataset-2/file1", "data/dataset-3/large-file"} == tracked
+
+    assert 0 == runner.invoke(cli, ["doctor"], catch_exceptions=False).exit_code
+    assert not client.repo.is_dirty()

--- a/tests/core/commands/test_client.py
+++ b/tests/core/commands/test_client.py
@@ -37,7 +37,7 @@ def test_local_client(tmpdir):
     (
         ([".renku.lock"], [".renku.lock"]),
         (["not ignored", "lib/foo", "build/html"], ["lib/foo", "build/html"]),
-        (["not ignored"], None),
+        (["not ignored"], []),
     ),
 )
 def test_ignored_paths(paths, ignored, client):

--- a/tests/core/fixtures/core_datasets.py
+++ b/tests/core/fixtures/core_datasets.py
@@ -55,4 +55,7 @@ def client_with_datasets(client, directory_tree):
 
         client.add_data_to_dataset(dataset=dataset, urls=[str(p) for p in directory_tree.glob("*")])
 
+    client.repo.git.add("--all")
+    client.repo.index.commit("add files to datasets")
+
     yield client

--- a/tests/fixtures/common.py
+++ b/tests/fixtures/common.py
@@ -16,23 +16,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Renku common fixtures."""
+
+import os
 import shutil
 from pathlib import Path
 
 import pytest
 
 
+@pytest.fixture
+def directory_tree_files():
+    """List of files for ``directory_tree`` fixture."""
+    return ["file1", os.path.join("dir1", "file2"), os.path.join("dir1", "file3")]
+
+
 @pytest.fixture()
-def directory_tree(tmp_path):
+def directory_tree(tmp_path, directory_tree_files):
     """Create a test directory tree."""
     # initialize
-    p = tmp_path / "directory_tree"
-    p.mkdir()
-    p.joinpath("file1").write_text("123")
-    p.joinpath("dir1").mkdir()
-    p.joinpath("dir1/file2").write_text("456")
-    p.joinpath("dir1/file3").write_text("789")
-    return p
+    base = tmp_path / "directory_tree"
+    for path in directory_tree_files:
+        path = base / path
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        if str(path).endswith("file1"):
+            path.write_text("123")
+        elif str(path).endswith("file2"):
+            path.write_text("456")
+        elif str(path).endswith("file3"):
+            path.write_text("789")
+
+    return base
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

Completes `renku mv` command by covering corner cases and fixing potential bugs. It also adds a `--to-dataset` flag that allows moving files from source datasets (determined by paths) to a destination dataset.

Fixes #1911 
Fixes #1159
