### PR TITLE
feat(service): pass auth info to core

### DIFF
--- a/renku/core/commands/dataset.py
+++ b/renku/core/commands/dataset.py
@@ -443,14 +443,16 @@ def export_dataset():
     return command.require_migration().require_clean()
 
 
-def _import_dataset(client, uri, name="", extract=False, yes=False, previous_dataset=None, delete=False):
+def _import_dataset(
+    client, uri, name="", extract=False, yes=False, previous_dataset=None, delete=False, gitlab_token=None
+):
     """Import data from a 3rd party provider or another renku project."""
     provider, err = ProviderFactory.from_uri(uri)
     if err and provider is None:
         raise ParameterError(f"Could not process '{uri}'.\n{err}")
 
     try:
-        record = provider.find_record(uri, client)
+        record = provider.find_record(uri, client, gitlab_token=gitlab_token)
         dataset = record.as_dataset(client)
         files = dataset.files
         total_size = 0

--- a/renku/core/commands/providers/__init__.py
+++ b/renku/core/commands/providers/__init__.py
@@ -28,7 +28,7 @@ from renku.core.utils.doi import is_doi
 class ProviderFactory:
     """Create a provider type from URI."""
 
-    PROVIDERS = {"Dataverse": DataverseProvider, "OLOS": OLOSProvider, "Renku": RenkuProvider, "Zenodo": ZenodoProvider}
+    PROVIDERS = {"OLOS": OLOSProvider, "Renku": RenkuProvider, "Zenodo": ZenodoProvider, "Dataverse": DataverseProvider}
 
     @staticmethod
     def from_uri(uri):

--- a/renku/core/commands/providers/api.py
+++ b/renku/core/commands/providers/api.py
@@ -21,7 +21,7 @@ class ProviderApi(abc.ABC):
     """Interface defining provider methods."""
 
     @abc.abstractmethod
-    def find_record(self, uri, client=None):
+    def find_record(self, uri, client=None, **kwargs):
         """Find record by uri."""
         pass
 

--- a/renku/core/commands/providers/dataverse.py
+++ b/renku/core/commands/providers/dataverse.py
@@ -192,7 +192,7 @@ class DataverseProvider(ProviderApi):
                 raise LookupError("record not found. Status: {}".format(response.status_code))
             return response
 
