### PR TITLE
fix(core): resolve the template folder path

### DIFF
--- a/renku/service/controllers/templates_read_manifest.py
+++ b/renku/service/controllers/templates_read_manifest.py
@@ -58,7 +58,9 @@ class TemplatesReadManifestCtrl(ServiceCtrl, RenkuOperationMixin):
                 continue
 
             # NOTE: prevent path traversal attack
-            icon_path = template_folder / ((template_folder / template["icon"]).resolve().relative_to(template_folder))
+            icon_path = template_folder / (
+                (template_folder / template["icon"]).resolve().relative_to(template_folder.resolve())
+            )
 
             icon = Image.open(icon_path)
             icon.thumbnail(MAX_ICON_SIZE)


### PR DESCRIPTION
# Description

on macOS the `/tmp` and `/var` are symlinks to `/private/tmp` and `/private/var`, which causes troubles when resolving relative paths. this is the reason why macos integration tests are actually failing.