### PR TITLE
fix(core): encoding format for output

### DIFF
--- a/renku/core/management/workflow/plan_factory.py
+++ b/renku/core/management/workflow/plan_factory.py
@@ -290,7 +290,8 @@ class PlanFactory:
 
                 self.add_command_output_from_parameter(param)
             else:
-                self.add_command_output(default_value=glob)
+                encoding_format = [DIRECTORY_MIME_TYPE] if candidate.is_dir() else self._get_mimetype(candidate)
+                self.add_command_output(default_value=glob, encoding_format=encoding_format)
 
     def _check_potential_output_directory(
         self, input_path: Path, candidates: Set[str], tree: DirectoryTree

--- a/renku/data/shacl_shape.json
+++ b/renku/data/shacl_shape.json
@@ -1122,6 +1122,13 @@
             },
             {
                "nodeKind": "sh:Literal",
+               "path": "schema:encodingFormat",
+               "datatype": {
+                  "@id": "xsd:string"
+               }
+            },
+            {
+               "nodeKind": "sh:Literal",
                "path": "rdfs:label",
                "datatype": {
                   "@id": "xsd:string"


### PR DESCRIPTION
# Description

in one scenario (generated output from script) the `CommandOutput`'s `encoding_format` parameter is not set currently in the metadata that will cause errors when trying to run with CWL backend (current default).

This bug has been found by @gavin-k-lee see: https://renkulab.io/gitlab/lee.gavin.k/debug-workflow repo for the workflows