### PR TITLE
fix(service): fixes management jobs running into timeouts

### DIFF
--- a/renku/service/jobs/cleanup.py
+++ b/renku/service/jobs/cleanup.py
@@ -38,6 +38,8 @@ def cache_files_cleanup():
             if file.exists() and file.ttl_expired():
                 worker_log.debug(f"purging file {file.file_id}:{file.file_name}")
                 file.purge()
+            elif not file.exists():
+                file.delete()
 
 
 def cache_project_cleanup():
@@ -57,3 +59,5 @@ def cache_project_cleanup():
             if project.exists() and project.ttl_expired():
                 worker_log.debug(f"purging project {project.project_id}:{project.name}")
                 project.purge()
+            elif not project.exists():
+                project.delete()

--- a/renku/service/scheduler.py
+++ b/renku/service/scheduler.py
@@ -43,6 +43,7 @@ def schedule(connection=None):
         queue_name=CLEANUP_QUEUE_FILES,
         func=cache_files_cleanup,
         interval=cleanup_interval,
+        timeout=cleanup_interval - 1,  # NOTE: Ensure job times out before next job starts
         result_ttl=cleanup_interval * 2,
     )
 
@@ -51,6 +52,7 @@ def schedule(connection=None):
         queue_name=CLEANUP_QUEUE_PROJECTS,
         func=cache_project_cleanup,
         interval=cleanup_interval,
+        timeout=cleanup_interval - 1,  # NOTE: Ensure job times out before next job starts
         result_ttl=cleanup_interval * 2,
     )
 


### PR DESCRIPTION
Redis File entries that weren't deleted (probably due to restarting the service but not clearing redis cache) will now be properly deleted.

Job timeout for management jobs have been adjusted to not run longer than until the next instance of the job.

closes #2085 