### PR TITLE
fix(service): fix service project creation

### DIFF
--- a/renku/core/commands/init.py
+++ b/renku/core/commands/init.py
@@ -525,7 +525,7 @@ def _create_from_template_local(
 
     metadata = {**default_metadata, **metadata}
 
-    client.init_repository(False, None, initial_branch=initial_branch)
+    client.init_repository(False, user, initial_branch=initial_branch)
 
     create_from_template(
         template_path=template_path,

--- a/renku/service/controllers/templates_create_project.py
+++ b/renku/service/controllers/templates_create_project.py
@@ -87,7 +87,7 @@ class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
             "name": self.ctx["project_name_stripped"],
             "fullname": self.ctx["fullname"],
             "email": self.ctx["email"],
-            "owner": self.ctx["owner"],
+            "owner": self.ctx["project_namespace"],
             "token": self.ctx["token"],
             "initialized": True,
         }
@@ -155,6 +155,7 @@ class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
             "url": self.ctx["new_project_url"],
             "namespace": self.ctx["project_namespace"],
             "name": self.ctx["project_name_stripped"],
+            "project_id": new_project.project_id,
         }
 
     def renku_op(self):

--- a/renku/service/serializers/templates.py
+++ b/renku/service/serializers/templates.py
@@ -133,6 +133,7 @@ class ProjectTemplateResponse(Schema):
     url = fields.String(required=True)
     namespace = fields.String(required=True)
     name = fields.String(required=True)
+    project_id = fields.String(required=False, default=None)
 
 
 class ProjectTemplateResponseRPC(JsonRPCResponse):

--- a/tests/service/controllers/test_templates_create_project.py
+++ b/tests/service/controllers/test_templates_create_project.py
@@ -35,7 +35,7 @@ def test_template_create_project_ctrl(ctrl_init, svc_client_templates_creation, 
 
     # Check response.
     assert {"result"} == response.json.keys()
-    assert {"url", "namespace", "name"} == response.json["result"].keys()
+    assert {"project_id", "url", "namespace", "name"} == response.json["result"].keys()
 
     # Check ctrl_mock.
     assert ctrl_mock.call_count == 1
@@ -139,7 +139,7 @@ def test_project_name_handler(project_name, expected_name, ctrl_init, svc_client
 
     # Check response.
     assert {"result"} == response.json.keys()
-    assert {"url", "namespace", "name"} == response.json["result"].keys()
+    assert {"project_id", "url", "namespace", "name"} == response.json["result"].keys()
     assert expected_name == response.json["result"]["name"]
 
 


### PR DESCRIPTION
Fixed git user not being set in newly created project.

Also fixes `owner` being taken from the template repository (e.g. `SwissDataScienceCenter` instead of the actual project namespace)

Now returns `project_id` in the `templates.create_project` request. As the project is in cache anyways, I don't understand why this wasn't returned before.

/deploy