### PR TITLE
feat(core): add dispatcher/factory classes for LocalClient and Database

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -454,7 +454,7 @@ jobs:
         ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
         OLOS_ACCESS_TOKEN: ${{ secrets.OLOS_ACCESS_TOKEN }}
         RENKU_REQUESTS_TIMEOUT_SECONDS: 120
-      run: pytest --cov-append -m "integration and serial" -v --timeout=600 -n auto
+      run: pytest --cov-append -m "integration and serial" -v --timeout=600
     - name: Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/renku/cli/rerun.py
+++ b/renku/cli/rerun.py
@@ -51,8 +51,8 @@ from renku.cli.utils.callback import ClickCallback
 from renku.core import errors
 from renku.core.commands.options import option_siblings
 from renku.core.commands.rerun import rerun_workflows
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 
 
 def show_inputs(workflow):
@@ -63,8 +63,9 @@ def show_inputs(workflow):
 
 
 @inject.autoparams()
-def edit_inputs(workflow, client: LocalClient):
+def edit_inputs(workflow, client_dispatcher: IClientDispatcher):
     """Edit workflow inputs."""
+    client = client_dispatcher.current_client
     for input_ in workflow.inputs:
         new_path = click.prompt("{0._id}".format(input_), default=input_.consumes.path)
         input_.consumes.path = str(Path(os.path.abspath(new_path)).relative_to(client.path))

--- a/renku/core/commands/checks/references.py
+++ b/renku/core/commands/checks/references.py
@@ -26,7 +26,7 @@ def check_missing_references(client):
     """Find missing references."""
     from renku.core.models.refs import LinkReference
 
-    missing = [ref for ref in LinkReference.iter_items(client) if not ref.reference.exists()]
+    missing = [ref for ref in LinkReference.iter_items() if not ref.reference.exists()]
 
     if not missing:
         return True, None

--- a/renku/core/commands/clone.py
+++ b/renku/core/commands/clone.py
@@ -17,16 +17,16 @@
 # limitations under the License.
 """Clone a Renku repo along with all Renku-specific initializations."""
 
