### PR TITLE
fix(core): do not remove unused template parameters

### DIFF
--- a/renku/core/commands/init.py
+++ b/renku/core/commands/init.py
@@ -18,6 +18,7 @@
 """Project initialization logic."""
 
 import json
+import re
 import tempfile
 from collections import OrderedDict, namedtuple
 from pathlib import Path
@@ -37,7 +38,7 @@ from renku.core.management.config import RENKU_HOME
 from renku.core.management.repository import INIT_APPEND_FILES, INIT_KEEP_FILES
 from renku.core.models.tabulate import tabulate
 from renku.core.utils import communication
-from renku.version import __version__ as renku_version
+from renku.version import __version__, is_release
 
 TEMPLATE_MANIFEST = "manifest.yaml"
 
@@ -159,14 +160,16 @@ def verify_template_variables(template_data, metadata):
             show_default=False,
         )
         metadata[key] = value
-    useless_variables = input_parameters_keys - template_variables_keys
-    if len(useless_variables) > 0:
+
+    # ignore internal variables, i.e. __\w__
+    internal_keys = re.compile(r"__\w+__$")
+    input_parameters_keys = set([i for i in input_parameters_keys if not internal_keys.match(i)])
+    unused_variables = input_parameters_keys - template_variables_keys
+    if len(unused_variables) > 0:
         communication.info(
             "These parameters are not used by the template and were "
-            "ignored:\n\t{}".format("\n\t".join(useless_variables))
+            "ignored:\n\t{}".format("\n\t".join(unused_variables))
         )
-        for key in useless_variables:
-            del metadata[key]
 
     return metadata
 
@@ -271,8 +274,8 @@ def _init(
     metadata["__sanitized_project_name__"] = ""
     metadata["__repository__"] = ""
     metadata["__project_slug__"] = ""
-    if "__renku_version__" not in metadata:
-        metadata["__renku_version__"] = renku_version
+    if is_release() and "__renku_version__" not in metadata:
+        metadata["__renku_version__"] = __version__
     metadata["name"] = name
 
     template_path = template_folder / template_data["folder"]

--- a/renku/service/controllers/templates_create_project.py
+++ b/renku/service/controllers/templates_create_project.py
@@ -30,7 +30,7 @@ from renku.service.controllers.utils.project_clone import user_project_clone
 from renku.service.serializers.templates import ProjectTemplateRequest, ProjectTemplateResponseRPC
 from renku.service.utils import new_repo_push
 from renku.service.views import result_response
-from renku.version import __version__ as renku_version
+from renku.version import __version__, is_release
 
 
 class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
@@ -67,8 +67,9 @@ class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
             "__repository__": self.ctx["project_repository"],
             "__sanitized_project_name__": self.ctx["project_name_stripped"],
             "__project_slug__": self.ctx["project_slug"],
-            "__renku_version__": renku_version,
         }
+        if is_release():
+            metadata["__renku_version__"] = __version__
 
         return metadata
 

--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,16 @@ version_template = """\
 # limitations under the License.
 \"\"\"Version information for Renku.\"\"\"
 
+import re
+
 __version__ = {version!r}
+
+
+def is_release():
+    \"\"\"Check if current version is a release semver.\"\"\"
+    if re.match(r"\\d+.\\d+.\\d+$", __version__):
+        return True
+    return False
 
 
 def _get_distribution_url():

--- a/tests/service/controllers/test_templates_create_project.py
+++ b/tests/service/controllers/test_templates_create_project.py
@@ -20,6 +20,7 @@ import pytest
 from marshmallow import ValidationError
 
 from renku.core.utils.scm import normalize_to_ascii
+from renku.version import is_release
 
 
 def test_template_create_project_ctrl(ctrl_init, svc_client_templates_creation, mocker):
@@ -77,8 +78,9 @@ def test_template_create_project_ctrl(ctrl_init, svc_client_templates_creation, 
         "__repository__",
         "__sanitized_project_name__",
         "__project_slug__",
-        "__renku_version__",
     }
+    if is_release():
+        expected_metadata.add("__renku_version__")
     assert expected_metadata == set(received_metadata.keys())
     assert payload["url"] == received_metadata["__template_source__"]
     assert payload["ref"] == received_metadata["__template_ref__"]


### PR DESCRIPTION
# Description

Do not remove from the template parameters - just warn user - that are not explicitly specified in metadata. moreover, internal parameters like `__parameter__` should not be exposed to the user.