### PR TITLE
test: make config write concurrency test deterministic

### DIFF
--- a/renku/core/management/config.py
+++ b/renku/core/management/config.py
@@ -120,11 +120,9 @@ class ConfigManagerMixin:
             with self.global_config_write_lock:
                 os.umask(0)
                 fd = os.open(filepath, os.O_CREAT | os.O_RDWR | os.O_TRUNC, 0o600)
-                with open(fd, "w+") as file:
-                    config.write(file)
+                self._write_config(fd, config)
         else:
-            with open(filepath, "w+") as file:
-                config.write(file)
+            self._write_config(filepath, config)
 
     def get_config(self, config_filter=ConfigFilter.ALL, as_string=True):
         """Read all configurations."""
@@ -188,6 +186,10 @@ class ConfigManagerMixin:
         if value is not None:
             self.store_config(config, global_only=global_only)
         return value
+
+    def _write_config(self, filepath, config):
+        with open(filepath, "w+") as file:
+            config.write(file)
 
     def _check_config_is_not_readonly(self, section, key):
         from renku.core import errors


### PR DESCRIPTION
The `test_config_write_concurrency` test used to fail often because the operation to test was very quick and trying to start many at the same time wasn't always enough.

The new test now monkey patches the write operation to introduce a slowdown, making the result deterministic.

P.S. I tried another solution using [site](https://docs.python.org/3/library/site.html) but I couldn't get a working test in a reasonable amount of time. Also, that solution was going to be more complicated and harder to debug should the test fail in the future due to some code change.