-from renku.core.management import LocalClient
 from renku.core.management.clone import clone
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 
 
 @inject.autoparams()
 def _project_clone(
     url,
-    client: LocalClient,
+    client_dispatcher: IClientDispatcher,
     path=None,
     install_githooks=True,
     skip_smudge=True,
@@ -38,7 +38,7 @@ def _project_clone(
     checkout_rev=None,
 ):
     """Clone Renku project repo, install Git hooks and LFS."""
-    install_lfs = client.external_storage_requested
+    install_lfs = client_dispatcher.current_client.external_storage_requested
 
     return clone(
         url=url,

--- a/renku/core/commands/config.py
+++ b/renku/core/commands/config.py
@@ -17,10 +17,10 @@
 # limitations under the License.
 """Get and set Renku repository or global options."""
 from renku.core import errors
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
 from renku.core.management.config import CONFIG_LOCAL_PATH
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.models.enums import ConfigFilter
 
 
@@ -53,8 +53,11 @@ def update_multiple_config():
 
 
 @inject.autoparams()
-def _update_config(key, client: LocalClient, *, value=None, remove=False, global_only=False, commit_message=None):
+def _update_config(
+    key, client_dispatcher: IClientDispatcher, *, value=None, remove=False, global_only=False, commit_message=None
+):
     """Add, update, or remove configuration values."""
+    client = client_dispatcher.current_client
     section, section_key = _split_section_and_key(key)
     if remove:
         value = client.remove_value(section, section_key, global_only=global_only)
@@ -77,8 +80,9 @@ def update_config():
 
 
 @inject.autoparams()
-def _read_config(key, client: LocalClient, config_filter=ConfigFilter.ALL, as_string=True):
+def _read_config(key, client_dispatcher: IClientDispatcher, config_filter=ConfigFilter.ALL, as_string=True):
     """Read configuration."""
+    client = client_dispatcher.current_client
     if key:
         section, section_key = _split_section_and_key(key)
         value = client.get_value(section, section_key, config_filter=config_filter)

--- a/renku/core/commands/cwl_runner.py
+++ b/renku/core/commands/cwl_runner.py
@@ -25,15 +25,17 @@ from urllib.parse import unquote
 import click
 
 from renku.core.errors import WorkflowRerunError
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 
 from .echo import progressbar
 
 
 @inject.autoparams()
-def execute(output_file, client: LocalClient, output_paths=None):
+def execute(output_file, client_dispatcher: IClientDispatcher, output_paths=None):
     """Run the generated workflow using cwltool library."""
+    client = client_dispatcher.current_client
+
     output_paths = output_paths or set()
 
     import cwltool.factory

--- a/renku/core/commands/docker.py
+++ b/renku/core/commands/docker.py
@@ -23,15 +23,15 @@ from configparser import NoSectionError
 import attr
 
 from renku.core import errors
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.models.git import GitURL
 
 
 @inject.autoparams()
-def detect_registry_url(client: LocalClient, auto_login=True):
+def detect_registry_url(client_dispatcher: IClientDispatcher, auto_login=True):
     """Return a URL of the Docker registry."""
-    repo = client.repo
+    repo = client_dispatcher.current_client.repo
     config = repo.config_reader()
 
     # Find registry URL in .git/config

--- a/renku/core/commands/doctor.py
+++ b/renku/core/commands/doctor.py
@@ -20,6 +20,7 @@ import traceback
 
 from renku.core.commands.echo import ERROR
 from renku.core.management.command_builder.command import Command, inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 
 DOCTOR_INFO = """\
 Please note that the diagnosis report is used to help Renku maintainers with
@@ -28,10 +29,12 @@ and if in doubt ask an expert around or file an issue. Thanks!
 """
 
 
-@inject.params(client="LocalClient")
-def _doctor_check(client):
+@inject.autoparams()
+def _doctor_check(client_dispatcher: IClientDispatcher):
     """Check your system and repository for potential problems."""
     from . import checks
+
+    client = client_dispatcher.current_client
 
     is_ok = True
     problems = []

--- a/renku/core/commands/format/dataset_files.py
+++ b/renku/core/commands/format/dataset_files.py
@@ -21,8 +21,8 @@ from subprocess import PIPE, SubprocessError, run
 
 from humanize import naturalsize
 
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.models.dataset import DatasetFileDetailsJson
 
 from .tabulate import tabulate
@@ -55,8 +55,10 @@ def tabular(records, *, columns=None):
 
 
 @inject.autoparams()
-def _get_lfs_tracking(records, client: LocalClient):
+def _get_lfs_tracking(records, client_dispatcher: IClientDispatcher):
     """Check if files are tracked in git lfs."""
+    client = client_dispatcher.current_client
+
     paths = [r.path for r in records]
     attrs = client.find_attr(*paths)
 
@@ -68,8 +70,10 @@ def _get_lfs_tracking(records, client: LocalClient):
 
 
 @inject.autoparams()
-def _get_lfs_file_sizes(records, client: LocalClient):
+def _get_lfs_file_sizes(records, client_dispatcher: IClientDispatcher):
     """Try to get file size from Git LFS."""
+    client = client_dispatcher.current_client
+
     lfs_files_sizes = {}
 
     try:

--- a/renku/core/commands/migrate.py
+++ b/renku/core/commands/migrate.py
@@ -17,9 +17,9 @@
 # limitations under the License.
 """Migrate project to the latest Renku version."""
 
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.management.migrate import (
     is_docker_update_possible,
     is_migration_required,
@@ -44,7 +44,9 @@ def migrations_check():
 
 
 @inject.autoparams()
-def _migrations_check(client: LocalClient):
+def _migrations_check(client_dispatcher: IClientDispatcher):
+    client = client_dispatcher.current_client
+
     template_update_possible, current_version, new_version = is_template_update_possible()
 
     try:
@@ -78,9 +80,11 @@ def migrations_versions():
 
 
 @inject.autoparams()
-def _migrations_versions(client: LocalClient):
+def _migrations_versions(client_dispatcher: IClientDispatcher):
     """Return source and destination migration versions."""
     from renku import __version__
+
+    client = client_dispatcher.current_client
 
     try:
         latest_agent = client.latest_agent
@@ -116,7 +120,9 @@ def check_project():
 
 
 @inject.autoparams()
-def _check_project(client: LocalClient):
+def _check_project(client_dispatcher: IClientDispatcher):
+    client = client_dispatcher.current_client
+
     if not is_renku_project():
         return NON_RENKU_REPOSITORY
     elif is_project_unsupported():
@@ -143,8 +149,10 @@ def _check_project(client: LocalClient):
 
 
 @inject.autoparams()
-def _check_immutable_template_files(paths, client: LocalClient):
+def _check_immutable_template_files(paths, client_dispatcher: IClientDispatcher):
     """Check paths and return a list of those that are marked immutable in the project template."""
+    client = client_dispatcher.current_client
+
     if not client.project.immutable_template_files:
         return []
 

--- a/renku/core/commands/providers/dataverse.py
+++ b/renku/core/commands/providers/dataverse.py
@@ -39,8 +39,8 @@ from renku.core.commands.providers.dataverse_metadata_templates import (
 )
 from renku.core.commands.providers.doi import DOIProvider
 from renku.core.commands.providers.models import ProviderDataset, ProviderDatasetSchema
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.metadata.immutable import DynamicProxy
 from renku.core.models.dataset import DatasetFile
 from renku.core.models.provenance.agent import PersonSchema
@@ -236,9 +236,11 @@ class DataverseProvider(ProviderApi):
         )
 
     @inject.autoparams()
-    def set_parameters(self, client: LocalClient, *, dataverse_server, dataverse_name, **kwargs):
+    def set_parameters(self, client_dispatcher: IClientDispatcher, *, dataverse_server, dataverse_name, **kwargs):
         """Set and validate required parameters for a provider."""
         CONFIG_BASE_URL = "server_url"
+
+        client = client_dispatcher.current_client
 
         if not dataverse_server:
             dataverse_server = client.get_value("dataverse", CONFIG_BASE_URL)

--- a/renku/core/commands/providers/olos.py
+++ b/renku/core/commands/providers/olos.py
@@ -28,8 +28,8 @@ import requests
 
 from renku.core import errors
 from renku.core.commands.providers.api import ExporterApi, ProviderApi
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.utils import communication
 from renku.core.utils.git import get_content
 from renku.core.utils.requests import retry
@@ -67,9 +67,11 @@ class OLOSProvider(ProviderApi):
         return OLOSExporter(dataset=dataset, access_token=access_token, server_url=self._server_url)
 
     @inject.autoparams()
-    def set_parameters(self, client: LocalClient, *, dlcm_server=None, **kwargs):
+    def set_parameters(self, client_dispatcher: IClientDispatcher, *, dlcm_server=None, **kwargs):
         """Set and validate required parameters for a provider."""
         config_base_url = "server_url"
+
+        client = client_dispatcher.current_client
 
         if not dlcm_server:
             dlcm_server = client.get_value("olos", config_base_url)

--- a/renku/core/commands/rerun.py
+++ b/renku/core/commands/rerun.py
@@ -17,8 +17,8 @@
 # limitations under the License.
 """Renku rerun command."""
 
-from renku.core.management import LocalClient
 from renku.core.management.command_builder.command import Command, inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 
 
 def rerun_workflows():
@@ -35,7 +35,7 @@ def rerun_workflows():
 
 
 @inject.autoparams()
-def _rerun_workflows(revision, roots, siblings, inputs, paths, client: LocalClient):
+def _rerun_workflows(revision, roots, siblings, inputs, paths, client_dispatcher: IClientDispatcher):
     pass
     # TODO: implement with new database
     # graph = Graph(client)

--- a/renku/core/commands/run.py
+++ b/renku/core/commands/run.py
@@ -24,11 +24,11 @@ from subprocess import call
 import click
 
 from renku.core import errors
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
 from renku.core.management.git import get_mapped_std_streams
 from renku.core.management.interface.activity_gateway import IActivityGateway
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.management.interface.plan_gateway import IPlanGateway
 from renku.core.management.workflow.plan_factory import PlanFactory
 from renku.core.models.provenance.activity import Activity
@@ -53,11 +53,13 @@ def _run_command(
     no_output_detection,
     success_codes,
     command_line,
-    client: LocalClient,
+    client_dispatcher: IClientDispatcher,
     activity_gateway: IActivityGateway,
     plan_gateway: IPlanGateway,
 ):
     # NOTE: validate name as early as possible
+    client = client_dispatcher.current_client
+
     if name:
         valid_name = get_slug(name)
         if name != valid_name:

--- a/renku/core/commands/save.py
+++ b/renku/core/commands/save.py
@@ -23,17 +23,19 @@ from uuid import uuid4
 import git
 
 from renku.core import errors
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.utils import communication
 from renku.core.utils.git import add_to_git
 from renku.core.utils.scm import git_unicode_unescape
 
 
 @inject.autoparams()
-def _save_and_push(client: LocalClient, message=None, remote=None, paths=None):
+def _save_and_push(client_dispatcher: IClientDispatcher, message=None, remote=None, paths=None):
     """Save and push local changes."""
+    client = client_dispatcher.current_client
+
     client.setup_credential_helper()
     if not paths:
         paths = client.dirty_paths

--- a/renku/core/commands/show.py
+++ b/renku/core/commands/show.py
@@ -19,9 +19,9 @@
 
 from collections import namedtuple
 
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 
 Result = namedtuple("Result", ["path", "commit", "time", "workflow"])
 
@@ -76,7 +76,7 @@ def get_inputs():
 
 
 @inject.autoparams()
-def _get_inputs(revision, paths, client: LocalClient):
+def _get_inputs(revision, paths, client_dispatcher: IClientDispatcher):
     pass
     # TODO: implement with new database
     # graph = Graph()

--- a/renku/core/commands/status.py
+++ b/renku/core/commands/status.py
@@ -23,10 +23,10 @@ from typing import List, Tuple
 
 from git import GitCommandError
 
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
 from renku.core.management.interface.activity_gateway import IActivityGateway
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.models.provenance.activity import Activity, Usage
 from renku.core.utils import communication
 
@@ -42,7 +42,9 @@ def get_status():
 
 
 @inject.autoparams()
-def _get_status(client: LocalClient, activity_gateway: IActivityGateway):
+def _get_status(client_dispatcher: IClientDispatcher, activity_gateway: IActivityGateway):
+    client = client_dispatcher.current_client
+
     latest_activities = activity_gateway.get_latest_activity_per_plan().values()
 
     if client.has_external_files():
@@ -82,9 +84,11 @@ def _get_status(client: LocalClient, activity_gateway: IActivityGateway):
 
 @inject.autoparams()
 def _get_modified_paths(
-    activities: List[Activity], client: LocalClient
+    activities: List[Activity], client_dispatcher: IClientDispatcher
 ) -> Tuple[List[Tuple[Activity, Usage]], List[Tuple[Activity, Usage]]]:
     """Get modified and deleted usages/inputs of a list of activities."""
+    client = client_dispatcher.current_client
+
     modified = set()
     deleted = set()
     for activity in activities:

--- a/renku/core/commands/storage.py
+++ b/renku/core/commands/storage.py
@@ -17,16 +17,16 @@
 # limitations under the License.
 """Renku storage command."""
 
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.utils import communication
 
 
 @inject.autoparams()
-def _check_lfs(client: LocalClient, everything=False):
+def _check_lfs(client_dispatcher: IClientDispatcher, everything=False):
     """Check if large files are not in lfs."""
-    files = client.check_lfs_migrate_info(everything)
+    files = client_dispatcher.current_client.check_lfs_migrate_info(everything)
 
     if files:
         communication.warn("Git history contains large files\n\t" + "\n\t".join(files))
@@ -40,9 +40,9 @@ def check_lfs_command():
 
 
 @inject.autoparams()
-def _fix_lfs(paths, client: LocalClient):
+def _fix_lfs(paths, client_dispatcher: IClientDispatcher):
     """Migrate large files into lfs."""
-    client.migrate_files_to_lfs(paths)
+    client_dispatcher.current_client.migrate_files_to_lfs(paths)
 
 
 def fix_lfs_command():
@@ -51,9 +51,9 @@ def fix_lfs_command():
 
 
 @inject.autoparams()
-def _pull(paths, client: LocalClient):
+def _pull(paths, client_dispatcher: IClientDispatcher):
     """Pull the specified paths from external storage."""
-    client.pull_paths_from_storage(*paths)
+    client_dispatcher.current_client.pull_paths_from_storage(*paths)
 
 
 def pull_command():
@@ -62,9 +62,9 @@ def pull_command():
 
 
 @inject.autoparams()
-def _clean(paths, client: LocalClient):
+def _clean(paths, client_dispatcher: IClientDispatcher):
     """Remove files from lfs cache/turn them back into pointer files."""
-    untracked_paths, local_only_paths = client.clean_storage_cache(*paths)
+    untracked_paths, local_only_paths = client_dispatcher.current_client.clean_storage_cache(*paths)
 
     if untracked_paths:
         communication.warn(
@@ -85,9 +85,9 @@ def clean_command():
 
 
 @inject.autoparams()
-def _check_lfs_hook(paths, client: LocalClient):
+def _check_lfs_hook(paths, client_dispatcher: IClientDispatcher):
     """Pull the specified paths from external storage."""
-    return client.check_requires_tracking(*paths)
+    return client_dispatcher.current_client.check_requires_tracking(*paths)
 
 
 def check_lfs_hook_command():

--- a/renku/core/commands/update.py
+++ b/renku/core/commands/update.py
@@ -23,10 +23,10 @@ from git import Actor
 
 from renku.core.commands.cwl_runner import execute
 from renku.core.errors import ParameterError
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
 from renku.core.management.interface.activity_gateway import IActivityGateway
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.management.workflow.converters.cwl import CWLConverter
 from renku.core.management.workflow.plan_factory import delete_indirect_files_list
 from renku.core.utils.git import add_to_git
@@ -75,9 +75,16 @@ def _update_workflows(revision, no_output, update_all, siblings, paths):
 
 @inject.autoparams()
 def execute_workflow(
-    workflow, output_paths, command_name, update_commits, client: LocalClient, activity_gateway: IActivityGateway
+    workflow,
+    output_paths,
+    command_name,
+    update_commits,
+    client_dispatcher: IClientDispatcher,
+    activity_gateway: IActivityGateway,
 ):
     """Execute a Run with/without subprocesses."""
+    client = client_dispatcher.current_client
+
     wf, path = CWLConverter.convert(workflow, client.path)
     # Don't compute paths if storage is disabled.
     if client.check_external_storage():

--- a/renku/core/commands/workflow.py
+++ b/renku/core/commands/workflow.py
@@ -26,9 +26,9 @@ from renku.core import errors
 from renku.core.commands.format.workflow import WORKFLOW_FORMATS
 from renku.core.commands.view_model import plan_view
 from renku.core.commands.view_model.composite_plan import CompositePlanViewModel
-from renku.core.management import LocalClient
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.management.interface.plan_gateway import IPlanGateway
 from renku.core.management.workflow.concrete_execution_graph import ExecutionGraph
 from renku.core.management.workflow.value_resolution import apply_run_values
@@ -257,8 +257,11 @@ def edit_workflow_command():
 
 
 @inject.autoparams()
-def _export_workflow(name_or_id, client: LocalClient, format: str, output: Optional[str], values: Optional[str]):
+def _export_workflow(
+    name_or_id, client_dispatcher: IClientDispatcher, format: str, output: Optional[str], values: Optional[str]
+):
     """Export a workflow to a given format."""
+    client = client_dispatcher.current_client
 
     workflow = _find_workflow(name_or_id)
     if output:

--- a/renku/core/incubation/graph.py
+++ b/renku/core/incubation/graph.py
@@ -24,10 +24,10 @@ from pathlib import Path
 from pkg_resources import resource_filename
 
 from renku.core import errors
-from renku.core.management import LocalClient
 from renku.core.management.command_builder.command import Command, inject
 from renku.core.management.config import RENKU_HOME
 from renku.core.management.datasets import DatasetsApiMixin
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.management.repository import RepositoryApiMixin
 from renku.core.utils.shacl import validate_graph
 
@@ -88,8 +88,10 @@ def export_graph():
 
 
 @inject.autoparams()
-def _export_graph(format, workflows_only, strict, client: LocalClient):
+def _export_graph(format, workflows_only, strict, client_dispatcher: IClientDispatcher):
     """Output graph in specific format."""
+    client = client_dispatcher.current_client
+
     if not client.provenance_graph_path.exists():
         raise errors.ParameterError("Graph is not generated.")
 

--- a/renku/core/management/clone.py
+++ b/renku/core/management/clone.py
@@ -25,6 +25,7 @@ from git import GitCommandError, Repo
 from renku.core import errors
 from renku.core.management.command_builder.command import inject
 from renku.core.management.interface.client_dispatcher import IClientDispatcher
+from renku.core.management.interface.database_dispatcher import IDatabaseDispatcher
 from renku.core.models.git import GitURL
 
 
@@ -43,6 +44,7 @@ def _handle_git_exception(e, raise_git_except, progress):
 def clone(
     url,
     client_dispatcher: IClientDispatcher,
+    database_dispatcher: IDatabaseDispatcher,
     path=None,
     install_githooks=True,
     install_lfs=True,
@@ -118,6 +120,7 @@ def clone(
         config_writer.release()
 
     client_dispatcher.push_client_to_stack(path=path)
+    database_dispatcher.push_database_to_stack(client_dispatcher.current_client.database_path)
 
     try:
         if install_githooks:
@@ -134,6 +137,7 @@ def clone(
 
         project_initialized = is_renku_project()
     finally:
+        database_dispatcher.pop_database()
         client_dispatcher.pop_client()
 
     return repo, project_initialized

--- a/renku/core/management/command_builder/__init__.py
+++ b/renku/core/management/command_builder/__init__.py
@@ -17,6 +17,6 @@
 # limitations under the License.
 """Renku Command Builder ."""
 
-from .command import Command, inject, replace_injected_client
+from .command import Command, inject
 
-__all__ = ["Command", "inject", "replace_injected_client"]
+__all__ = ["Command", "inject"]

--- a/renku/core/management/command_builder/client_dispatcher.py
+++ b/renku/core/management/command_builder/client_dispatcher.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renku client dispatcher."""
+
+from typing import Optional
+
+from renku.core import errors
+from renku.core.management import LocalClient
+from renku.core.management.config import RENKU_HOME
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
+
+
+class ClientDispatcher(IClientDispatcher):
+    """Dispatch currently active client.
+
+    Handles getting current client (LocalClient) and entering/exiting the stack for the client.
+    """
+
+    client_stack = []
+
+    @property
+    def current_client(self) -> Optional[LocalClient]:
+        """Get the currently active client."""
+        if len(self.client_stack) == 0:
+            raise errors.ConfigurationError("No client configured for injection")
+
+        return self.client_stack[-1]
+
+    def push_client_to_stack(
+        self, path: str, renku_home: str = RENKU_HOME, external_storage_requested: bool = True
+    ) -> None:
+        """Create and push a new client to the stack."""
+        new_client = LocalClient(path)
+        self.client_stack.append(new_client)
+
+    def push_created_client_to_stack(self, client: LocalClient) -> None:
+        """Push an already created client to the stack."""
+
+        self.client_stack.append(client)
+
+    def pop_client(self) -> None:
+        """Remove the current client from the stack."""
+        self.client_stack.pop()

--- a/renku/core/management/command_builder/client_dispatcher.py
+++ b/renku/core/management/command_builder/client_dispatcher.py
@@ -31,7 +31,8 @@ class ClientDispatcher(IClientDispatcher):
     Handles getting current client (LocalClient) and entering/exiting the stack for the client.
     """
 
-    client_stack = []
+    def __init__(self):
+        self.client_stack = []
 
     @property
     def current_client(self) -> Optional[LocalClient]:

--- a/renku/core/management/command_builder/database_dispatcher.py
+++ b/renku/core/management/command_builder/database_dispatcher.py
@@ -29,7 +29,8 @@ class DatabaseDispatcher(IDatabaseDispatcher):
     Handles getting current database (Database) and entering/exiting the stack for the database.
     """
 
-    database_stack = []
+    def __init__(self):
+        self.database_stack = []
 
     @property
     def current_database(self) -> Database:

--- a/renku/core/management/command_builder/database_dispatcher.py
+++ b/renku/core/management/command_builder/database_dispatcher.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renku database dispatcher."""
+
+
+from renku.core import errors
+from renku.core.management.interface.database_dispatcher import IDatabaseDispatcher
+from renku.core.metadata.database import Database
+
+
+class DatabaseDispatcher(IDatabaseDispatcher):
+    """Interface for the DatabaseDispatcher.
+
+    Handles getting current database (Database) and entering/exiting the stack for the database.
+    """
+
+    database_stack = []
+
+    @property
+    def current_database(self) -> Database:
+        """Get the currently active database."""
+        if len(self.database_stack) == 0:
+            raise errors.ConfigurationError("No database configured for injection")
+
+        return self.database_stack[-1][0]
+
+    def push_database_to_stack(self, path: str, commit: bool = False) -> None:
+        """Create and push a new client to the stack."""
+        new_database = Database.from_path(path)
+        self.database_stack.append((new_database, commit))
+
+    def pop_database(self) -> None:
+        """Remove the current client from the stack."""
+        popped_database = self.database_stack.pop()
+
+        if popped_database[1]:
+            popped_database[0].commit()
+
+    def finalize_dispatcher(self) -> None:
+        """Close all database contexts."""
+        while self.database_stack:
+            self.pop_database()

--- a/renku/core/management/command_builder/lock.py
+++ b/renku/core/management/command_builder/lock.py
@@ -31,12 +31,12 @@ class ProjectLock(Command):
 
     def _pre_hook(self, builder: Command, context: dict, *args, **kwargs) -> None:
         """Lock the project."""
-        if "client" not in context:
-            raise ValueError("Commit builder needs a LocalClient to be set.")
+        if "client_dispatcher" not in context:
+            raise ValueError("Project lock builder needs a IClientDispatcher to be set.")
         if "stack" not in context:
-            raise ValueError("Commit builder needs a stack to be set.")
+            raise ValueError("Project lock builder needs a stack to be set.")
 
-        context["stack"].enter_context(context["client"].lock)
+        context["stack"].enter_context(context["client_dispatcher"].current_client.lock)
 
     @check_finalized
     def build(self) -> Command:
@@ -56,12 +56,12 @@ class DatasetLock(Command):
         self._builder = builder
 
     def _pre_hook(self, builder: Command, context: dict, *args, **kwargs) -> None:
-        if "client" not in context:
-            raise ValueError("Commit builder needs a LocalClient to be set.")
+        if "client_dispatcher" not in context:
+            raise ValueError("Dataset lock builder needs a IClientDispatcher to be set.")
         if "stack" not in context:
-            raise ValueError("Commit builder needs a stack to be set.")
+            raise ValueError("Dataset lock builder needs a stack to be set.")
 
-        context["stack"].enter_context(context["client"].lock)
+        context["stack"].enter_context(context["client_dispatcher"].current_client.lock)
 
     @check_finalized
     def build(self) -> Command:

--- a/renku/core/management/command_builder/migration.py
+++ b/renku/core/management/command_builder/migration.py
@@ -32,9 +32,6 @@ class RequireMigration(Command):
 
     def _pre_hook(self, builder: Command, context: dict, *args, **kwargs) -> None:
         """Check if migration is necessary."""
-        if "client" not in context:
-            raise ValueError("Commit builder needs a LocalClient to be set.")
-
         check_for_migration()
 
     @check_finalized

--- a/renku/core/management/dataset/__init__.py
+++ b/renku/core/management/dataset/__init__.py
@@ -20,14 +20,13 @@
 from typing import Optional
 
 from renku.core import errors
-from renku.core.management.command_builder import inject
 from renku.core.management.dataset.datasets_provenance import DatasetsProvenance
 from renku.core.models.dataset import Dataset
 
 
-@inject.autoparams()
-def get_dataset(name, datasets_provenance: DatasetsProvenance, strict=False, immutable=False) -> Optional[Dataset]:
+def get_dataset(name, strict=False, immutable=False) -> Optional[Dataset]:
     """Return a dataset based on its name."""
+    datasets_provenance = DatasetsProvenance()
     dataset = datasets_provenance.get_by_name(name, immutable=immutable)
 
     if not dataset and strict:

--- a/renku/core/management/dataset/tag.py
+++ b/renku/core/management/dataset/tag.py
@@ -21,13 +21,11 @@ import re
 from typing import List
 
 from renku.core import errors
-from renku.core.management.command_builder import inject
 from renku.core.management.dataset.datasets_provenance import DatasetsProvenance
 from renku.core.models.dataset import Dataset, DatasetTag
 
 
-@inject.autoparams()
-def add_dataset_tag(dataset: Dataset, tag: str, datasets_provenance: DatasetsProvenance, description="", force=False):
+def add_dataset_tag(dataset: Dataset, tag: str, description="", force=False):
     """Adds a new tag to a dataset.
 
     Validates if the tag already exists and that the tag follows the same rules as docker tags.
@@ -43,7 +41,7 @@ def add_dataset_tag(dataset: Dataset, tag: str, datasets_provenance: DatasetsPro
             f"Tag '{tag}' is invalid.\n"
             "Only characters a-z, A-Z, 0-9, ., - and _ are allowed.\nTag can't start with a . or -"
         )
-
+    datasets_provenance = DatasetsProvenance()
     tags = datasets_provenance.get_all_tags(dataset)
     existing_tag = next((t for t in tags if t.name == tag), None)
     if existing_tag:
@@ -56,9 +54,10 @@ def add_dataset_tag(dataset: Dataset, tag: str, datasets_provenance: DatasetsPro
     datasets_provenance.add_tag(dataset, new_tag)
 
 
-@inject.autoparams()
-def remove_dataset_tags(dataset: Dataset, tags: List[str], datasets_provenance: DatasetsProvenance):
+def remove_dataset_tags(dataset: Dataset, tags: List[str]):
     """Removes tags from a dataset."""
+    datasets_provenance = DatasetsProvenance()
+
     dataset_tags = datasets_provenance.get_all_tags(dataset)
     tag_names = {t.name for t in dataset_tags}
     not_found = set(tags).difference(tag_names)

--- a/renku/core/management/githooks.py
+++ b/renku/core/management/githooks.py
@@ -23,15 +23,17 @@ from pathlib import Path
 import pkg_resources
 from git.index.fun import hook_path as get_hook_path
 
-from renku.core.management import LocalClient
 from renku.core.management.command_builder.command import inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 
 HOOKS = ("pre-commit",)
 
 
 @inject.autoparams()
-def install(force, client: LocalClient):
+def install(force, client_dispatcher: IClientDispatcher):
     """Install Git hooks."""
+    client = client_dispatcher.current_client
+
     warning_messages = []
     for hook in HOOKS:
         hook_path = Path(get_hook_path(hook, client.repo.git_dir))
@@ -52,8 +54,10 @@ def install(force, client: LocalClient):
 
 
 @inject.autoparams()
-def uninstall(client: LocalClient):
+def uninstall(client_dispatcher: IClientDispatcher):
     """Uninstall Git hooks."""
+    client = client_dispatcher.current_client
+
     for hook in HOOKS:
         hook_path = Path(get_hook_path(hook, client.repo.git_dir))
         if hook_path.exists():

--- a/renku/core/management/interface/client_dispatcher.py
+++ b/renku/core/management/interface/client_dispatcher.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renku client dispatcher interface."""
+
+from abc import ABC
+
+
+class IClientDispatcher(ABC):
+    """Interface for the ClientDispatcher.
+
+    Handles getting current client (LocalClient) and entering/exiting the stack for the client.
+    """
+
+    @property
+    def current_client(self):
+        """Get the currently active client."""
+        raise NotImplementedError
+
+    def push_client_to_stack(self, path: str, renku_home: str, external_storage_requested: bool) -> None:
+        """Create and push a new client to the stack."""
+        raise NotImplementedError
+
+    def push_created_client_to_stack(self, client) -> None:
+        """Push an already created client to the stack."""
+        raise NotImplementedError
+
+    def pop_client(self) -> None:
+        """Remove the current client from the stack."""
+        raise NotImplementedError

--- a/renku/core/management/interface/database_dispatcher.py
+++ b/renku/core/management/interface/database_dispatcher.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renku database dispatcher interface."""
+
+from abc import ABC
+
+from renku.core.metadata.database import Database
+
+
+class IDatabaseDispatcher(ABC):
+    """Interface for the DatabaseDispatcher.
+
+    Handles getting current database (Database) and entering/exiting the stack for the database.
+    """
+
+    @property
+    def current_database(self) -> Database:
+        """Get the currently active database."""
+        raise NotImplementedError
+
+    def push_database_to_stack(self, path: str, commit: bool = False) -> None:
+        """Create and push a new database to the stack."""
+        raise NotImplementedError
+
+    def pop_database(self) -> None:
+        """Remove the current database from the stack."""
+        raise NotImplementedError
+
+    def finalize_dispatcher(self) -> None:
+        """Close all database contexts."""
+        raise NotImplementedError

--- a/renku/core/management/migrations/m_0003__1_jsonld.py
+++ b/renku/core/management/migrations/m_0003__1_jsonld.py
@@ -64,10 +64,10 @@ def _migrate_datasets_metadata(client):
         ],
     }
 
-    OLD_METADATA_PATHs = get_pre_0_3_4_datasets_metadata(client)
+    old_metadata_paths = get_pre_0_3_4_datasets_metadata(client)
     new_metadata_paths = client.renku_datasets_path.rglob(OLD_METADATA_PATH)
 
-    for path in itertools.chain(OLD_METADATA_PATHs, new_metadata_paths):
+    for path in itertools.chain(old_metadata_paths, new_metadata_paths):
         _apply_on_the_fly_jsonld_migrations(
             path=path,
             jsonld_context=_INITIAL_JSONLD_DATASET_CONTEXT,

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -35,7 +35,6 @@ from renku.core import errors
 from renku.core.compat import Path
 from renku.core.management.command_builder import inject
 from renku.core.management.config import RENKU_HOME
-from renku.core.management.interface.database_dispatcher import IDatabaseDispatcher
 from renku.core.management.interface.database_gateway import IDatabaseGateway
 from renku.core.management.interface.project_gateway import IProjectGateway
 from renku.core.models.enums import ConfigFilter

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -35,6 +35,7 @@ from renku.core import errors
 from renku.core.compat import Path
 from renku.core.management.command_builder import inject
 from renku.core.management.config import RENKU_HOME
+from renku.core.management.interface.database_dispatcher import IDatabaseDispatcher
 from renku.core.management.interface.database_gateway import IDatabaseGateway
 from renku.core.management.interface.project_gateway import IProjectGateway
 from renku.core.models.enums import ConfigFilter
@@ -363,7 +364,7 @@ class RepositoryApiMixin(GitCore):
     def workflow_names(self):
         """Return index of workflow names."""
         names = defaultdict(list)
-        for ref in LinkReference.iter_items(self, common_path="workflows"):
+        for ref in LinkReference.iter_items(common_path="workflows"):
             names[str(ref.reference.relative_to(self.path))].append(ref.name)
         return names
 

--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -33,8 +33,6 @@ import pathspec
 from werkzeug.utils import cached_property
 
 from renku.core import errors
-from renku.core.management.command_builder.command import inject
-from renku.core.metadata.database import Database
 from renku.core.models.entity import Entity
 from renku.core.models.provenance.activity import Collection
 from renku.core.utils import communication
@@ -472,8 +470,7 @@ class StorageApiMixin(RepositoryApiMixin):
 
         return groups
 
-    @inject.autoparams()
-    def migrate_files_to_lfs(self, paths, database: Database):
+    def migrate_files_to_lfs(self, paths):
         """Migrate files to Git LFS."""
         if not self.has_graph_files:
             raise errors.OperationError(

--- a/renku/core/management/workflow/converters/cwl.py
+++ b/renku/core/management/workflow/converters/cwl.py
@@ -473,18 +473,6 @@ class CWLExporter(IWorkflowConverter):
     def _sanitize_id(id):
         return re.sub(r"/|-", "_", id)
 
-    def _recurse_plans(workflow: Union[CompositePlan, Plan], index):
-        """Recursively get actual steps (not ``WorkflowRun``) for execution."""
-        if isinstance(workflow, Plan):
-            return [(index, workflow)], index + 1
-
-        workflows = []
-        for s in workflow.plans:
-            result, index = CWLExporter._recurse_plans(s, index)
-            workflows.extend(result)
-
-        return workflows, index
-
     @staticmethod
     def _convert_composite(
         workflow: CompositePlan, tmpdir: Path, basedir: Path, filename: Optional[Path], output_format: Optional[str]

--- a/renku/core/management/workflow/plan_factory.py
+++ b/renku/core/management/workflow/plan_factory.py
@@ -32,6 +32,7 @@ from git import Actor
 from renku.core import errors
 from renku.core.management.command_builder.command import inject
 from renku.core.management.config import RENKU_HOME
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.management.workflow.types import PATH_OBJECTS, Directory, File
 from renku.core.models.datastructures import DirectoryTree
 from renku.core.models.workflow.parameter import (
@@ -487,9 +488,10 @@ class PlanFactory:
             )
 
     @contextmanager
-    @inject.params(client="LocalClient")
-    def watch(self, client, no_output=False):
+    @inject.autoparams()
+    def watch(self, client_dispatcher: IClientDispatcher, no_output=False):
         """Watch a Renku repository for changes to detect outputs."""
+        client = client_dispatcher.current_client
         client.check_external_storage()
 
         repo = client.repo

--- a/renku/core/metadata/gateway/activity_gateway.py
+++ b/renku/core/metadata/gateway/activity_gateway.py
@@ -94,7 +94,7 @@ class ActivityGateway(IActivityGateway):
             if isinstance(generation.entity, Collection):
                 # NOTE: Get dependants that are in a generated directory
                 for path, activities in by_generation.items():
-                    parent = Path(usage.entity.path).resolve()
+                    parent = Path(generation.entity.path).resolve()
                     child = Path(path).resolve()
                     if parent == child or parent in child.parents:
                         downstreams.extend(activities)

--- a/renku/core/metadata/gateway/activity_gateway.py
+++ b/renku/core/metadata/gateway/activity_gateway.py
@@ -17,16 +17,17 @@
 # limitations under the License.
 """Renku activity database gateway implementation."""
 
+from pathlib import Path
 from typing import Dict, List, Set
 
 from persistent.list import PersistentList
-from zc.relation import RELATION
 
 from renku.core.management.command_builder.command import inject
 from renku.core.management.interface.activity_gateway import IActivityGateway
+from renku.core.management.interface.database_dispatcher import IDatabaseDispatcher
 from renku.core.management.interface.plan_gateway import IPlanGateway
-from renku.core.metadata.database import Database
-from renku.core.metadata.gateway.database_gateway import downstream_transitive_factory, upstream_transitive_factory
+from renku.core.metadata.gateway.database_gateway import ActivityDownstreamRelation
+from renku.core.models.entity import Collection
 from renku.core.models.provenance.activity import Activity, Usage
 from renku.core.models.workflow.plan import AbstractPlan
 
@@ -34,61 +35,83 @@ from renku.core.models.workflow.plan import AbstractPlan
 class ActivityGateway(IActivityGateway):
     """Gateway for activity database operations."""
 
-    database = inject.attr(Database)
+    database_dispatcher = inject.attr(IDatabaseDispatcher)
 
     def get_latest_activity_per_plan(self) -> Dict[AbstractPlan, Activity]:
         """Get latest activity for each plan."""
-        plan_activities = self.database["latest-activity-by-plan"].values()
+        plan_activities = self.database_dispatcher.current_database["latest-activity-by-plan"].values()
 
         return {a.association.plan: a for a in plan_activities}
 
     def get_plans_and_usages_for_latest_activities(self) -> Dict[AbstractPlan, List[Usage]]:
         """Get all usages associated with a plan by its latest activity."""
-        plan_activities = self.database["latest-activity-by-plan"].values()
+        plan_activities = self.database_dispatcher.current_database["latest-activity-by-plan"].values()
 
         return {a.association.plan: a.usages for a in plan_activities}
 
     def get_downstream_activities(self, activity: Activity) -> Set[Activity]:
         """Get downstream activities that depend on this activity."""
         # NOTE: since indices are populated one way when adding an activity, we need to query two indices
-        tok = self.database["activity-catalog"].tokenizeQuery
-        downstream = set(
-            self.database["activity-catalog"].findValues(
-                "downstream_activity", tok({RELATION: activity}), queryFactory=downstream_transitive_factory
-            )
-        )
+        database = self.database_dispatcher.current_database
 
-        downstream |= set(
-            self.database["activity-catalog"].findRelations(
-                tok({"upstream_activity": activity}), queryFactory=upstream_transitive_factory
-            )
-        )
+        tok = database["activity-catalog"].tokenizeQuery
+        downstream = set(database["activity-catalog"].findValues("downstream", tok(upstream=activity)))
 
         return downstream
 
     def add(self, activity: Activity):
         """Add an ``Activity`` to storage."""
-        self.database["activities"].add(activity)
+        database = self.database_dispatcher.current_database
 
-        by_usage = self.database["activities-by-usage"]
+        database["activities"].add(activity)
+
+        upstreams = []
+        downstreams = []
+
+        by_usage = database["activities-by-usage"]
+        by_generation = database["activities-by-generation"]
+
         for usage in activity.usages:
             if usage.entity.path not in by_usage:
                 by_usage[usage.entity.path] = PersistentList()
             by_usage[usage.entity.path].append(activity)
 
-        by_generation = self.database["activities-by-generation"]
+            if isinstance(usage.entity, Collection):
+                # NOTE: Get dependants that are in a generated directory
+                for path, activities in database["activities-by-generation"].items():
+                    parent = Path(usage.entity.path).resolve()
+                    child = Path(path).resolve()
+                    if parent == child or parent in child.parents:
+                        upstreams.extend(activities)
+            elif usage.entity.path in by_generation:
+                upstreams.extend(by_generation[usage.entity.path])
+
         for generation in activity.generations:
             if generation.entity.path not in by_generation:
                 by_generation[generation.entity.path] = PersistentList()
             by_generation[generation.entity.path].append(activity)
 
-        self.database["activity-catalog"].index(activity)
+            if isinstance(generation.entity, Collection):
+                # NOTE: Get dependants that are in a generated directory
+                for path, activities in by_generation.items():
+                    parent = Path(usage.entity.path).resolve()
+                    child = Path(path).resolve()
+                    if parent == child or parent in child.parents:
+                        downstreams.extend(activities)
+            elif generation.entity.path in by_usage:
+                downstreams.extend(by_usage[generation.entity.path])
+
+        if upstreams:
+            database["activity-catalog"].index(ActivityDownstreamRelation(downstream=[activity], upstream=upstreams))
+
+        if downstreams:
+            database["activity-catalog"].index(ActivityDownstreamRelation(downstream=downstreams, upstream=[activity]))
 
         plan_gateway = inject.instance(IPlanGateway)
 
         plan_gateway.add(activity.association.plan)
 
-        existing_activity = self.database["latest-activity-by-plan"].get(activity.association.plan.id)
+        existing_activity = database["latest-activity-by-plan"].get(activity.association.plan.id)
 
         if not existing_activity or existing_activity.ended_at_time < activity.ended_at_time:
-            self.database["latest-activity-by-plan"].add(activity)
+            database["latest-activity-by-plan"].add(activity)

--- a/renku/core/metadata/immutable.py
+++ b/renku/core/metadata/immutable.py
@@ -76,17 +76,16 @@ class Immutable(Slots):
     _local = threading.local()
 
     @classmethod
-    def make_instance(cls, **kwargs):
+    def make_instance(cls, instance):
         """Return a cached instance if available otherwise create an instance from the given parameters."""
         if getattr(cls._local, "cache", None) is None:
             cls._local.cache = weakref.WeakValueDictionary()
 
-        id = kwargs.get("id")
+        id = getattr(instance, "id", None)
         existing_instance = cls._local.cache.get(id)
         if existing_instance:
             return existing_instance
 
-        instance = cls(**kwargs)
         if id is not None:
             cls._local.cache[id] = instance
 

--- a/renku/core/models/provenance/activity.py
+++ b/renku/core/models/provenance/activity.py
@@ -24,6 +24,7 @@ from uuid import uuid4
 from marshmallow import EXCLUDE
 
 from renku.core.management.command_builder import inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.metadata.database import Persistent
 from renku.core.metadata.immutable import Immutable
 from renku.core.models.calamus import JsonLDSchema, Nested, fields, oa, prov, renku
@@ -124,11 +125,11 @@ class Activity(Persistent):
         # TODO: influenced = attr.ib(kw_only=True)
 
     @classmethod
-    @inject.params(client="LocalClient")
+    @inject.autoparams()
     def from_plan(
         cls,
         plan: Plan,
-        client,
+        client_dispatcher: IClientDispatcher,
         started_at_time: datetime,
         ended_at_time: datetime,
         annotations: List[Annotation],
@@ -137,6 +138,8 @@ class Activity(Persistent):
     ):
         """Convert a ``Plan`` to a ``Activity``."""
         from renku.core.models.provenance.agent import SoftwareAgent
+
+        client = client_dispatcher.current_client
 
         if not commit:
             commit = client.repo.head.commit

--- a/renku/core/models/refs.py
+++ b/renku/core/models/refs.py
@@ -25,6 +25,7 @@ import attr
 
 from renku.core import errors
 from renku.core.management.command_builder import inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 
 
 @attr.s(slots=True)
@@ -83,9 +84,11 @@ class LinkReference:
         os.symlink(os.path.relpath(str(reference_path), start=str(self.path.parent)), str(self.path))
 
     @classmethod
-    @inject.params(client="LocalClient")
-    def iter_items(cls, client, common_path=None):
+    @inject.autoparams()
+    def iter_items(cls, client_dispatcher: IClientDispatcher, common_path=None):
         """Find all references in the repository."""
+        client = client_dispatcher.current_client
+
         refs_path = path = client.renku_path / cls.REFS
         if common_path:
             path = path / common_path
@@ -96,9 +99,11 @@ class LinkReference:
             yield cls(client=client, name=str(name.relative_to(refs_path)))
 
     @classmethod
-    @inject.params(client="LocalClient")
-    def create(cls, client, name, force=False):
+    @inject.autoparams()
+    def create(cls, client_dispatcher: IClientDispatcher, name, force=False):
         """Create symlink to object in reference path."""
+        client = client_dispatcher.current_client
+
         ref = cls(client=client, name=name)
         path = ref.path
         if os.path.lexists(path):

--- a/renku/core/models/workflow/parameter.py
+++ b/renku/core/models/workflow/parameter.py
@@ -112,7 +112,7 @@ class CommandParameterBase:
     @property
     def actual_value(self):
         """Get the actual value to be used for execution."""
-        if self._v_actual_value_set:
+        if getattr(self, "_v_actual_value_set", False):
             return self._v_actual_value
 
         return self.default_value

--- a/renku/core/utils/urls.py
+++ b/renku/core/utils/urls.py
@@ -27,6 +27,7 @@ from yagup import GitURL
 
 from renku.core import errors
 from renku.core.management.command_builder.command import inject
+from renku.core.management.interface.client_dispatcher import IClientDispatcher
 
 
 def url_to_string(url):
@@ -64,13 +65,14 @@ def get_host(client):
     return os.environ.get("RENKU_DOMAIN") or host
 
 
-@inject.params(client="LocalClient")
-def parse_authentication_endpoint(endpoint, client, use_remote=False):
+@inject.autoparams()
+def parse_authentication_endpoint(endpoint, client_dispatcher: IClientDispatcher, use_remote=False):
     """Return a parsed url.
 
     If an endpoint is provided then use it, otherwise, look for a configured endpoint. If no configured endpoint exists
     then try to use project's remote url.
     """
+    client = client_dispatcher.current_client
     if not endpoint:
         endpoint = client.get_value(section="renku", key="endpoint")
         if not endpoint:

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -784,7 +784,7 @@ def test_export_dataset_unauthorized(
     result = runner.invoke(cli, ["dataset", "export", "my-dataset", provider] + params)
 
     assert 1 == result.exit_code, result.output + str(result.stderr_bytes)
-    assert "Access unauthorized - update access token." in result.output
+    assert "Access unauthorized - update access token." in result.output, format_result_exception(result)
 
     secret = client.get_value("zenodo", "secret")
     assert secret is None

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -513,7 +513,7 @@ def test_dataset_export_upload_file(
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
     with client_database_injection_manager(client):
-        with with_dataset(client, "my-dataset", commit_database=True) as dataset:
+        with with_dataset(client, name="my-dataset", commit_database=True) as dataset:
             dataset.description = "awesome dataset"
             dataset.creators[0].affiliation = "eth"
 
@@ -563,7 +563,7 @@ def test_dataset_export_upload_tag(
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
     with client_database_injection_manager(client):
-        with with_dataset(client, "my-dataset", commit_database=True) as dataset:
+        with with_dataset(client, name="my-dataset", commit_database=True) as dataset:
             dataset.description = "awesome dataset"
             dataset.creators[0].affiliation = "eth"
 
@@ -645,7 +645,7 @@ def test_dataset_export_upload_multiple(
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
     with client_database_injection_manager(client):
-        with with_dataset(client, "my-dataset", commit_database=True) as dataset:
+        with with_dataset(client, name="my-dataset", commit_database=True) as dataset:
             dataset.description = "awesome dataset"
             dataset.creators[0].affiliation = "eth"
 
@@ -704,7 +704,7 @@ def test_dataset_export_published_url(runner, tmpdir, client, zenodo_sandbox, da
     result = runner.invoke(cli, ["dataset", "add", "my-dataset", str(new_file)])
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
-    with with_dataset(client, "my-dataset", commit_database=True) as dataset:
+    with with_dataset(client, name="my-dataset", commit_database=True) as dataset:
         dataset.description = "awesome dataset"
         dataset.creators[0].affiliation = "eth"
 
@@ -1031,7 +1031,7 @@ def test_dataset_update_dataverse(client, runner, doi, load_dataset_with_injecti
     assert 0 == runner.invoke(cli, ["dataset", "rm-tags", "imported_dataset", "2.2"], catch_exceptions=False).exit_code
 
     with client_database_injection_manager(client):
-        with with_dataset(client, "imported_dataset", commit_database=True) as dataset:
+        with with_dataset(client, name="imported_dataset", commit_database=True) as dataset:
             dataset.version = "0.1"
 
     client.repo.git.add(all=True)
@@ -1060,7 +1060,7 @@ def test_dataset_update_renku(client, runner, load_dataset_with_injection, clien
     assert 0 == runner.invoke(cli, ["dataset", "import", "--name", "remote-dataset", uri], input="y").exit_code
 
     with client_database_injection_manager(client):
-        with with_dataset(client, "remote-dataset", commit_database=True) as dataset:
+        with with_dataset(client, name="remote-dataset", commit_database=True) as dataset:
             # NOTE: To mock an update we schema:sameAs to a dataset that has an update
             update_uri = "https://dev.renku.ch/datasets/04b463b0-1b51-4833-b236-186a941f6259"
             dataset.same_as = Url(url_id=update_uri)

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -504,6 +504,9 @@ def test_status_consistency(client, project):
     os.chdir("somedirectory")
     comp_result = runner.invoke(cli, ["status"])
 
+    assert 1 == base_result.exit_code, format_result_exception(base_result)
+    assert 1 == comp_result.exit_code, format_result_exception(comp_result)
+
     base_result_stdout = "\n".join(base_result.stdout.split("\n"))
     comp_result_stdout = "\n".join(comp_result.output.split("\n"))
     assert base_result_stdout.replace("somedirectory/", "") == comp_result_stdout

--- a/tests/core/commands/test_init.py
+++ b/tests/core/commands/test_init.py
@@ -223,7 +223,7 @@ def test_update_from_template(local_client, template_update, client_database_inj
         p.write_text(f"{p.read_text()}\nmodified")
 
     with client_database_injection_manager(local_client):
-        migrate(local_client, skip_docker_update=True)
+        migrate(skip_docker_update=True)
 
     for p in project_files:
         if p.is_dir():
@@ -258,7 +258,7 @@ def test_update_from_template_with_modified_files(local_client, template_update,
     deleted_file.unlink()
 
     with client_database_injection_manager(local_client):
-        migrate(local_client, skip_docker_update=True)
+        migrate(skip_docker_update=True)
 
     for p in project_files:
         if p.is_dir():
@@ -299,7 +299,7 @@ def test_update_from_template_with_immutable_modified_files(
     with pytest.raises(
         errors.TemplateUpdateError, match=r"Can't update template as immutable template file .* has local changes."
     ), client_database_injection_manager(local_client):
-        migrate(local_client)
+        migrate()
 
 
 def test_update_from_template_with_immutable_deleted_files(
@@ -324,7 +324,7 @@ def test_update_from_template_with_immutable_deleted_files(
     with pytest.raises(
         errors.TemplateUpdateError, match=r"Can't update template as immutable template file .* has local changes."
     ), client_database_injection_manager(local_client):
-        migrate(local_client)
+        migrate()
 
 
 def test_update_template_dockerfile(local_client, monkeypatch, template_update, client_database_injection_manager):
@@ -336,7 +336,7 @@ def test_update_template_dockerfile(local_client, monkeypatch, template_update, 
     monkeypatch.setattr("renku.__version__", "0.0.2")
 
     with client_database_injection_manager(local_client):
-        migrate(local_client)
+        migrate()
 
     dockerfile = (local_client.path / "Dockerfile").read_text()
     assert "0.0.2" in dockerfile
@@ -366,4 +366,4 @@ def test_update_from_template_with_new_variable(
     with pytest.raises(
         errors.TemplateUpdateError, match=r".*Can't update template, it now requires variable.*"
     ), client_database_injection_manager(local_client):
-        migrate(local_client)
+        migrate()

--- a/tests/core/fixtures/core_datasets.py
+++ b/tests/core/fixtures/core_datasets.py
@@ -61,7 +61,7 @@ def client_with_datasets(client, directory_tree, client_database_injection_manag
     with client_database_injection_manager(client):
         client.create_dataset(name="dataset-1", keywords=["dataset", "1"], creators=[person_1])
 
-        with client.with_dataset("dataset-2", create=True, commit_database=True) as dataset:
+        with client.with_dataset(name="dataset-2", create=True, commit_database=True) as dataset:
             dataset.keywords = ["dataset", "2"]
             dataset.creators = [person_1, person_2]
 
@@ -92,9 +92,9 @@ def get_datasets_provenance_with_injection(client_database_injection_manager):
 
     @contextmanager
     def _inner(client):
-        from tests.utils import get_datasets_provenance
+        from renku.core.management.datasets import DatasetsProvenance
 
         with client_database_injection_manager(client):
-            yield get_datasets_provenance(client)
+            yield DatasetsProvenance()
 
     return _inner

--- a/tests/core/management/test_dispatchers.py
+++ b/tests/core/management/test_dispatchers.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019-2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dispatcher tests."""
+from pathlib import Path
+
+import pytest
+
+from renku.core import errors
+from renku.core.management import LocalClient
+from renku.core.management.command_builder.client_dispatcher import ClientDispatcher
+from renku.core.management.command_builder.database_dispatcher import DatabaseDispatcher
+
+
+def test_client_dispatcher(tmpdir):
+    """Test getting correct current client."""
+    test_dir = tmpdir.mkdir("test")
+    other_test_dir = tmpdir.mkdir("other_test")
+
+    dispatcher = ClientDispatcher()
+
+    with pytest.raises(errors.ConfigurationError):
+        dispatcher.current_client
+
+    dispatcher.push_client_to_stack(Path(tmpdir))
+
+    assert dispatcher.current_client.path == Path(tmpdir).resolve()
+
+    dispatcher.push_client_to_stack(str(Path(test_dir)))
+
+    assert dispatcher.current_client.path == Path(test_dir).resolve()
+
+    dispatcher.push_created_client_to_stack(LocalClient(Path(other_test_dir)))
+
+    assert dispatcher.current_client.path == Path(other_test_dir).resolve()
+
+    dispatcher.pop_client()
+
+    assert dispatcher.current_client.path == Path(test_dir).resolve()
+
+    dispatcher.pop_client()
+
+    assert dispatcher.current_client.path == Path(tmpdir).resolve()
+
+    dispatcher.pop_client()
+
+    with pytest.raises(errors.ConfigurationError):
+        dispatcher.current_client
+
+
+def test_database_dispatcher(tmpdir):
+    """Test getting correct database."""
+
+    test_dir = tmpdir.mkdir("test")
+    other_test_dir = tmpdir.mkdir("other_test")
+
+    dispatcher = DatabaseDispatcher()
+
+    with pytest.raises(errors.ConfigurationError):
+        dispatcher.current_database
+
+    dispatcher.push_database_to_stack(Path(tmpdir))
+
+    assert dispatcher.current_database._storage.path == Path(tmpdir).resolve()
+
+    dispatcher.push_database_to_stack(str(Path(test_dir)))
+
+    assert dispatcher.current_database._storage.path == Path(test_dir).resolve()
+
+    dispatcher.push_database_to_stack(Path(other_test_dir), commit=True)
+
+    assert dispatcher.current_database._storage.path == Path(other_test_dir).resolve()
+
+    dispatcher.pop_database()
+
+    # NOTE: Make sure the database was committed on pop
+    assert (Path(other_test_dir) / "root").exists()
+
+    assert dispatcher.current_database._storage.path == Path(test_dir).resolve()
+
+    dispatcher.pop_database()
+
+    # NOTE: Make sure the database was not committed on pop
+    assert not (Path(test_dir) / "root").exists()
+
+    assert dispatcher.current_database._storage.path == Path(tmpdir).resolve()
+
+    dispatcher.pop_database()
+
+    # NOTE: Make sure the database was not committed on pop
+    assert not (Path(tmpdir) / "root").exists()
+
+    with pytest.raises(errors.ConfigurationError):
+        dispatcher.current_database

--- a/tests/core/metadata/test_activity_gateway.py
+++ b/tests/core/metadata/test_activity_gateway.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2021- Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test activity database gateways."""
+
+from datetime import datetime, timedelta
+
+from renku.core.metadata.gateway.activity_gateway import ActivityGateway
+from renku.core.models.entity import Entity
+from renku.core.models.provenance.activity import Activity, Association, Generation, Usage
+from renku.core.models.workflow.plan import Plan
+
+
+def test_activity_gateway_get_latest_activity(dummy_database_injection_manager):
+    """Test getting latest activity for a plan."""
+
+    plan = Plan(id=Plan.generate_id(), name="plan")
+    plan2 = Plan(id=Plan.generate_id(), name="plan2")
+
+    activity1_id = Activity.generate_id()
+    activity1 = Activity(
+        id=activity1_id,
+        ended_at_time=datetime.utcnow() - timedelta(hours=1),
+        association=Association(id=Association.generate_id(activity1_id), plan=plan),
+    )
+
+    activity2_id = Activity.generate_id()
+    activity2 = Activity(
+        id=activity2_id,
+        ended_at_time=datetime.utcnow(),
+        association=Association(id=Association.generate_id(activity2_id), plan=plan),
+    )
+
+    activity3_id = Activity.generate_id()
+    activity3 = Activity(
+        id=activity3_id,
+        ended_at_time=datetime.utcnow(),
+        association=Association(id=Association.generate_id(activity3_id), plan=plan2),
+    )
+
+    with dummy_database_injection_manager(None):
+        activity_gateway = ActivityGateway()
+
+        activity_gateway.add(activity1)
+
+        latest_activities = activity_gateway.get_latest_activity_per_plan()
+        assert len(latest_activities) == 1
+        assert {activity1_id} == {a.id for a in latest_activities.values()}
+        assert {plan.id} == {p.id for p in latest_activities.keys()}
+
+        activity_gateway.add(activity3)
+
+        latest_activities = activity_gateway.get_latest_activity_per_plan()
+        assert len(latest_activities) == 2
+        assert {activity1_id, activity3_id} == {a.id for a in latest_activities.values()}
+        assert {plan.id, plan2.id} == {p.id for p in latest_activities.keys()}
+
+        activity_gateway.add(activity2)
+
+        latest_activities = activity_gateway.get_latest_activity_per_plan()
+        assert len(latest_activities) == 2
+        assert {activity2_id, activity3_id} == {a.id for a in latest_activities.values()}
+        assert {plan.id, plan2.id} == {p.id for p in latest_activities.keys()}
+
+
+def test_activity_gateway_get_latest_plan_usages(dummy_database_injection_manager):
+    """Test getting latest activity for a plan."""
+
+    plan = Plan(id=Plan.generate_id(), name="plan")
+    plan2 = Plan(id=Plan.generate_id(), name="plan2")
+
+    activity1_id = Activity.generate_id()
+    activity1 = Activity(
+        id=activity1_id,
+        ended_at_time=datetime.utcnow() - timedelta(hours=1),
+        association=Association(id=Association.generate_id(activity1_id), plan=plan),
+        usages=[
+            Usage(
+                id=Usage.generate_id(activity1_id),
+                entity=Entity(id=Entity.generate_id("abcdefg", "in1"), checksum="abcdefg", path="in1"),
+            )
+        ],
+    )
+
+    activity2_id = Activity.generate_id()
+    activity2 = Activity(
+        id=activity2_id,
+        ended_at_time=datetime.utcnow(),
+        association=Association(id=Association.generate_id(activity2_id), plan=plan),
+        usages=[
+            Usage(
+                id=Usage.generate_id(activity2_id),
+                entity=Entity(id=Entity.generate_id("abcdefg", "in1"), checksum="abcdefg", path="in1"),
+            )
+        ],
+    )
+
+    activity3_id = Activity.generate_id()
+    activity3 = Activity(
+        id=activity3_id,
+        ended_at_time=datetime.utcnow(),
+        association=Association(id=Association.generate_id(activity3_id), plan=plan2),
+        usages=[
+            Usage(
+                id=Usage.generate_id(activity3_id),
+                entity=Entity(id=Entity.generate_id("abcdefg", "in2"), checksum="abcdefg", path="in2"),
+            )
+        ],
+    )
+
+    with dummy_database_injection_manager(None):
+        activity_gateway = ActivityGateway()
+
+        activity_gateway.add(activity1)
+        activity_gateway.add(activity2)
+        activity_gateway.add(activity3)
+
+        latest_usages = activity_gateway.get_plans_and_usages_for_latest_activities()
+
+        assert len(latest_usages) == 2
+        assert latest_usages[plan] == activity2.usages
+        assert latest_usages[plan2] == activity3.usages
+
+
+def test_activity_gateway_downstream_activities(dummy_database_injection_manager):
+    """test getting downstream activities works."""
+
+    plan = Plan(id=Plan.generate_id(), name="plan")
+
+    intermediate_id = Activity.generate_id()
+    intermediate = Activity(
+        id=intermediate_id,
+        ended_at_time=datetime.utcnow() - timedelta(hours=1),
+        association=Association(id=Association.generate_id(intermediate_id), plan=plan),
+        generations=[
+            Generation(
+                id=Generation.generate_id(intermediate_id),
+                entity=Entity(
+                    id=Entity.generate_id("abcdefg", "intermediate_out"), checksum="abcdefg", path="intermediate_out"
+                ),
+            )
+        ],
+        usages=[
+            Usage(
+                id=Usage.generate_id(intermediate_id),
+                entity=Entity(
+                    id=Entity.generate_id("abcdefg", "intermediate_in"), checksum="abcdefg", path="intermediate_in"
+                ),
+            )
+        ],
+    )
+
+    previous_id = Activity.generate_id()
+    previous = Activity(
+        id=previous_id,
+        ended_at_time=datetime.utcnow() - timedelta(hours=1),
+        association=Association(id=Association.generate_id(previous_id), plan=plan),
+        generations=[
+            Generation(
+                id=Generation.generate_id(previous_id),
+                entity=Entity(
+                    id=Entity.generate_id("abcdefg", "intermediate_in"), checksum="abcdefg", path="intermediate_in"
+                ),
+            )
+        ],
+    )
+
+    following_id = Activity.generate_id()
+    following = Activity(
+        id=following_id,
+        ended_at_time=datetime.utcnow() - timedelta(hours=1),
+        association=Association(id=Association.generate_id(following_id), plan=plan),
+        usages=[
+            Usage(
+                id=Usage.generate_id(following_id),
+                entity=Entity(
+                    id=Entity.generate_id("abcdefg", "intermediate_out"), checksum="abcdefg", path="intermediate_out"
+                ),
+            )
+        ],
+    )
+
+    unrelated_id = Activity.generate_id()
+    unrelated = Activity(
+        id=unrelated_id,
+        ended_at_time=datetime.utcnow() - timedelta(hours=1),
+        association=Association(id=Association.generate_id(unrelated_id), plan=plan),
+        generations=[
+            Generation(
+                id=Generation.generate_id(unrelated_id),
+                entity=Entity(
+                    id=Entity.generate_id("abcdefg", "unrelated_out"), checksum="abcdefg", path="unrelated_out"
+                ),
+            )
+        ],
+        usages=[
+            Usage(
+                id=Usage.generate_id(unrelated_id),
+                entity=Entity(
+                    id=Entity.generate_id("abcdefg", "unrelated_in"), checksum="abcdefg", path="unrelated_in"
+                ),
+            )
+        ],
+    )
+
+    with dummy_database_injection_manager(None):
+        activity_gateway = ActivityGateway()
+
+        activity_gateway.add(intermediate)
+        activity_gateway.add(following)
+        activity_gateway.add(previous)
+        activity_gateway.add(unrelated)
+
+        downstream = activity_gateway.get_downstream_activities(following)
+
+        assert not downstream
+
+        downstream = activity_gateway.get_downstream_activities(intermediate)
+        assert {following_id} == {a.id for a in downstream}
+
+        downstream = activity_gateway.get_downstream_activities(previous)
+        assert {following_id, intermediate_id} == {a.id for a in downstream}

--- a/tests/core/metadata/test_immutable.py
+++ b/tests/core/metadata/test_immutable.py
@@ -95,8 +95,8 @@ def test_immutable_objects_cache():
     """Test Immutable objects are cached once created."""
     data = {"id": 42, "c_member": 43}
 
-    o1 = C.make_instance(**data)
-    o2 = C.make_instance(**data)
+    o1 = C.make_instance(C(**data))
+    o2 = C.make_instance(C(**data))
 
     assert o1 is o2
 
@@ -105,7 +105,7 @@ def test_immutable_objects_cache_without_id():
     """Test Immutable objects cannot be cached if id is not set."""
     data = {"c_member": 43}
 
-    o1 = C.make_instance(**data)
-    o2 = C.make_instance(**data)
+    o1 = C.make_instance(C(**data))
+    o2 = C.make_instance(C(**data))
 
     assert o1 is not o2

--- a/tests/core/metadata/test_plan_gateway.py
+++ b/tests/core/metadata/test_plan_gateway.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2021- Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test plan database gateways."""
+
+from datetime import datetime
+
+from renku.core.metadata.gateway.plan_gateway import PlanGateway
+from renku.core.models.workflow.composite_plan import CompositePlan
+from renku.core.models.workflow.plan import Plan
+
+
+def test_plan_gateway_add_get(dummy_database_injection_manager):
+    """Test getting a plan by id."""
+
+    plan = Plan(id=Plan.generate_id(), name="plan")
+    composite_plan = CompositePlan(id=CompositePlan.generate_id(), name="composite-plan")
+
+    with dummy_database_injection_manager(None):
+        plan_gateway = PlanGateway()
+
+        plan_gateway.add(plan)
+        plan_gateway.add(composite_plan)
+
+        assert plan == plan_gateway.get_by_id(plan.id)
+        assert composite_plan == plan_gateway.get_by_id(composite_plan.id)
+
+        assert plan == plan_gateway.get_by_name("plan")
+        assert composite_plan == plan_gateway.get_by_name("composite-plan")
+
+        assert not plan_gateway.get_by_name(plan.id)
+        assert not plan_gateway.get_by_name(composite_plan.id)
+
+        assert not plan_gateway.get_by_id("plan")
+        assert not plan_gateway.get_by_id("composite-plan")
+
+
+def test_plan_gateway_newest_plans(dummy_database_injection_manager, database):
+    """Test getting newest plans."""
+    plan = Plan(id=Plan.generate_id(), name="plan")
+    plan2 = Plan(id=Plan.generate_id(), name="plan")
+    invalidated_plan = Plan(id=Plan.generate_id(), name="invalidated_plan", invalidated_at=datetime.utcnow())
+    invalidated_plan2 = Plan(id=Plan.generate_id(), name="invalidated_plan", invalidated_at=datetime.utcnow())
+
+    with dummy_database_injection_manager(None):
+        plan_gateway = PlanGateway()
+
+        plan_gateway.add(plan)
+        plan_gateway.add(plan2)
+        plan_gateway.add(invalidated_plan)
+        plan_gateway.add(invalidated_plan2)
+
+        newest_plans_by_names = {p.id for p in plan_gateway.get_newest_plans_by_names().values()}
+
+        assert {plan2.id} == newest_plans_by_names
+
+        newest_plans_by_names_with_invalidated = {
+            p.id for p in plan_gateway.get_newest_plans_by_names(with_invalidated=True).values()
+        }
+
+        assert {plan2.id, invalidated_plan2.id} == newest_plans_by_names_with_invalidated

--- a/tests/core/metadata/test_project_gateway.py
+++ b/tests/core/metadata/test_project_gateway.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2021- Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test project database gateways."""
+
+from datetime import datetime
+
+from renku.core.metadata.gateway.project_gateway import ProjectGateway
+from renku.core.models.project import Project
+from renku.core.models.provenance.agent import Person
+
+
+def test_project_gateway_update(dummy_database_injection_manager, monkeypatch):
+    """Test updating project metadata."""
+
+    project = Project(
+        id=Project.generate_id("namespace", "my_project"),
+        name="my_project",
+        creator=Person(
+            id=Person.generate_id("test@test.com", "Test tester"), email="test@test.com", name="Test tester"
+        ),
+        date_created=datetime.utcnow(),
+    )
+
+    with dummy_database_injection_manager(None):
+        project_gateway = ProjectGateway()
+
+        project_gateway.update_project(project)
+
+        stored_project = project_gateway.get_project()
+
+        assert stored_project.id == project.id
+        assert stored_project.agent_version
+        assert stored_project.name == "my_project"
+
+        monkeypatch.setattr("renku.__version__", "999.999.999")
+
+        stored_project.name = "new name"
+
+        project_gateway.update_project(project)
+
+        stored_project = project_gateway.get_project()
+
+        assert stored_project.id == project.id
+        assert stored_project.agent_version == "999.999.999"
+        assert stored_project.name == "new name"

--- a/tests/fixtures/repository.py
+++ b/tests/fixtures/repository.py
@@ -128,9 +128,12 @@ def client_injection_bindings():
     """Return bindings needed for client dependency injection."""
 
     def _create_client_bindings(client):
-        from renku.core.management import LocalClient
+        from renku.core.management.command_builder.client_dispatcher import ClientDispatcher
+        from renku.core.management.interface.client_dispatcher import IClientDispatcher
 
-        return {"bindings": {LocalClient: client, "LocalClient": client}, "constructor_bindings": {}}
+        client_dispatcher = ClientDispatcher()
+        client_dispatcher.push_created_client_to_stack(client)
+        return {"bindings": {"LocalClient": client, IClientDispatcher: client_dispatcher}, "constructor_bindings": {}}
 
     return _create_client_bindings
 
@@ -150,7 +153,7 @@ def injection_binder(request):
 
             return binder
 
-        inject.configure(_bind)
+        inject.configure(_bind, bind_in_runtime=False)
         request.addfinalizer(lambda: remove_injector())
         return
 

--- a/tests/service/views/test_cache_views.py
+++ b/tests/service/views/test_cache_views.py
@@ -786,7 +786,7 @@ def test_cache_gets_synchronized(
     assert response
     assert 200 == response.status_code
 
-    assert {"datasets"} == set(response.json["result"].keys())
+    assert {"datasets"} == set(response.json["result"].keys()), response.json
     assert 1 == len(response.json["result"]["datasets"])
 
     payload = {

--- a/tests/service/views/test_cache_views.py
+++ b/tests/service/views/test_cache_views.py
@@ -774,7 +774,7 @@ def test_cache_gets_synchronized(
 
     with client_database_injection_manager(client):
         with client.commit(commit_message="Create dataset"):
-            with client.with_dataset("my_dataset", create=True, commit_database=True) as dataset:
+            with client.with_dataset(name="my_dataset", create=True, commit_database=True) as dataset:
                 dataset.creators = [Person(name="me", email="me@example.com", id="me_id")]
 
     remote.push()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,7 +27,10 @@ from typing import Optional
 import pytest
 from flaky import flaky
 
+from renku.core.management.command_builder.command import inject, remove_injector
 from renku.core.management.dataset.datasets_provenance import DatasetsProvenance
+from renku.core.management.interface.database_dispatcher import IDatabaseDispatcher
+from renku.core.management.interface.dataset_gateway import IDatasetGateway
 from renku.core.models.dataset import Dataset
 
 
@@ -133,7 +136,14 @@ def load_dataset(name: str) -> Optional[Dataset]:
 
 
 @contextmanager
-def with_dataset(client, name=None, commit_database=False):
+@inject.autoparams("dataset_gateway", "database_dispatcher")
+def with_dataset(
+    client,
+    name: str = None,
+    dataset_gateway: IDatasetGateway = None,
+    database_dispatcher: IDatabaseDispatcher = None,
+    commit_database: bool = False,
+):
     """Yield an editable metadata object for a dataset."""
     dataset = client.get_dataset(name=name, strict=True, immutable=True)
     dataset._v_immutable = False
@@ -141,8 +151,8 @@ def with_dataset(client, name=None, commit_database=False):
     yield dataset
 
     if commit_database:
-        client.get_database().register(dataset)
-        client.get_database().commit()
+        dataset_gateway.add_or_remove(dataset)
+        database_dispatcher.current_database.commit()
 
 
 def retry_failed(fn=None, extended: bool = False):
@@ -170,8 +180,6 @@ def retry_failed(fn=None, extended: bool = False):
 @contextlib.contextmanager
 def injection_manager(bindings):
     """Context manager to temporarly do injections."""
-    from renku.core.management.command_builder.command import inject, remove_injector
-    from renku.core.management.interface.database_dispatcher import IDatabaseDispatcher
 
     def _bind(binder):
         for key, value in bindings["bindings"].items():
@@ -185,6 +193,8 @@ def injection_manager(bindings):
     try:
         yield
     finally:
-        if IDatabaseDispatcher in bindings["bindings"]:
-            bindings["bindings"][IDatabaseDispatcher].finalize_dispatcher()
-        remove_injector()
+        try:
+            if IDatabaseDispatcher in bindings["bindings"]:
+                bindings["bindings"][IDatabaseDispatcher].finalize_dispatcher()
+        finally:
+            remove_injector()


### PR DESCRIPTION
adds dispatchers with context for LocalClient and database
adds tests for gateways
adds method for dealing with circular references in nested objects
changes database to load object properties directly instead of calling the constructor

There's an issue left with keeping the relationship catalog up to date, to be addressed in https://github.com/SwissDataScienceCenter/renku-python/issues/2270

closes #2264 