### PR TITLE
feat(core): git login from CLI

### DIFF
--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -80,7 +80,7 @@ from renku.cli.githooks import githooks as githooks_command
 from renku.cli.graph import graph
 from renku.cli.init import init as init_command
 from renku.cli.log import log
-from renku.cli.login import login, logout
+from renku.cli.login import login, logout, token
 from renku.cli.migrate import check_immutable_template_files, migrate, migrationscheck
 from renku.cli.move import move
 from renku.cli.remove import remove
@@ -212,6 +212,7 @@ cli.add_command(save)
 cli.add_command(show)
 cli.add_command(status)
 cli.add_command(storage)
+cli.add_command(token)
 cli.add_command(update)
 cli.add_command(workflow)
 cli.add_command(service)

--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -202,6 +202,7 @@ def _add_to_dataset(
     all_at_once=False,
     destination_names=None,
     total_size=None,
+    repository=None,
 ):
     """Add data to a dataset."""
     if len(urls) == 0:
@@ -240,6 +241,7 @@ def _add_to_dataset(
                 extract=extract,
                 all_at_once=all_at_once,
                 destination_names=destination_names,
+                repository=repository,
             )
             if with_metadata:
                 # dataset has the correct list of files
@@ -548,6 +550,7 @@ def _import_dataset(
             with_metadata=dataset,
             create=not previous_dataset,
             overwrite=True,
+            repository=record.repository,
         )
 
         if previous_dataset:

--- a/renku/core/commands/login.py
+++ b/renku/core/commands/login.py
@@ -23,15 +23,18 @@ import urllib
 import uuid
 import webbrowser
 
+import git
 import requests
 
 from renku.core import errors
 from renku.core.incubation.command import Command
 from renku.core.models.enums import ConfigFilter
 from renku.core.utils import communication
-from renku.core.utils.urls import parse_authentication_endpoint
+from renku.core.utils.git import get_renku_repo_url
+from renku.core.utils.urls import get_remote, parse_authentication_endpoint
 
 CONFIG_SECTION = "http"
+RENKU_BACKUP_PREFIX = "renku-backup"
 
 
 def login_command():
@@ -39,8 +42,21 @@ def login_command():
     return Command().command(_login)
 
 
-def _login(client, endpoint):
+def _login(client, endpoint, git_login, yes):
     parsed_endpoint = _parse_endpoint(client, endpoint)
+
+    remote_name, remote_url = None, None
+    if git_login:
+        if not client.repo:
+            raise errors.ParameterError("Cannot use '--git' flag outside a project.")
+
+        remote_name, remote_url = get_remote(client.repo)
+        if remote_name and remote_url:
+            if not yes:
+                communication.confirm("Remote URL will be changed. Do you want to continue?", abort=True, warning=True)
+        else:
+            raise errors.ParameterError("Cannot find a unique remote URL for project.")
+
     cli_nonce = str(uuid.uuid4())
 
     communication.echo(f"Please log in at {parsed_endpoint.geturl()} on your browser.")
@@ -49,16 +65,20 @@ def _login(client, endpoint):
     webbrowser.open_new_tab(login_url)
 
     server_nonce = communication.prompt("Once completed, enter the security code that you receive at the end")
-    info_url = _get_url(parsed_endpoint, "/api/auth/cli-token", cli_nonce=cli_nonce, server_nonce=server_nonce)
+    cli_token_url = _get_url(parsed_endpoint, "/api/auth/cli-token", cli_nonce=cli_nonce, server_nonce=server_nonce)
 
     try:
-        response = requests.get(info_url)
+        response = requests.get(cli_token_url)
     except requests.RequestException as e:
         raise errors.OperationError("Cannot get access token from remote host.") from e
 
     if response.status_code == 200:
         access_token = response.json().get("access_token")
