### PR TITLE
feat(cli): add 'command' column to 'renku workflow ls'

### DIFF
--- a/renku/cli/workflow.py
+++ b/renku/cli/workflow.py
@@ -506,7 +506,7 @@ def workflow():
     "-c",
     "--columns",
     type=click.STRING,
-    default="id,name",
+    default="id,name,command",
     metavar="<columns>",
     help="Comma-separated list of column to display: {}.".format(", ".join(WORKFLOW_COLUMNS.keys())),
     show_default=True,

--- a/renku/core/commands/format/workflow.py
+++ b/renku/core/commands/format/workflow.py
@@ -67,4 +67,5 @@ WORKFLOW_COLUMNS = {
     "name": ("name", None),
     "keywords": ("keywords_csv", "keywords"),
     "description": ("short_description", "description"),
+    "command": ("full_command", "command"),
 }

--- a/renku/core/commands/view_model/composite_plan.py
+++ b/renku/core/commands/view_model/composite_plan.py
@@ -82,6 +82,7 @@ class CompositePlanViewModel:
         self.mappings = mappings
         self.links = links
         self.steps = steps
+        self.full_command = ""
 
     @classmethod
     def from_composite_plan(cls, plan: CompositePlan):

--- a/renku/core/commands/view_model/plan.py
+++ b/renku/core/commands/view_model/plan.py
@@ -119,32 +119,6 @@ class CommandParameterViewModel:
         )
 
 
-def _get_full_command(plan: Plan):
-    """Get the full command for a Plan."""
-    argv = []
-
-    if plan.command:
-        argv.extend(plan.command.split(" "))
-
-    arguments = plan.inputs + plan.outputs + plan.parameters
-
-    arguments = filter(lambda x: x.position, arguments)
-    arguments = sorted(arguments, key=lambda x: x.position)
-    argv.extend(e for a in arguments for e in a.to_argv())
-
-    stream_repr = []
-
-    for input_ in plan.inputs:
-        if input_.mapped_to:
-            stream_repr.append(input_.to_stream_representation())
-
-    for output in plan.outputs:
-        if output.mapped_to:
-            stream_repr.append(output.to_stream_representation())
-
-    return " ".join(argv) + " ".join(stream_repr)
-
-
 class PlanViewModel:
     """A view model for a ``Plan``."""
 
@@ -175,7 +149,7 @@ class PlanViewModel:
             id=plan.id,
             name=plan.name,
             description=plan.description,
-            full_command=_get_full_command(plan),
+            full_command=" ".join(plan.to_argv(with_streams=True)),
             success_codes=", ".join(str(c) for c in plan.success_codes),
             inputs=[CommandInputViewModel.from_input(input) for input in plan.inputs],
             outputs=[CommandOutputViewModel.from_output(output) for output in plan.outputs],

--- a/renku/core/models/workflow/plan.py
+++ b/renku/core/models/workflow/plan.py
@@ -326,8 +326,8 @@ class PlanDetailsJson(marshmallow.Schema):
     """Serialize a plan to a response object."""
 
     name = marshmallow.fields.String(required=True)
+    full_command = marshmallow.fields.String(data_key="command")
     derived_from = marshmallow.fields.String()
-    title = marshmallow.fields.String()
     description = marshmallow.fields.String()
     keywords = marshmallow.fields.List(marshmallow.fields.String())
     id = marshmallow.fields.String()

--- a/tests/cli/test_workflow.py
+++ b/tests/cli/test_workflow.py
@@ -35,6 +35,52 @@ from renku.core.plugins.provider import available_workflow_providers
 from tests.utils import format_result_exception
 
 
+def test_workflow_list(runner, project, run_shell, client):
+    """Test listing of workflows."""
+    # Run a shell command with pipe.
+    output = run_shell('renku run --name run1 --description desc1 -- echo "a" > output1')
+
+    # Assert expected empty stdout.
+    assert b"" == output[0]
+    # Assert not allocated stderr.
+    assert output[1] is None
+
+    # Run a shell command with pipe.
+    output = run_shell("renku run --name run2 --description desc2 -- cp output1 output2")
+
+    # Assert expected empty stdout.
+    assert b"" == output[0]
+    # Assert not allocated stderr.
+    assert output[1] is None
+
+    result = runner.invoke(cli, ["workflow", "ls"])
+    assert 0 == result.exit_code, format_result_exception(result)
+    assert "run1" in result.output
+    assert "run2" in result.output
+    assert "desc1" not in result.output
+    assert "desc2" not in result.output
+    assert "echo a > output1" in result.output
+    assert "cp output1 output2" in result.output
+
+    result = runner.invoke(cli, ["workflow", "ls", "-c", "id,description"])
+    assert 0 == result.exit_code, format_result_exception(result)
+    assert "run1" not in result.output
+    assert "run2" not in result.output
+    assert "desc1" in result.output
+    assert "desc2" in result.output
+    assert "echo a > output1" not in result.output
+    assert "cp output1 output2" not in result.output
+
+    result = runner.invoke(cli, ["workflow", "ls", "--format", "json"])
+    assert 0 == result.exit_code, format_result_exception(result)
+    assert "run1" in result.output
+    assert "run2" in result.output
+    assert "desc1" in result.output
+    assert "desc2" in result.output
+    assert "echo a > output1" in result.output
+    assert "cp output1 output2" in result.output
+
+
 def test_workflow_compose(runner, project, run_shell, client):
     """Test renku workflow compose."""
     # Run a shell command with pipe.


### PR DESCRIPTION
closes #2334 

Use like
```
$ renku workflow ls
ID                                       NAME             COMMAND
---------------------------------------  ---------------  -------------
/plans/11a3702184394b93ac422df760e40999  cp-B-C-ca4da     cp B C
/plans/1cc6d33b48ef4d13bf5b1f441b286397  cp-CC-DD-fab0c   cp CC DD
/plans/1e36a9ff580d49cda5f3f8fbf8224b53  cat-Z-C-E-c6bbf  cat Z C E > n
/plans/286c1a56342d4a9c9f03f62ff18e4b0e  cat-Y-Z-1b5ab    cat Y Z > M
/plans/2a6b5588f52d4579bac46f3a5bfc8fbb  cat-B-D-bd7eb    cat B D > E
/plans/2a6db7a35f47499dbce56ae55c2b725d  cp-BB-CC-a3ad0   cp BB CC
```
or
```
$ renku  workflow ls -c command
COMMAND
-------------
cat A C > D
cat B D > E
cat Y Z > M
cat Z C E > n
cp A B
cp B C
cp BB CC
cp CC DD
cp X Y
cp X Z
cp bla CC
```