### PR TITLE
chore: update renku action paths

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -29,7 +29,7 @@ jobs:
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku/actions/check-pr-description@master
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v0.1.0
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -41,7 +41,7 @@ jobs:
       name: renku-ci-rp-${{ github.event.number }}
     steps:
     - name: deploy-pr
-      uses: SwissDataScienceCenter/renku/actions/deploy-renku@master
+      uses: SwissDataScienceCenter/renku-actions/deploy-renku@v0.1.0
       env:
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -99,7 +99,7 @@ jobs:
         helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 80m --logs
     - name: Download artifact for packaging on failure
       if: failure()
-      uses: SwissDataScienceCenter/renku/actions/download-test-artifacts@master
+      uses: SwissDataScienceCenter/renku-actions/download-test-artifacts@v0.1.0
       env:
         RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
         TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
@@ -115,7 +115,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: renku teardown
-      uses: SwissDataScienceCenter/renku/actions/teardown-renku@master
+      uses: SwissDataScienceCenter/renku-actions/teardown-renku@v0.1.0
       env:
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
         KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -590,7 +590,7 @@ jobs:
         echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
         echo "GIT_EMAIL=renku@datascience.ch" >> $GITHUB_ENV
     - name: Push chart and images
-      uses: SwissDataScienceCenter/renku/actions/publish-chart@master
+      uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.1.0
       env:
         CHART_NAME: renku-core
         GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
@@ -599,7 +599,7 @@ jobs:
     - name: Wait for chart to be available
       run: sleep 120
     - name: Update component version
-      uses: SwissDataScienceCenter/renku/actions/update-component-version@master
+      uses: SwissDataScienceCenter/renku-actions/update-component-version@v0.1.0
       env:
         CHART_NAME: renku-core
         GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}


### PR DESCRIPTION
Renku github actions have been moved to https://github.com/SwissDataScienceCenter/renku-actions so we need to update the references. 

/deploy