### PR TITLE
chore: enable service reloading in debug mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,27 +1,3 @@
-# .cache
-# .pytest_cache
-# .venv
-# .vscode
-# __pycache__
-
-# build
-# dist
-
-# *.mo
-# *.pyc
-# *.swp
-# *.swo
-# *.~
-
-# *.egg
-# *.egg-info
-# .eggs
-
-# Procfile*
-# Dockerfile*
-# docker-compose*
-# chartpress.yaml
-
 .*
 **
 !renku/**

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,20 +1,31 @@
-.cache
-.pytest_cache
-.venv
-.vscode
-__pycache__
+# .cache
+# .pytest_cache
+# .venv
+# .vscode
+# __pycache__
 
-build
-dist
+# build
+# dist
 
-*.mo
-*.pyc
-*.swp
-*.swo
-*.~
+# *.mo
+# *.pyc
+# *.swp
+# *.swo
+# *.~
 
-*.egg
-*.egg-info
-.eggs
+# *.egg
+# *.egg-info
+# .eggs
 
-Procfile*
+# Procfile*
+# Dockerfile*
+# docker-compose*
+# chartpress.yaml
+
+.*
+**
+!renku/**
+!setup.py
+!*.rst
+!entrypoint-svc.sh
+!.git

--- a/Dockerfile.svc
+++ b/Dockerfile.svc
@@ -19,7 +19,9 @@ WORKDIR /code/renku
 RUN requirements-builder -e service --level=pypi setup.py > /tmp/requirements.txt && \
     pip install -r /tmp/requirements.txt
 
-COPY . /code/renku
+COPY .git /code/renku/.git
+COPY renku /code/renku/renku
+
 # Set CLEAN_INSTALL to a non-null value to ensure that only a committed version of
 # renku-python is installed in the image. This is the default for chartpress builds.
 ARG CLEAN_INSTALL
@@ -36,4 +38,5 @@ USER shuhitsu
 ENV RENKU_SVC_NUM_WORKERS 4
 ENV RENKU_SVC_NUM_THREADS 8
 
-ENTRYPOINT ["renku", "service"]
+COPY entrypoint-svc.sh /code/renku/
+ENTRYPOINT ["./entrypoint-svc.sh"]

--- a/README.rst
+++ b/README.rst
@@ -310,6 +310,16 @@ in editable mode using ``pipx``. Clone the repository and then do:
 This will install all the extras for testing and debugging.
 
 
+Service
+-------
+
+Developing the service and testing its APIs can be done with ``docker compose`` (see
+"Deploying Locally" above). To enable live reloading of the code, set the environment
+variable ``DEBUG_MODE=true`` either in your shell or in the ``.env`` file. Note that in
+this case the local directory is mounted in the docker container and renku is re-installed
+so it may take a few minutes before the container is ready.
+
+
 Running tests
 -------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,9 @@ services:
       - reverse-proxy
     ports:
       - "8080:8080"
-    command: ["api", "--debug"]
+    volumes:
+      - ${PWD}:/code/renku
+    command: "api --debug"
     labels:
       - "traefik.http.routers.renku-svc.rule=PathPrefix(`/api/renku`)"
       - "traefik.http.middlewares.stripprefix.stripprefix.prefixes=/api"

--- a/entrypoint-svc.sh
+++ b/entrypoint-svc.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# if running in debug mode, install editable
+if [ "${DEBUG_MODE}" = "true" ]; then
+    pip3 install --user --no-use-pep517 -e ".[service]"
+fi
+
+renku service "$@"


### PR DESCRIPTION
This PR modifies the image of the renku core service to enable live service reloads to make development a more pleasant experience. It also makes sure that the image build is split up sufficiently to prevent reinstalling/rebuilding of dependencies when this is not necessary. A follow-up to this PR should turn this into a proper two-stage build in order to also reduce the final image size. 

/deploy