### PR TITLE
fix(core): add missing Subject to dataverse export

### DIFF
--- a/renku/core/commands/providers/dataverse.py
+++ b/renku/core/commands/providers/dataverse.py
@@ -44,6 +44,7 @@ from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.metadata.immutable import DynamicProxy
 from renku.core.models.dataset import DatasetFile
 from renku.core.models.provenance.agent import PersonSchema
+from renku.core.utils import communication
 from renku.core.utils.doi import extract_doi, is_doi
 from renku.core.utils.file_size import bytes_to_unit
 from renku.core.utils.git import get_content
@@ -56,6 +57,24 @@ DATAVERSE_METADATA_API = "datasets/export"
 DATAVERSE_VERSIONS_API = "datasets/:persistentId/versions"
 DATAVERSE_FILE_API = "access/datafile/:persistentId/"
 DATAVERSE_EXPORTER = "schema.org"
+
+
+DATAVERSE_SUBJECTS = [
+    "Agricultural Sciences",
+    "Arts and Humanities",
+    "Astronomy and Astrophysics",
+    "Business and Management",
+    "Chemistry",
+    "Computer and Information Science",
+    "Earth and Environmental Sciences",
+    "Engineering",
+    "Law",
+    "Mathematical Sciences",
+    "Medicine, Health and Life Sciences",
+    "Physics",
+    "Social Sciences",
+    "Other",
+]
 
 
 class _DataverseDatasetSchema(ProviderDatasetSchema):
@@ -438,14 +457,25 @@ class DataverseExporter(ExporterApi):
 
     def _get_dataset_metadata(self):
         authors, contacts = self._get_creators()
+        subject = self._get_subject()
         metadata_template = Template(DATASET_METADATA_TEMPLATE)
         metadata = metadata_template.substitute(
             name=_escape_json_string(self.dataset.title),
             authors=json.dumps(authors),
             contacts=json.dumps(contacts),
             description=_escape_json_string(self.dataset.description),
+            subject=subject,
         )
         return json.loads(metadata)
+
+    def _get_subject(self):
+        text_prompt = "Subject of this dataset: \n\n"
+        text_prompt += "\n".join(f"{s}\t[{i}]" for i, s in enumerate(DATAVERSE_SUBJECTS, start=1))
+        text_prompt += "\n\nSubject"
+
+        selection = communication.prompt(text_prompt, type=int, default=len(DATAVERSE_SUBJECTS)) or 0
+
+        return DATAVERSE_SUBJECTS[selection - 1]
 
     def _get_creators(self):
         authors = []

