### PR TITLE
fix(core): version template lint

### DIFF
--- a/renku/version.py.tmpl
+++ b/renku/version.py.tmpl
@@ -19,7 +19,7 @@
 
 import re
 
-__version__ = {version!r}
+__version__ = "{version}"
 
 
 def is_release():
@@ -32,12 +32,13 @@ def is_release():
 def _get_distribution_url():
     try:
         import pkg_resources
-        d = pkg_resources.get_distribution('renku')
+
+        d = pkg_resources.get_distribution("renku")
         metadata = d._get_metadata(d.PKG_INFO)
-        home_page = [m for m in metadata if m.startswith('Home-page:')]
-        return home_page[0].split(':', 1)[1].strip()
+        home_page = [m for m in metadata if m.startswith("Home-page:")]
+        return home_page[0].split(":", 1)[1].strip()
     except Exception:
-        return 'N/A'
+        return "N/A"
 
 
-version_url = '{{}}/tree/{{}}'.format(_get_distribution_url(), 'v' + __version__)
+version_url = "{{}}/tree/{{}}".format(_get_distribution_url(), "v" + __version__)


### PR DESCRIPTION
# Description

With the current version template the generated `version.py` fails passing linting constraints. this patch is addressing those warnings.