### PR TITLE
feat(core): show status for specific paths

### DIFF
--- a/renku/cli/status.py
+++ b/renku/cli/status.py
@@ -67,7 +67,7 @@ def status(ctx, paths):
             f"Outdated outputs({len(stales)}):\n"
             # TODO: Enable once renku workflow visualize is implemented
             # "  (use `renku workflow visualize [<file>...]` to see the full lineage)\n"
-            "  (use `renku update [<file>...]` to generate the file from its latest inputs)\n"
+            "  (use `renku update --all` to generate the file from its latest inputs)\n"
         )
         for k, v in stales.items():
             paths = click.style(", ".join(sorted(v)), fg="blue", bold=True)

--- a/renku/core/management/migrations/m_0009__new_metadata_storage.py
+++ b/renku/core/management/migrations/m_0009__new_metadata_storage.py
@@ -304,7 +304,7 @@ def _process_workflows(client: LocalClient, activity_gateway: IActivityGateway, 
                 pass
 
 
-@inject.autoparams()
+@inject.autoparams("client_dispatcher")
 def _process_run_to_new_activity(process_run: old_schema.ProcessRun, client_dispatcher: IClientDispatcher) -> Activity:
     """Convert a ProcessRun to a new Activity."""
     assert not isinstance(process_run, old_schema.WorkflowRun)

--- a/renku/core/metadata/database.py
+++ b/renku/core/metadata/database.py
@@ -32,6 +32,7 @@ from persistent import GHOST, UPTODATE
 from persistent.interfaces import IPickleCache
 from ZODB.utils import z64
 from zope.interface import implementer
+from zope.interface.interface import InterfaceClass
 
 from renku.core import errors
 from renku.core.metadata.immutable import Immutable
@@ -633,6 +634,10 @@ class ObjectWriter:
             value = object.isoformat()
         elif isinstance(object, tuple):
             value = tuple(self._serialize_helper(value) for value in object)
+        elif isinstance(object, (InterfaceClass)):
+            # NOTE: Zope interfaces are weird, they're a class with type InterfaceClass, but need to be deserialized
+            # as the class (without instantiation)
+            return {"@type": TYPE_TYPE, "@value": f"{object.__module__}.{object.__name__}"}
         elif isinstance(object, type):
             # NOTE: We're storing a type, not an instance
             return {"@type": TYPE_TYPE, "@value": get_type_name(object)}

--- a/renku/core/metadata/gateway/database_gateway.py
+++ b/renku/core/metadata/gateway/database_gateway.py
@@ -88,10 +88,6 @@ def load_downstream_relations(token, catalog, cache, database_dispatcher: IDatab
     return btree[token]
 
 
-# NOTE: Transitive query factory is needed for transitive (follow more than 1 edge) queries
-downstream_transitive_factory = TransposingTransitive("downstream", "upstream")
-
-
 class DatabaseGateway(IDatabaseGateway):
     """Gateway for base database operations."""
 
@@ -100,6 +96,9 @@ class DatabaseGateway(IDatabaseGateway):
     def initialize(self) -> None:
         """Initialize the database."""
         database = self.database_dispatcher.current_database
+
+        # NOTE: Transitive query factory is needed for transitive (follow more than 1 edge) queries
+        downstream_transitive_factory = TransposingTransitive("downstream", "upstream")
 
         database.clear()
 

--- a/renku/core/utils/os.py
+++ b/renku/core/utils/os.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OS utility functions."""
+
+import os
+from pathlib import Path
+from typing import List, Union
+
+from renku.core import errors
+
+
+def get_relative_path_to_cwd(path: Union[Path, str]) -> str:
+    """Get a relative path to current working directory."""
+    absolute_path = os.path.abspath(path)
+    return os.path.relpath(absolute_path, os.getcwd())
+
+
+def get_relative_paths(base: Union[Path, str], paths: List[Union[Path, str]]) -> List[str]:
+    """Return a list of paths relative to a base path."""
+    relative_paths = []
+
+    for path in paths:
+        try:
+            # NOTE: Do not use os.path.realpath or Path.resolve() because they resolve symlinks
+            absolute_path = os.path.abspath(os.path.join(base, path))
+            relative_path = Path(absolute_path).relative_to(base)
+        except ValueError:
+            raise errors.ParameterError(f"Path '{path}' is not within base path '{base}'")
+
+        relative_paths.append(str(relative_path))
+
+    return relative_paths

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2021 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test `status` command."""
+
+import os
+
+import pytest
+from git import Repo
+
+from renku.cli import cli
+from tests.utils import format_result_exception, write_and_commit_file
+
+
+def test_status(runner, project, subdirectory):
+    """Test status check."""
+    source = os.path.join(project, "source.txt")
+    output = os.path.join(project, "data", "output.txt")
+
+    repo = Repo(project)
+
+    write_and_commit_file(repo, source, "content")
+
+    assert 0 == runner.invoke(cli, ["run", "cp", source, output]).exit_code
+
+    result = runner.invoke(cli, ["status"])
+    assert 0 == result.exit_code, format_result_exception(result)
+
+    write_and_commit_file(repo, source, "new content")
+
+    result = runner.invoke(cli, ["status"])
+    assert 1 == result.exit_code
+    assert "Outdated outputs(1):" in result.output
+    assert f"{os.path.relpath(output)}: {os.path.relpath(source)}" in result.output
+    assert "Modified inputs(1):" in result.output
+    assert "Outdated activities that have no outputs" not in result.output
+
+
+@pytest.mark.xfail(reason="Fails because of a bug in Catalog de/serialization")
+def test_status_multiple_steps(runner, project):
+    """Test status check with multiple steps."""
+    source = os.path.join(os.getcwd(), "source.txt")
+    intermediate = os.path.join(os.getcwd(), "intermediate.txt")
+    output = os.path.join(os.getcwd(), "data", "output.txt")
+
+    repo = Repo(project)
+
+    write_and_commit_file(repo, source, "content")
+
+    assert 0 == runner.invoke(cli, ["run", "cp", source, intermediate]).exit_code
+    assert 0 == runner.invoke(cli, ["run", "cp", intermediate, output]).exit_code
+
+    write_and_commit_file(repo, source, "new content")
+
+    result = runner.invoke(cli, ["status"])
+    assert 1 == result.exit_code
+    assert "data/output.txt: source.txt" in result.output
+
+
+def test_workflow_without_outputs(runner, project):
+    """Test workflow without outputs."""
+    source = os.path.join(os.getcwd(), "source.txt")
+
+    repo = Repo(project)
+
+    write_and_commit_file(repo, source, "content")
+
+    result = runner.invoke(cli, ["run", "cat", "--no-output", source])
+    assert 0 == result.exit_code, format_result_exception(result)
+
+    write_and_commit_file(repo, source, "new content")
+
+    result = runner.invoke(cli, ["status"])
+    assert 1 == result.exit_code
+    assert "Modified inputs(1):" in result.output
+    assert "source.txt" in result.output
+    assert "Outdated activities that have no outputs(1)" in result.output
+    assert "/activities/" in result.output
+
+
+def test_status_with_paths(runner, project):
+    """Test status check with multiple steps."""
+    source1 = os.path.join(os.getcwd(), "source1.txt")
+    output1 = os.path.join(os.getcwd(), "data", "output1.txt")
+    source2 = os.path.join(os.getcwd(), "source2.txt")
+    output2 = os.path.join(os.getcwd(), "data", "output2.txt")
+
+    repo = Repo(project)
+
+    write_and_commit_file(repo, source1, "content")
+    write_and_commit_file(repo, source2, "content")
+
+    assert 0 == runner.invoke(cli, ["run", "cp", source1, output1]).exit_code
+    assert 0 == runner.invoke(cli, ["run", "cp", source2, output2]).exit_code
+
+    write_and_commit_file(repo, source1, "new content")
+    write_and_commit_file(repo, source2, "new content")
+
+    result = runner.invoke(cli, ["status", source1])
+    assert 1 == result.exit_code, format_result_exception(result)
+    assert "data/output1.txt: source1.txt" in result.output
+    assert "Modified inputs(1):" in result.output
+    assert "source2.txt" not in result.output
+
+    result = runner.invoke(cli, ["status", output1])
+    assert 1 == result.exit_code, format_result_exception(result)
+    assert "data/output1.txt: source1.txt" in result.output
+    assert "Modified inputs(1):" in result.output
+    assert "source2.txt" not in result.output
+
+    result = runner.invoke(cli, ["status", "source2.txt"])
+    assert 1 == result.exit_code, format_result_exception(result)
+    assert "data/output2.txt: source2.txt" in result.output
+    assert "Modified inputs(1):" in result.output
+    assert "source1.txt" not in result.output
+
+    result = runner.invoke(cli, ["status", "data/output2.txt"])
+    assert 1 == result.exit_code, format_result_exception(result)
+    assert "data/output2.txt: source2.txt" in result.output
+    assert "Modified inputs(1):" in result.output
+    assert "source1.txt" not in result.output
+
+    result = runner.invoke(cli, ["status", source1, output2])
+    assert 1 == result.exit_code, format_result_exception(result)
+    assert "data/output1.txt: source1.txt" in result.output
+    assert "data/output2.txt: source2.txt" in result.output
+    assert "Modified inputs(2):" in result.output

--- a/tests/core/fixtures/core_database.py
+++ b/tests/core/fixtures/core_database.py
@@ -22,6 +22,7 @@ import datetime
 from typing import Tuple
 
 import pytest
+from zc.relation.queryfactory import TransposingTransitive
 
 from renku.core import errors
 from renku.core.management.interface.database_dispatcher import IDatabaseDispatcher
@@ -95,7 +96,6 @@ def database() -> Tuple[Database, DummyStorage]:
 
     from renku.core.metadata.gateway.database_gateway import (
         IActivityDownstreamRelation,
-        downstream_transitive_factory,
         dump_activity,
         dump_downstream_relations,
         load_activity,
@@ -122,6 +122,7 @@ def database() -> Tuple[Database, DummyStorage]:
     activity_catalog.addValueIndex(
         IActivityDownstreamRelation["upstream"], dump_activity, load_activity, btree=BTrees.family32.OO, multiple=True
     )
+    downstream_transitive_factory = TransposingTransitive("downstream", "upstream")
     activity_catalog.addDefaultQueryFactory(downstream_transitive_factory)
     database.add_root_object(name="activity-catalog", obj=activity_catalog)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,10 +22,12 @@ import traceback
 import uuid
 from contextlib import contextmanager
 from functools import wraps
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 
 import pytest
 from flaky import flaky
+from git import Repo
 
 from renku.core.management.command_builder.command import inject, remove_injector
 from renku.core.management.dataset.datasets_provenance import DatasetsProvenance
@@ -198,3 +200,15 @@ def injection_manager(bindings):
                 bindings["bindings"][IDatabaseDispatcher].finalize_dispatcher()
         finally:
             remove_injector()
+
+
+def write_and_commit_file(repo: Repo, path: Union[Path, str], content: str):
+    """Write content to a given file and make a commit."""
+    filepath = Path(path)
+    path = str(path)
+
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_text(content)
+
+    repo.git.add(path)
+    repo.index.commit(f"Updated '{path}'")


### PR DESCRIPTION
# Description

Allows specifying files paths when calling `renku status` to limit the scope to only those paths. A path can be both input and output. If an outdated activity has no generation, we will show the activity id along with modified input(s).

Fixes #2260 
