### PR TITLE
chore(service): get rid of Andreas

### DIFF
--- a/tests/service/fixtures/service_client.py
+++ b/tests/service/fixtures/service_client.py
@@ -123,11 +123,11 @@ def identity_headers():
         "session_state": "12345",
         "acr": "1",
         "email_verified": False,
-        "preferred_username": "andi@bleuler.com",
-        "given_name": "Andreas",
-        "family_name": "Bleuler",
-        "name": "Andreas Bleuler",
-        "email": "andi@bleuler.com",
+        "preferred_username": "renkubot@datascience.ch",
+        "given_name": "Renku",
+        "family_name": "Bot",
+        "name": "Renkubot",
+        "email": "renkubot@datascience.ch",
     }
 
     headers = {


### PR DESCRIPTION
For some reason, we have a service integration test that impersonates Andreas. This PR replaces that with fake data.