-        _store_token(client, parsed_endpoint, access_token)
+        _store_token(client, parsed_endpoint.netloc, access_token)
+
+        if git_login:
+            _store_git_credential_helper(client, parsed_endpoint.netloc)
+            _swap_git_remote(client, parsed_endpoint, remote_name, remote_url)
     else:
         communication.error(
             f"Remote host did not return an access token: {parsed_endpoint.geturl()}, "
@@ -80,15 +100,50 @@ def _get_url(parsed_endpoint, path, **query_args):
     return parsed_endpoint._replace(path=path, query=query).geturl()
 
 
-def _store_token(client, parsed_endpoint, token):
-    client.set_value(section=CONFIG_SECTION, key=parsed_endpoint.netloc, value=token, global_only=True)
+def _store_token(client, netloc, access_token):
+    client.set_value(section=CONFIG_SECTION, key=netloc, value=access_token, global_only=True)
     os.chmod(client.global_config_path, 0o600)
+
+
+def _store_git_credential_helper(client, netloc):
+    client.repo.git.config("credential.helper", f"!renku token --hostname {netloc}", local=True)
+
+
+def _swap_git_remote(client, parsed_endpoint, remote_name, remote_url):
+    backup_remote_name = f"{RENKU_BACKUP_PREFIX}-{remote_name}"
+
+    if backup_remote_name in [r.name for r in client.repo.remotes]:
+        communication.echo(f"Backup remove '{backup_remote_name}' already exists. Ignoring '--git' flag.")
+        return
+
+    new_remote_url = get_renku_repo_url(remote_url, deployment_hostname=parsed_endpoint.netloc)
+
+    try:
+        client.repo.create_remote(backup_remote_name, url=remote_url)
+    except git.GitCommandError:
+        communication.error(f"Cannot create backup remote '{backup_remote_name}' for '{remote_url}'")
+    else:
+        try:
+            client.repo.git.remote("set-url", remote_name, new_remote_url)
+        except git.GitCommandError:
+            client.repo.delete_remote(backup_remote_name)
+            raise errors.GitError(f"Cannot change remote url for '{remote_name}' to {new_remote_url}")
 
 
 def read_renku_token(client, endpoint):
     """Read renku token from renku config file."""
-    parsed_endpoint = _parse_endpoint(client, endpoint)
-    return client.get_value(section=CONFIG_SECTION, key=parsed_endpoint.netloc, config_filter=ConfigFilter.GLOBAL_ONLY)
+    try:
+        parsed_endpoint = _parse_endpoint(client, endpoint)
+    except errors.ParameterError:
+        return
+    if not parsed_endpoint:
+        return
+
+    return _read_renku_token_for_hostname(client, parsed_endpoint.netloc)
+
+
+def _read_renku_token_for_hostname(client, hostname):
+    return client.get_value(section=CONFIG_SECTION, key=hostname, config_filter=ConfigFilter.GLOBAL_ONLY)
 
 
 def logout_command():
@@ -104,3 +159,49 @@ def _logout(client, endpoint):
         key = "*"
 
     client.remove_value(section=CONFIG_SECTION, key=key, global_only=True)
+    _remove_git_credential_helper(client)
+    _restore_git_remote(client)
+
+
+def _remove_git_credential_helper(client):
+    try:
+        client.repo.git.config("credential.helper", local=True, unset=True)
+    except git.exc.GitCommandError:  # NOTE: If already logged out, ``git config --unset`` raises an exception
+        pass
+
+
+def _restore_git_remote(client):
+    if not client.repo:  # Outside a renku project
+        return
+
+    backup_remotes = [r.name for r in client.repo.remotes if r.name.startswith(RENKU_BACKUP_PREFIX)]
+    for backup_remote in backup_remotes:
+        remote_name = backup_remote.replace(f"{RENKU_BACKUP_PREFIX}-", "")
+        remote_url = client.repo.remotes[backup_remote].url
+
+        try:
+            client.repo.git.remote("set-url", remote_name, remote_url)
+        except git.GitCommandError:
+            raise errors.GitError(f"Cannot restore remote url for '{remote_name}' to {remote_url}")
+
+        try:
+            client.repo.delete_remote(backup_remote)
+        except git.GitCommandError:
+            communication.error(f"Cannot delete backup remote '{backup_remote}'")
+
+
+def token_command():
+    """Return a command as git credential helper."""
+    return Command().command(_token)
+
+
+def _token(client, command, hostname):
+    if command != "get":
+        return
+
+    # NOTE: hostname comes from the credential helper we set up and has proper format
+    hostname = hostname or ""
+    token = _read_renku_token_for_hostname(client, hostname) or ""
+
+    communication.echo("username=renku")
+    communication.echo(f"password={token}")

--- a/renku/core/management/clone.py
+++ b/renku/core/management/clone.py
@@ -63,16 +63,23 @@ def clone(
     if skip_smudge:
         os.environ["GIT_LFS_SKIP_SMUDGE"] = "1"
 
+    clone_config = None
+    if isinstance(config, str):
+        clone_config = config
+        config = None
+
     try:
         # NOTE: Try to clone, assuming checkout_rev is a branch (if it is set)
-        repo = Repo.clone_from(url, path, branch=checkout_rev, recursive=recursive, depth=depth, progress=progress)
+        repo = Repo.clone_from(
+            url, path, branch=checkout_rev, recursive=recursive, depth=depth, progress=progress, config=clone_config
+        )
     except GitCommandError as e:
         # NOTE: clone without branch set, in case checkout_rev was not a branch but a tag or commit
         if not checkout_rev:
             _handle_git_exception(e, raise_git_except, progress)
 
         try:
-            repo = Repo.clone_from(url, path, recursive=recursive, depth=depth, progress=progress)
+            repo = Repo.clone_from(url, path, recursive=recursive, depth=depth, progress=progress, config=clone_config)
         except GitCommandError as e:
             _handle_git_exception(e, raise_git_except, progress)
 

--- a/renku/core/management/datasets.py
+++ b/renku/core/management/datasets.py
@@ -1341,7 +1341,7 @@ class DatasetsApiMixin(object):
             git_url = str(path)
         elif "http" in u.scheme and gitlab_token:
             git_url = get_oauth_url(url, gitlab_token)
-        elif "http" in u.protocol and renku_token:
+        elif "http" in u.scheme and renku_token:
             git_url = get_renku_repo_url(url, deployment_hostname=deployment_hostname, access_token=renku_token)
         else:
             git_url = url

--- a/renku/core/utils/urls.py
+++ b/renku/core/utils/urls.py
@@ -90,13 +90,15 @@ def parse_authentication_endpoint(client, endpoint, use_remote=False):
 
 
 def get_remote(repo):
-    """Return remote url of repo or its active branch."""
-    if not repo or not repo.remotes:
-        return
-    elif len(repo.remotes) == 1:
-        return repo.remotes[0].url
-    elif repo.active_branch.tracking_branch():
-        return repo.remotes[repo.active_branch.tracking_branch().remote_name].url
+    """Return remote name and url of repo or its active branch."""
+    if repo and repo.remotes:
+        if len(repo.remotes) == 1:
+            return repo.remotes[0].name, repo.remotes[0].url
+        elif repo.active_branch.tracking_branch():
+            name = repo.active_branch.tracking_branch().remote_name
+            return name, repo.remotes[name].url
+
+    return None, None
 
 
 def get_slug(name):

--- a/tests/cli/fixtures/cli_projects.py
+++ b/tests/cli/fixtures/cli_projects.py
@@ -45,8 +45,9 @@ def client_with_remote(client, tmpdir):
     origin = client.repo.create_remote("origin", path)
     client.repo.git.push("--set-upstream", "origin", "master")
 
-    yield {"client": client, "origin": origin}
+    yield client
 
+    client.repo.heads["master"].checkout()
     client.repo.git.branch("--unset-upstream")
     client.repo.delete_remote(origin)
     shutil.rmtree(path)

--- a/tests/cli/test_save.py
+++ b/tests/cli/test_save.py
@@ -47,20 +47,19 @@ def test_save_without_remote(runner, project, client, tmpdir_factory):
 
 def test_save_with_remote(runner, project, client_with_remote, tmpdir_factory):
     """Test saving local changes."""
-    client = client_with_remote["client"]
-    with (client.path / "tracked").open("w") as fp:
+    with (client_with_remote.path / "tracked").open("w") as fp:
         fp.write("tracked file")
 
     result = runner.invoke(cli, ["save", "-m", "save changes", "tracked"], catch_exceptions=False)
 
     assert 0 == result.exit_code
     assert "tracked" in result.output
-    assert "save changes" in client.repo.head.commit.message
+    assert "save changes" in client_with_remote.repo.head.commit.message
 
 
 def test_save_with_merge_conflict(runner, project, client_with_remote, tmpdir_factory):
     """Test saving local changes."""
-    client = client_with_remote["client"]
+    client = client_with_remote
     with (client.path / "tracked").open("w") as fp:
         fp.write("tracked file")
 
@@ -88,7 +87,7 @@ def test_save_with_merge_conflict(runner, project, client_with_remote, tmpdir_fa
 
 def test_save_with_staged(runner, project, client_with_remote, tmpdir_factory):
     """Test saving local changes."""
-    client = client_with_remote["client"]
+    client = client_with_remote
     with (client.path / "deleted").open("w") as fp:
         fp.write("deleted file")
 

--- a/tests/core/commands/test_storage.py
+++ b/tests/core/commands/test_storage.py
@@ -38,7 +38,7 @@ def test_lfs_storage_clean_no_remote(runner, project, client):
 
 def test_lfs_storage_clean(runner, project, client_with_remote):
     """Test ``renku storage clean`` command."""
-    client = client_with_remote["client"]
+    client = client_with_remote
 
     with (client.path / "tracked").open("w") as fp:
         fp.write("tracked file")
@@ -83,13 +83,11 @@ def test_lfs_storage_clean(runner, project, client_with_remote):
 
 def test_lfs_storage_unpushed_clean(runner, project, client_with_remote):
     """Test ``renku storage clean`` command for unpushed files."""
-    client = client_with_remote["client"]
-
-    with (client.path / "tracked").open("w") as fp:
+    with (client_with_remote.path / "tracked").open("w") as fp:
         fp.write("tracked file")
     subprocess.call(["git", "lfs", "track", "tracked"])
-    client.repo.git.add("*")
-    client.repo.index.commit("tracked file")
+    client_with_remote.repo.git.add("*")
+    client_with_remote.repo.index.commit("tracked file")
 
     result = runner.invoke(cli, ["storage", "clean", "tracked"], catch_exceptions=False)
 


### PR DESCRIPTION
# Description

Allows log into private repos by using `renku login --git endpoint`. It changes project's remote URL to a `<endpoint>/repo/...` URL which will authenticate gitlab server accesses through the renku gateway. Original remote URL will be saved in a remote with name `renku-backup-<remote-name>`. Logout will restorer the original remote URL.

Fixes #1892 
