### PR TITLE
fix(cli): fixes importlib.metadata usage in Python 3.8

### DIFF
--- a/renku/cli/__init__.py
+++ b/renku/cli/__init__.py
@@ -103,6 +103,18 @@ try:
 except ImportError:
     from importlib_metadata import entry_points
 
+
+def get_entry_points(name: str):
+    """Get entry points from importlib."""
+    all_entry_points = entry_points()
+
+    if hasattr(all_entry_points, "select"):
+        return all_entry_points.select(group=name)
+    else:
+        # Prior to Python 3.10, this returns a dict instead of the selection interface, which is slightly slower
+        return all_entry_points.get(name, [])
+
+
 #: Monkeypatch Click application.
 click_completion.init()
 
@@ -132,7 +144,7 @@ def is_allowed_command(ctx):
     return ctx.invoked_subcommand in WARNING_UNPROTECTED_COMMANDS or "-h" in sys.argv or "--help" in sys.argv
 
 
-@with_plugins(entry_points(group="renku.cli_plugins"))
+@with_plugins(get_entry_points("renku.cli_plugins"))
 @click.group(
     cls=IssueFromTraceback, context_settings={"auto_envvar_prefix": "RENKU", "help_option_names": ["-h", "--help"]}
 )


### PR DESCRIPTION
Importlib was changed in Python 3.10 to take a "group" argument in Python 3.10 and backported to 3.7, but this is not available in 3.8 and 3.9, where the `entry_points()` method just returns a dict instead of a SelectableGroup object.

This fixes that (SelectableGroup inherits from dict so we can't just `isinstance(x, dict)` but instead use `hasattr`)