--- a/renku/core/commands/providers/dataverse_metadata_templates.py
+++ b/renku/core/commands/providers/dataverse_metadata_templates.py
@@ -56,7 +56,7 @@ DATASET_METADATA_TEMPLATE = """
                         "typeName": "dsDescription"
                     },
                     {
-                        "value": [],
+                        "value": ["${subject}"],
                         "typeClass": "controlledVocabulary",
                         "multiple": true,
                         "typeName": "subject"

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -480,11 +480,11 @@ def test_renku_dataset_import_missing_lfs_objects(runner, project):
 @pytest.mark.integration
 @retry_failed
 @pytest.mark.parametrize(
-    "provider,params,output",
+    "provider,params,output,input",
     [
-        ("zenodo", [], "zenodo.org/deposit"),
-        ("dataverse", ["--dataverse-name", "sdsc-test-dataverse"], "doi:"),
-        ("olos", ["--dlcm-server", "https://sandbox.dlcm.ch/"], "sandbox.dlcm.ch/ingestion/preingest/deposits/"),
+        ("zenodo", [], "zenodo.org/deposit", None),
+        ("dataverse", ["--dataverse-name", "sdsc-test-dataverse"], "doi:", "1"),
+        ("olos", ["--dlcm-server", "https://sandbox.dlcm.ch/"], "sandbox.dlcm.ch/ingestion/preingest/deposits/", None),
     ],
 )
 def test_dataset_export_upload_file(
@@ -497,6 +497,7 @@ def test_dataset_export_upload_file(
     provider,
     params,
     output,
+    input,
     client_database_injection_manager,
 ):
     """Test successful uploading of a file to Zenodo/Dataverse deposit."""
@@ -521,7 +522,9 @@ def test_dataset_export_upload_file(
     client.repo.git.add(all=True)
     client.repo.index.commit("metadata updated")
 
-    result = runner.invoke(cli, ["dataset", "export", "my-dataset", provider] + params, catch_exceptions=False)
+    result = runner.invoke(
+        cli, ["dataset", "export", "my-dataset", provider] + params, input=input, catch_exceptions=False
+    )
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
     assert "Exported to:" in result.output
@@ -531,11 +534,11 @@ def test_dataset_export_upload_file(
 @pytest.mark.integration
 @retry_failed
 @pytest.mark.parametrize(
-    "provider,params,output",
+    "provider,params,output,input",
     [
-        ("zenodo", [], "zenodo.org/deposit"),
-        ("dataverse", ["--dataverse-name", "sdsc-test-dataverse"], "doi:"),
-        ("olos", ["--dlcm-server", "https://sandbox.dlcm.ch/"], "sandbox.dlcm.ch/ingestion/preingest/deposits/"),
+        ("zenodo", [], "zenodo.org/deposit", None),
+        ("dataverse", ["--dataverse-name", "sdsc-test-dataverse"], "doi:", "1"),
+        ("olos", ["--dlcm-server", "https://sandbox.dlcm.ch/"], "sandbox.dlcm.ch/ingestion/preingest/deposits/", None),
     ],
 )
 def test_dataset_export_upload_tag(
@@ -548,6 +551,7 @@ def test_dataset_export_upload_tag(
     provider,
     params,
     output,
+    input,
     client_database_injection_manager,
 ):
     """Test successful uploading of a file to Zenodo/Dataverse deposit."""
@@ -587,19 +591,19 @@ def test_dataset_export_upload_tag(
     result = runner.invoke(cli, ["dataset", "tag", "my-dataset", "2.0"])
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
-    result = runner.invoke(cli, ["dataset", "export", "my-dataset", provider, "-t", "2.0"] + params)
+    result = runner.invoke(cli, ["dataset", "export", "my-dataset", provider, "-t", "2.0"] + params, input=input)
 
     assert 0 == result.exit_code, format_result_exception(result)
     assert "Exported to:" in result.output
     assert output in result.output
 
-    result = runner.invoke(cli, ["dataset", "export", "my-dataset", provider, "-t", "1.0"] + params)
+    result = runner.invoke(cli, ["dataset", "export", "my-dataset", provider, "-t", "1.0"] + params, input=input)
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
     assert "Exported to:" in result.output
     assert output in result.output
 
-    result = runner.invoke(cli, ["dataset", "export", "my-dataset", provider] + params, input="0")  # HEAD
+    result = runner.invoke(cli, ["dataset", "export", "my-dataset", provider] + params, input=f"0\n{input}")  # HEAD
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
     assert "Exported to:" in result.output
@@ -609,11 +613,11 @@ def test_dataset_export_upload_tag(
 @pytest.mark.integration
 @retry_failed
 @pytest.mark.parametrize(
-    "provider,params,output",
+    "provider,params,output,input",
     [
-        ("zenodo", [], "zenodo.org/deposit"),
-        ("dataverse", ["--dataverse-name", "sdsc-test-dataverse"], "doi:"),
-        ("olos", ["--dlcm-server", "https://sandbox.dlcm.ch/"], "sandbox.dlcm.ch/ingestion/preingest/deposits/"),
+        ("zenodo", [], "zenodo.org/deposit", None),
+        ("dataverse", ["--dataverse-name", "sdsc-test-dataverse"], "doi:", "1"),
+        ("olos", ["--dlcm-server", "https://sandbox.dlcm.ch/"], "sandbox.dlcm.ch/ingestion/preingest/deposits/", None),
     ],
 )
 def test_dataset_export_upload_multiple(
@@ -626,6 +630,7 @@ def test_dataset_export_upload_multiple(
     provider,
     params,
     output,
+    input,
     client_database_injection_manager,
 ):
     """Test successful uploading of a files to Zenodo deposit."""
@@ -653,7 +658,7 @@ def test_dataset_export_upload_multiple(
     client.repo.git.add(all=True)
     client.repo.index.commit("metadata updated")
 
-    result = runner.invoke(cli, ["dataset", "export", "my-dataset", provider] + params)
+    result = runner.invoke(cli, ["dataset", "export", "my-dataset", provider] + params, input=input)
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
     assert "Exported to:" in result.output


### PR DESCRIPTION
"Subject" is now required in Dataverse exports. This prompts the user on export, defaults to `Other`