### PR TITLE
fix: set missing creator when migrating projects

### DIFF
--- a/renku/core/management/migrations/m_0009__new_metadata_storage.py
+++ b/renku/core/management/migrations/m_0009__new_metadata_storage.py
@@ -97,7 +97,7 @@ def maybe_migrate_project_to_database(client, project_gateway: IProjectGateway):
     metadata_path = client.renku_path.joinpath(OLD_METADATA_PATH)
 
     if metadata_path.exists():
-        old_project = old_schema.Project.from_yaml(metadata_path)
+        old_project = old_schema.Project.from_yaml(metadata_path, client=client)
 
         id_path = urlparse(old_project._id).path
         id_path = id_path.replace("/projects/", "")

--- a/renku/core/management/migrations/models/v9.py
+++ b/renku/core/management/migrations/models/v9.py
@@ -262,7 +262,7 @@ class CommitMixin:
                 self._project = self.client.project
             except ValueError:
                 metadata_path = self.client.renku_path.joinpath(OLD_METADATA_PATH)
-                self._project = Project.from_yaml(metadata_path)
+                self._project = Project.from_yaml(metadata_path, client=self.client)
 
         if not self._id:
             self._id = self.default_id()

--- a/renku/core/management/migrations/utils/__init__.py
+++ b/renku/core/management/migrations/utils/__init__.py
@@ -116,7 +116,7 @@ def generate_dataset_file_url(client, filepath):
         from renku.core.management.migrations.models.v9 import Project
 
         metadata_path = client.renku_path.joinpath(OLD_METADATA_PATH)
-        project = Project.from_yaml(metadata_path)
+        project = Project.from_yaml(metadata_path, client=client)
 
         project_id = urlparse(project._id)
     else:


### PR DESCRIPTION
closes #2463 


Loading metadata code did not pass LocalClient, which in turn didn't set creator from git if it was missing. This makes sure LocalClient is passed in all relevant places.