-    def find_record(self, uri, client=None):
+    def find_record(self, uri, client=None, **kwargs):
         """Retrieves a record from Dataverse.
 
         :raises: ``LookupError``

--- a/renku/core/commands/providers/doi.py
+++ b/renku/core/commands/providers/doi.py
@@ -106,7 +106,7 @@ class DOIProvider(ProviderApi):
 
             return response
 
-    def find_record(self, uri, client=None):
+    def find_record(self, uri, client=None, **kwargs):
         """Finds DOI record."""
         response = self._query(uri).json()
         return DOIProvider._serialize(response)

--- a/renku/core/commands/providers/olos.py
+++ b/renku/core/commands/providers/olos.py
@@ -55,7 +55,7 @@ class OLOSProvider(ProviderApi):
             "dlcm-server": ("DLCM server base url.", str),
         }
 
-    def find_record(self, uri, client=None):
+    def find_record(self, uri, client=None, **kwargs):
         """Find record by uri."""
         return None
 

--- a/renku/core/commands/providers/renku.py
+++ b/renku/core/commands/providers/renku.py
@@ -44,6 +44,7 @@ class RenkuProvider(ProviderApi):
     _accept = attr.ib(default="application/json")
     _authorization_header = attr.ib(default=None)
     _authentication_endpoint = attr.ib(default="")
+    _use_gitlab_token = attr.ib(default=False)
 
     @staticmethod
     def supports(uri):
@@ -57,14 +58,16 @@ class RenkuProvider(ProviderApi):
         """Whether this provider supports dataset import."""
         return True
 
-    def find_record(self, uri, client=None):
+    def find_record(self, uri, client=None, **kwargs):
         """Retrieves a dataset from Renku.
 
         :raises: ``NotFound``, ``OperationError``, ``ParameterError``
         :param uri: URL
         :return: ``_RenkuRecordSerializer``
         """
-        self._prepare_authentication(client, uri)
+        gitlab_token = kwargs.get("gitlab_token")
+
+        self._prepare_authentication(client, uri, gitlab_token=gitlab_token)
 
         name, identifier, latest_version_uri, kg_url = self._fetch_dataset_info(uri)
 
@@ -77,6 +80,7 @@ class RenkuProvider(ProviderApi):
             latest_version_uri=latest_version_uri,
             project_url_ssh=project_url_ssh,
             project_url_http=project_url_http,
+            gitlab_token=gitlab_token,
         )
 
     def get_exporter(self, dataset, access_token):
@@ -158,9 +162,10 @@ class RenkuProvider(ProviderApi):
         return project_id, dataset_name_or_id
 
     def _query_knowledge_graph(self, url):
-        if self._authorization_header:
-            # NOTE: Authorization requires going through the gateway route
+        if self._authorization_header and not self._use_gitlab_token:
+            # NOTE: Authorization with renku token requires going through the gateway route
             url = url.replace("/knowledge-graph/", "/api/kg/")
+
         try:
             response = requests.get(url, headers=self._authorization_header)
         except urllib.error.HTTPError as e:
@@ -183,8 +188,13 @@ class RenkuProvider(ProviderApi):
 
         return urls.get("ssh"), urls.get("http")
 
-    def _prepare_authentication(self, client, uri):
-        token = self._read_renku_token(client, uri)
+    def _prepare_authentication(self, client, uri, gitlab_token):
+        if gitlab_token:
+            token = gitlab_token
+            self._use_gitlab_token = True
+        else:
+            token = self._read_renku_token(client, uri)
+
         self._authorization_header = {"Authorization": f"Bearer {token}"} if token else {}
 
     def _read_renku_token(self, client, uri):
@@ -200,7 +210,7 @@ class RenkuProvider(ProviderApi):
 class _RenkuRecordSerializer:
     """Renku record Serializer."""
 
-    def __init__(self, uri, identifier, name, latest_version_uri, project_url_ssh, project_url_http):
+    def __init__(self, uri, identifier, name, latest_version_uri, project_url_ssh, project_url_http, gitlab_token):
         """Create a _RenkuRecordSerializer from a Dataset."""
         self._uri = uri
         self._identifier = identifier
@@ -208,6 +218,7 @@ class _RenkuRecordSerializer:
         self._latest_version_uri = latest_version_uri
         self._project_url_ssh = project_url_ssh
         self._project_url_http = project_url_http
+        self._gitlab_token = gitlab_token
 
         self._dataset = None
         self._project_url = None
@@ -255,7 +266,7 @@ class _RenkuRecordSerializer:
 
     def as_dataset(self, client):
         """Return encapsulated dataset instance."""
-        self._fetch_dataset(client)
+        self._fetch_dataset(client, gitlab_token=self._gitlab_token)
         return self._dataset
 
     def import_images(self, client, dataset):
@@ -305,14 +316,14 @@ class _RenkuRecordSerializer:
         """Whether the dataset datadir exists (might be missing in git if empty)."""
         return (self._remote_client.path / self._dataset.data_dir).exists()
 
-    def _fetch_dataset(self, client):
+    def _fetch_dataset(self, client, gitlab_token):
         repo_path = None
 
         urls = (self._project_url_ssh, self._project_url_http)
         # Clone the project
         for url in urls:
             try:
-                repo, repo_path = client.prepare_git_repo(url)
+                repo, repo_path = client.prepare_git_repo(url, gitlab_token=gitlab_token)
             except errors.GitError:
                 pass
             else:

--- a/renku/core/commands/providers/zenodo.py
+++ b/renku/core/commands/providers/zenodo.py
@@ -518,7 +518,7 @@ class ZenodoProvider(ProviderApi):
                 raise LookupError("record not found. Status: {}".format(response.status_code))
             return response
 
-    def find_record(self, uri, client=None):
+    def find_record(self, uri, client=None, **kwargs):
         """Retrieves a record from Zenodo.
 
         :raises: ``LookupError``

--- a/renku/service/jobs/project.py
+++ b/renku/service/jobs/project.py
@@ -70,7 +70,7 @@ def migrate_job(
 ):
     """Execute migrations job."""
     user = cache.ensure_user(user_data)
-    worker_log.debug(f"executing dataset import job for {user.user_id}:{user.fullname}")
+    worker_log.debug(f"executing migrate job for {user.user_id}:{user.fullname}")
 
     user_job = cache.get_job(user, user_job_id)
 

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -385,7 +385,7 @@ def test_dataset_import_renku_fail(runner, client, monkeypatch, url):
     """Test dataset import fails if cannot clone repo."""
     from renku.core.management import LocalClient
 
-    def prepare_git_repo(*_):
+    def prepare_git_repo(*_, **__):
         raise errors.GitError
 
     with monkeypatch.context() as monkey:

--- a/tests/service/jobs/test_datasets.py
+++ b/tests/service/jobs/test_datasets.py
@@ -33,7 +33,13 @@ from renku.service.utils import make_project_path
 from tests.service.views.test_dataset_views import assert_rpc_response
 
 
-@pytest.mark.parametrize("url", ["https://dev.renku.ch/datasets/428c3626-1c56-463d-8753-336470cc6917/"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://dev.renku.ch/datasets/428c3626-1c56-463d-8753-336470cc6917/",
+        "https://dev.renku.ch/datasets/0d4630e5-6ee5-42b3-bb3a-b3222da811ec",
+    ],
+)
 @pytest.mark.integration
 @flaky(max_runs=30, min_passes=1)
 def test_dataset_url_import_job(url, svc_client_with_repo):


### PR DESCRIPTION
# Description

Service passes its gitlab token to renku core when importing a renku dataset from the same deployment. The token is used in renku core to access KG and to clone project that contains the dataset.

Fixes #1962 
