### PR TITLE
fix(cli): fix output of CompositePlan mappings and small bug in visualization

### DIFF
--- a/renku/cli/workflow.py
+++ b/renku/cli/workflow.py
@@ -633,7 +633,7 @@ def _print_composite_plan(composite_plan: "CompositePlanViewModel"):
             )
             click.echo(click.style("\tMaps to: ", bold=True, fg="magenta"))
             for maps_to in mapping.maps_to:
-                click.style(maps_to, bold=True)
+                click.echo(click.style(f"\t\t{maps_to}", bold=True))
 
     if composite_plan.links:
         click.echo(click.style("Links: ", bold=True, fg="magenta"))

--- a/renku/core/commands/view_model/activity_graph.py
+++ b/renku/core/commands/view_model/activity_graph.py
@@ -68,12 +68,15 @@ class ActivityGraphViewModel:
         from grandalf.layouts import SugiyamaLayout
         from grandalf.routing import EdgeViewer, route_with_lines
 
+        from renku.core.models.provenance.activity import Activity
+
         columns = [ACTIVITY_GRAPH_COLUMNS[c] for c in columns.split(",")]
 
         self.layouts = []
 
         components = networkx.weakly_connected_components(self.graph)
         subgraphs = [self.graph.subgraph(component).copy() for component in components]
+        subgraphs = filter(lambda s: any(isinstance(n, Activity) for n in s), subgraphs)
         subgraphs = sorted(subgraphs, key=self._subgraph_order_key)
 
         for subgraph in subgraphs:


### PR DESCRIPTION
CompositePlan maps_to was not printed to console on `renku workflow show`

In some cases, a workflow subgraph could contain only a file, with no activity attached to it, which would elad to exceptions. This filters out those workflows subgraphs when visualizing executions.