### PR TITLE
chore: fix CI with pip 21.3

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-        python -m pip install -e .[all]
+        python -m pip install .[all]
     - name: Build Package
       run: python setup.py sdist bdist_wheel
     - name: test with twine
@@ -122,7 +122,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install coveralls setuptools wheel
-        python -m pip install -e .[nodocs]
+        python -m pip install .[nodocs]
         python setup.py --version
         git config --global --add user.name "Renku @ SDSC"
         git config --global --add user.email "renku@datascience.ch"
@@ -163,7 +163,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install coveralls setuptools wheel
-        python -m pip install -e .[nodocs]
+        python -m pip install .[nodocs]
         python setup.py --version
         git config --global --add user.name "Renku @ SDSC"
         git config --global --add user.email "renku@datascience.ch"
@@ -209,7 +209,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install coveralls setuptools wheel
-          python -m pip install -e .[nodocs]
+          python -m pip install .[nodocs]
           python setup.py --version
           git config --global --add user.name "Renku @ SDSC"
           git config --global --add user.email "renku@datascience.ch"
@@ -255,7 +255,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install coveralls setuptools wheel
-          python -m pip install -e .[nodocs]
+          python -m pip install .[nodocs]
           python setup.py --version
           git config --global --add user.name "Renku @ SDSC"
           git config --global --add user.email "renku@datascience.ch"
@@ -296,7 +296,7 @@ jobs:
         brew install shellcheck node || brew link --overwrite node
         python -m pip install --upgrade pip
         python -m pip install setuptools wheel twine
-        python -m pip install -e .[all]
+        python -m pip install .[all]
         git config --global --add user.name "Renku @ SDSC"
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
@@ -329,7 +329,7 @@ jobs:
         brew install shellcheck node || brew link --overwrite node
         python -m pip install --upgrade pip
         python -m pip install setuptools wheel twine
-        python -m pip install -e .[all]
+        python -m pip install .[all]
         git config --global --add user.name "Renku @ SDSC"
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
@@ -368,7 +368,7 @@ jobs:
           brew install shellcheck node || brew link --overwrite node
           python -m pip install --upgrade pip
           python -m pip install setuptools wheel twine
-          python -m pip install -e .[all]
+          python -m pip install .[all]
           git config --global --add user.name "Renku @ SDSC"
           git config --global --add user.email "renku@datascience.ch"
       - name: Test with pytest
@@ -407,7 +407,7 @@ jobs:
           brew install shellcheck node || brew link --overwrite node
           python -m pip install --upgrade pip
           python -m pip install setuptools wheel twine
-          python -m pip install -e .[all]
+          python -m pip install .[all]
           git config --global --add user.name "Renku @ SDSC"
           git config --global --add user.email "renku@datascience.ch"
       - name: Test with pytest
@@ -440,7 +440,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install coveralls setuptools wheel
-        python -m pip install -e .[nodocs]
+        python -m pip install .[nodocs]
         git config --global --add user.name "Renku @ SDSC"
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
@@ -496,7 +496,7 @@ jobs:
         brew install shellcheck node || brew link --overwrite node
         python -m pip install --upgrade pip
         python -m pip install setuptools wheel
-        python -m pip install -e .[all]
+        python -m pip install .[all]
         git config --global --add user.name "Renku @ SDSC"
         git config --global --add user.email "renku@datascience.ch"
     - name: Test with pytest
@@ -536,7 +536,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-        python -m pip install -e .[all]
+        python -m pip install .[all]
         git config --global --add user.name "Renku @ SDSC"
         git config --global --add user.email "renku@datascience.ch"
     - name: Tag if necessary


### PR DESCRIPTION
Pip 21.3 broke installing renku in editable mode. Until https://github.com/pypa/pip/issues/10573 is fixed, don't use editable mode in tests.