### PR TITLE
chore(core): use github.event's information to figure out default branch name

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -17,8 +17,9 @@ jobs:
       id: set-matrix
       env:
         REF: ${{ github.ref }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       run: |
-        if [ "$REF" == "refs/heads/master" ] || [[ "$REF" =~ ^refs/tags/.* ]]
+        if [ "$REF" == "refs/heads/$DEFAULT_BRANCH" ] || [[ "$REF" =~ ^refs/tags/.* ]]
         then
             echo "::set-output name=matrix::{\"python-version\": [\"3.6\", \"3.7\", \"3.8\"]}"
         else
@@ -30,7 +31,7 @@ jobs:
     - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+    if: "!startsWith(github.ref, 'refs/tags/') && !endsWith(github.ref, github.event.repository.default_branch)
 
   style-check:
     runs-on: ubuntu-latest
@@ -469,7 +470,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix: ${{fromJson(needs.set-matrix.outputs.matrix)}}
-    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
+    if: "startsWith(github.ref, 'refs/tags/') || endsWith(github.ref, github.event.repository.default_branch)"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -566,13 +567,13 @@ jobs:
     - name: build images
       run: make docker-tag
     - name: Docker Login
-      if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
+      if: "startsWith(github.ref, 'refs/tags/') || endsWith(github.ref, github.event.repository.default_branch)"
       uses: Azure/docker-login@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     - name: push images
-      if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
+      if: "startsWith(github.ref, 'refs/tags/') ||  endsWith(github.ref, github.event.repository.default_branch)"
       run: |
         make docker-push
 

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    if: "!startsWith(github.ref, 'refs/tags/') && !endsWith(github.ref, github.event.repository.default_branch)
+    if: "!startsWith(github.ref, 'refs/tags/') && !endsWith(github.ref, github.event.repository.default_branch)"
 
   style-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -43,7 +43,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6]
-    if: "startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'"
+    if: "startsWith(github.ref, 'refs/tags/') || endsWith(github.ref, github.event.repository.default_branch)"
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
# Description

remove the hardcoded `master` branch as default branch of the renku-python repository and rely on github.event information