### PR TITLE
fix(core): make status and update consider all relevant activities

### DIFF
--- a/renku/core/commands/status.py
+++ b/renku/core/commands/status.py
@@ -88,6 +88,7 @@ def _get_status(client_dispatcher: IClientDispatcher, activity_gateway: IActivit
 def _get_modified_paths(activity_gateway, repository) -> Tuple[Set[Tuple[Activity, Entity]], Set[str]]:
     """Get modified and deleted usages/inputs of a list of activities."""
     all_activities = activity_gateway.get_all_activities()
+
     relevant_activities = set()
     for activity in all_activities:
         add_activity_if_recent(activity, relevant_activities)

--- a/renku/core/commands/status.py
+++ b/renku/core/commands/status.py
@@ -87,7 +87,7 @@ def _get_status(client_dispatcher: IClientDispatcher, activity_gateway: IActivit
 
 def _get_modified_paths(activity_gateway, repository) -> Tuple[Set[Tuple[Activity, Entity]], Set[str]]:
     """Get modified and deleted usages/inputs of a list of activities."""
-    latest_activities = activity_gateway.get_latest_activity_per_plan().values()
+    latest_activities = activity_gateway.get_latest_activities()
     modified, deleted = get_modified_activities(activities=latest_activities, repository=repository)
 
     return modified, {e.path for _, e in deleted}

--- a/renku/core/commands/status.py
+++ b/renku/core/commands/status.py
@@ -26,7 +26,7 @@ from renku.core.management.interface.activity_gateway import IActivityGateway
 from renku.core.management.interface.client_dispatcher import IClientDispatcher
 from renku.core.models.entity import Entity
 from renku.core.models.provenance.activity import Activity
-from renku.core.utils.metadata import get_modified_activities
+from renku.core.utils.metadata import add_activity_if_recent, get_modified_activities
 from renku.core.utils.os import get_relative_path_to_cwd, get_relative_paths
 
 
@@ -87,7 +87,10 @@ def _get_status(client_dispatcher: IClientDispatcher, activity_gateway: IActivit
 
 def _get_modified_paths(activity_gateway, repository) -> Tuple[Set[Tuple[Activity, Entity]], Set[str]]:
     """Get modified and deleted usages/inputs of a list of activities."""
-    latest_activities = activity_gateway.get_latest_activities()
-    modified, deleted = get_modified_activities(activities=latest_activities, repository=repository)
+    all_activities = activity_gateway.get_all_activities()
+    relevant_activities = set()
+    for activity in all_activities:
+        add_activity_if_recent(activity, relevant_activities)
+    modified, deleted = get_modified_activities(activities=list(relevant_activities), repository=repository)
 
     return modified, {e.path for _, e in deleted}

--- a/renku/core/commands/update.py
+++ b/renku/core/commands/update.py
@@ -113,7 +113,6 @@ def _get_modified_activities_and_paths(repository, activity_gateway) -> Tuple[Se
     for activity in all_activities:
         add_activity_if_recent(activity, relevant_activities)
     modified, _ = get_modified_activities(activities=list(relevant_activities), repository=repository)
-
     return {a for a, _ in modified if _is_activity_valid(a)}, {e.path for _, e in modified}
 
 

--- a/renku/core/commands/update.py
+++ b/renku/core/commands/update.py
@@ -108,7 +108,7 @@ def _is_activity_valid(activity: Activity, plan_gateway: IPlanGateway, client_di
 
 def _get_modified_activities_and_paths(repository, activity_gateway) -> Tuple[Set[Activity], Set[str]]:
     """Return latest activities that one of their inputs is modified."""
-    latest_activities = activity_gateway.get_latest_activity_per_plan().values()
+    latest_activities = activity_gateway.get_latest_activities()
     modified, _ = get_modified_activities(activities=latest_activities, repository=repository)
 
     return {a for a, _ in modified if _is_activity_valid(a)}, {e.path for _, e in modified}

--- a/renku/core/commands/update.py
+++ b/renku/core/commands/update.py
@@ -108,8 +108,11 @@ def _is_activity_valid(activity: Activity, plan_gateway: IPlanGateway, client_di
 
 def _get_modified_activities_and_paths(repository, activity_gateway) -> Tuple[Set[Activity], Set[str]]:
     """Return latest activities that one of their inputs is modified."""
-    latest_activities = activity_gateway.get_latest_activities()
-    modified, _ = get_modified_activities(activities=latest_activities, repository=repository)
+    all_activities = activity_gateway.get_all_activities()
+    relevant_activities = set()
+    for activity in all_activities:
+        add_activity_if_recent(activity, relevant_activities)
+    modified, _ = get_modified_activities(activities=list(relevant_activities), repository=repository)
 
     return {a for a, _ in modified if _is_activity_valid(a)}, {e.path for _, e in modified}
 

--- a/renku/core/commands/workflow.py
+++ b/renku/core/commands/workflow.py
@@ -480,7 +480,8 @@ def execute_workflow(
     for plan in plans:
         # NOTE: Update plans are copies of Plan objects. We need to use the original Plan objects to avoid duplicates.
         original_plan = plan_gateway.get_by_id(plan.id)
-        activity = Activity.from_plan(plan=original_plan, started_at_time=started_at_time, ended_at_time=ended_at_time)
+        activity = Activity.from_plan(plan=plan, started_at_time=started_at_time, ended_at_time=ended_at_time)
+        activity.association.plan = original_plan
         activity_gateway.add(activity)
         activities.append(activity)
 

--- a/renku/core/management/interface/activity_gateway.py
+++ b/renku/core/management/interface/activity_gateway.py
@@ -19,10 +19,9 @@
 
 from abc import ABC
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import List, Optional, Set, Tuple, Union
 
-from renku.core.models.provenance.activity import Activity, ActivityCollection, Usage
-from renku.core.models.workflow.plan import AbstractPlan
+from renku.core.models.provenance.activity import Activity, ActivityCollection
 
 
 class IActivityGateway(ABC):
@@ -30,14 +29,6 @@ class IActivityGateway(ABC):
 
     def get_latest_activities(self) -> List[Activity]:
         """Get the latest activites by their usages and generations."""
-        raise NotImplementedError
-
-    def get_latest_activity_per_plan(self):
-        """Get latest activity for each plan."""
-        raise NotImplementedError
-
-    def get_plans_and_usages_for_latest_activities(self) -> Dict[AbstractPlan, List[Usage]]:
-        """Get all usages associated with a plan by its latest activity."""
         raise NotImplementedError
 
     def get_all_usage_paths(self) -> List[str]:

--- a/renku/core/management/interface/activity_gateway.py
+++ b/renku/core/management/interface/activity_gateway.py
@@ -27,10 +27,6 @@ from renku.core.models.provenance.activity import Activity, ActivityCollection
 class IActivityGateway(ABC):
     """Interface for the ActivityGateway."""
 
-    def get_latest_activities(self) -> List[Activity]:
-        """Get the latest activites by their usages and generations."""
-        raise NotImplementedError
-
     def get_all_usage_paths(self) -> List[str]:
         """Return all usage paths."""
         raise NotImplementedError

--- a/renku/core/management/interface/activity_gateway.py
+++ b/renku/core/management/interface/activity_gateway.py
@@ -28,6 +28,10 @@ from renku.core.models.workflow.plan import AbstractPlan
 class IActivityGateway(ABC):
     """Interface for the ActivityGateway."""
 
+    def get_latest_activities(self) -> List[Activity]:
+        """Get the latest activites by their usages and generations."""
+        raise NotImplementedError
+
     def get_latest_activity_per_plan(self):
         """Get latest activity for each plan."""
         raise NotImplementedError

--- a/renku/core/metadata/gateway/activity_gateway.py
+++ b/renku/core/metadata/gateway/activity_gateway.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 """Renku activity database gateway implementation."""
 
-from itertools import chain
 from pathlib import Path
 from typing import List, Optional, Set, Tuple, Union
 
@@ -37,13 +36,6 @@ class ActivityGateway(IActivityGateway):
     """Gateway for activity database operations."""
 
     database_dispatcher = inject.attr(IDatabaseDispatcher)
-
-    def get_latest_activities(self) -> List[Activity]:
-        """Get the latest activites by their usages and generations."""
-        database = self.database_dispatcher.current_database
-        activities_with_generations = database["latest-activity-by-generations"].values()
-        activities_without_generations = database["activities-without-generation"].values()
-        return chain(activities_with_generations, activities_without_generations)
 
     def get_all_usage_paths(self) -> List[str]:
         """Return all usage paths."""
@@ -123,11 +115,7 @@ class ActivityGateway(IActivityGateway):
         downstreams = set()
 
         by_usage = database["activities-by-usage"]
-        latest_by_generations = database["latest-activity-by-generations"]
-        activities_without_generations = database["activities-without-generation"]
         by_generation = database["activities-by-generation"]
-
-        generations = []
 
         for usage in activity.usages:
             if usage.entity.path not in by_usage:
@@ -139,8 +127,6 @@ class ActivityGateway(IActivityGateway):
                     upstreams.update(activities)
 
         for generation in activity.generations:
-            generations.append(generation.entity.path)
-
             if generation.entity.path not in by_generation:
                 by_generation[generation.entity.path] = PersistentList()
             by_generation[generation.entity.path].append(activity)
@@ -148,22 +134,6 @@ class ActivityGateway(IActivityGateway):
             for path, activities in by_usage.items():
                 if are_paths_related(path, generation.entity.path):
                     downstreams.update(activities)
-
-        if generations:
-            latest_by_generations[frozenset(generations)] = activity
-        else:
-            # activity has no outputs
-            usages = set(u.entity.path for u in activity.usages)
-            existing_activities = [
-                a for a in activities_without_generations.values() if a.association.plan == activity.association.plan
-            ]
-            existing_activities = [a for a in existing_activities if set(u.entity.path for u in a.usages) == usages]
-
-            if existing_activities:
-                for a in existing_activities:
-                    activities_without_generations.pop(a.id)
-
-            activities_without_generations.add(activity)
 
         if upstreams:
             for s in upstreams:

--- a/renku/core/metadata/gateway/database_gateway.py
+++ b/renku/core/metadata/gateway/database_gateway.py
@@ -90,10 +90,7 @@ def load_downstream_relations(token, catalog, cache, database_dispatcher: IDatab
 def initialize_database(database):
     """Initialize an empty database with all required metadata."""
     database.add_index(name="activities", object_type=Activity, attribute="id")
-    database.add_index(name="activities-without-generation", object_type=Activity, attribute="id")
-    database.add_index(name="latest-activity-by-plan", object_type=Activity, attribute="association.plan.id")
     database.add_root_object(name="activities-by-usage", obj=BTrees.OOBTree.OOBTree())
-    database.add_root_object(name="latest-activity-by-generations", obj=BTrees.OOBTree.OOBTree())
     database.add_root_object(name="activities-by-generation", obj=BTrees.OOBTree.OOBTree())
 
     database.add_index(name="activity-collections", object_type=ActivityCollection, attribute="id")

--- a/renku/core/metadata/gateway/database_gateway.py
+++ b/renku/core/metadata/gateway/database_gateway.py
@@ -90,8 +90,10 @@ def load_downstream_relations(token, catalog, cache, database_dispatcher: IDatab
 def initialize_database(database):
     """Initialize an empty database with all required metadata."""
     database.add_index(name="activities", object_type=Activity, attribute="id")
+    database.add_index(name="activities-without-generation", object_type=Activity, attribute="id")
     database.add_index(name="latest-activity-by-plan", object_type=Activity, attribute="association.plan.id")
     database.add_root_object(name="activities-by-usage", obj=BTrees.OOBTree.OOBTree())
+    database.add_root_object(name="latest-activity-by-generations", obj=BTrees.OOBTree.OOBTree())
     database.add_root_object(name="activities-by-generation", obj=BTrees.OOBTree.OOBTree())
 
     database.add_index(name="activity-collections", object_type=ActivityCollection, attribute="id")

--- a/renku/core/utils/metadata.py
+++ b/renku/core/utils/metadata.py
@@ -87,10 +87,12 @@ def get_modified_activities(
     modified = set()
     deleted = set()
 
+    checksum_cache = {}
+
     for activity in activities:
         for usage in activity.usages:
             entity = usage.entity
-            current_checksum = repository.get_object_hash(path=entity.path)
+            current_checksum = checksum_cache.setdefault(entity.path, repository.get_object_hash(path=entity.path))
             if current_checksum is None:
                 deleted.add((activity, entity))
             elif current_checksum != entity.checksum:

--- a/tests/cli/fixtures/cli_runner.py
+++ b/tests/cli/fixtures/cli_runner.py
@@ -38,7 +38,7 @@ def renku_cli(client, run, client_database_injection_manager):
     def renku_cli_(*args, **kwargs) -> Tuple[int, Union[None, Activity, List[Activity]]]:
         @inject.autoparams()
         def _get_activities(activity_gateway: IActivityGateway):
-            return {a.id: a for a in activity_gateway.get_latest_activities()}
+            return {a.id: a for a in activity_gateway.get_all_activities()}
 
         with client_database_injection_manager(client):
             activities_before = _get_activities()

--- a/tests/cli/fixtures/cli_runner.py
+++ b/tests/cli/fixtures/cli_runner.py
@@ -38,7 +38,7 @@ def renku_cli(client, run, client_database_injection_manager):
     def renku_cli_(*args, **kwargs) -> Tuple[int, Union[None, Activity, List[Activity]]]:
         @inject.autoparams()
         def _get_activities(activity_gateway: IActivityGateway):
-            return {a.id: a for a in activity_gateway.get_latest_activity_per_plan().values()}
+            return {a.id: a for a in activity_gateway.get_latest_activities()}
 
         with client_database_injection_manager(client):
             activities_before = _get_activities()

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -199,7 +199,9 @@ def test_update_workflow_without_outputs(runner, project, run):
 
     write_and_commit_file(repo, source, "content")
 
-    assert 0 == runner.invoke(cli, ["run", "cat", "--no-output", source]).exit_code
+    result = runner.invoke(cli, ["run", "cat", "--no-output", source])
+
+    assert 0 == result.exit_code, format_result_exception(result)
 
     write_and_commit_file(repo, source, "changes")
 

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -417,3 +417,58 @@ def test_update_multiple_paths_common_output(project, renku_cli, runner):
     assert "r2" not in result.output
     assert "r3" in result.output
     assert "r4" in result.output
+
+
+def test_update_with_execute(runner, client, renku_cli, client_database_injection_manager):
+    """Test output is updated when source changes."""
+    source1 = Path("source.txt")
+    output1 = Path("output.txt")
+    source2 = Path("source2.txt")
+    output2 = Path("output2.txt")
+    script = Path("cp.sh")
+
+    write_and_commit_file(client.repository, source1, "content_a")
+    write_and_commit_file(client.repository, source2, "content_b")
+    write_and_commit_file(client.repository, script, "cp $1 $2")
+
+    result = runner.invoke(cli, ["run", "--name", "test", "bash", str(script), str(source1), str(output1)])
+    assert 0 == result.exit_code, format_result_exception(result)
+
+    assert (
+        0
+        == renku_cli(
+            "workflow", "execute", "--set", f"input-2={source2}", "--set", f"output-3={output2}", "test"
+        ).exit_code
+    )
+
+    assert "content_a" == (client.path / output1).read_text()
+    assert "content_b" == (client.path / output2).read_text()
+
+    result = runner.invoke(cli, ["status"])
+    assert 0 == result.exit_code, format_result_exception(result)
+
+    write_and_commit_file(client.repository, script, "cp $1 $2\necho 'modified' >> $2")
+
+    result = runner.invoke(cli, ["status"])
+    assert 1 == result.exit_code
+
+    assert 0 == renku_cli("update", "--all").exit_code
+
+    result = runner.invoke(cli, ["status"])
+    assert 0 == result.exit_code
+
+    assert "content_amodified\n" == (client.path / output1).read_text()
+    assert "content_bmodified\n" == (client.path / output2).read_text()
+
+    write_and_commit_file(client.repository, script, "cp $1 $2\necho 'even more modified' >> $2")
+
+    result = runner.invoke(cli, ["status"])
+    assert 1 == result.exit_code
+
+    assert 0 == renku_cli("update", "--all").exit_code
+
+    result = runner.invoke(cli, ["status"])
+    assert 0 == result.exit_code
+
+    assert "content_aeven more modified\n" == (client.path / output1).read_text()
+    assert "content_beven more modified\n" == (client.path / output2).read_text()

--- a/tests/core/metadata/test_activity_gateway.py
+++ b/tests/core/metadata/test_activity_gateway.py
@@ -17,64 +17,10 @@
 # limitations under the License.
 """Test activity database gateways."""
 
-from datetime import datetime, timedelta
 
 from renku.core.metadata.gateway.activity_gateway import ActivityGateway
-from renku.core.models.provenance.activity import Activity, Association
 from renku.core.models.workflow.plan import Plan
 from tests.utils import create_dummy_activity
-
-
-def test_activity_gateway_get_latest_activity(dummy_database_injection_manager):
-    """Test getting latest activity for a plan."""
-
-    plan = Plan(id=Plan.generate_id(), name="plan")
-    plan2 = Plan(id=Plan.generate_id(), name="plan2")
-
-    activity1_id = Activity.generate_id()
-    activity1 = Activity(
-        id=activity1_id,
-        ended_at_time=datetime.utcnow() - timedelta(hours=1),
-        association=Association(id=Association.generate_id(activity1_id), plan=plan),
-    )
-
-    activity2_id = Activity.generate_id()
-    activity2 = Activity(
-        id=activity2_id,
-        ended_at_time=datetime.utcnow(),
-        association=Association(id=Association.generate_id(activity2_id), plan=plan),
-    )
-
-    activity3_id = Activity.generate_id()
-    activity3 = Activity(
-        id=activity3_id,
-        ended_at_time=datetime.utcnow(),
-        association=Association(id=Association.generate_id(activity3_id), plan=plan2),
-    )
-
-    with dummy_database_injection_manager(None):
-        activity_gateway = ActivityGateway()
-
-        activity_gateway.add(activity1)
-
-        latest_activities = activity_gateway.get_latest_activities()
-        assert len(latest_activities) == 1
-        assert {activity1_id} == {a.id for a in latest_activities.values()}
-        assert {plan.id} == {p.id for p in latest_activities.keys()}
-
-        activity_gateway.add(activity3)
-
-        latest_activities = activity_gateway.get_latest_activities()
-        assert len(latest_activities) == 2
-        assert {activity1_id, activity3_id} == {a.id for a in latest_activities.values()}
-        assert {plan.id, plan2.id} == {p.id for p in latest_activities.keys()}
-
-        activity_gateway.add(activity2)
-
-        latest_activities = activity_gateway.get_latest_activities()
-        assert len(latest_activities) == 2
-        assert {activity2_id, activity3_id} == {a.id for a in latest_activities.values()}
-        assert {plan.id, plan2.id} == {p.id for p in latest_activities.keys()}
 
 
 def test_activity_gateway_downstream_activities(dummy_database_injection_manager):

--- a/tests/core/metadata/test_activity_gateway.py
+++ b/tests/core/metadata/test_activity_gateway.py
@@ -57,48 +57,24 @@ def test_activity_gateway_get_latest_activity(dummy_database_injection_manager):
 
         activity_gateway.add(activity1)
 
-        latest_activities = activity_gateway.get_latest_activity_per_plan()
+        latest_activities = activity_gateway.get_latest_activities()
         assert len(latest_activities) == 1
         assert {activity1_id} == {a.id for a in latest_activities.values()}
         assert {plan.id} == {p.id for p in latest_activities.keys()}
 
         activity_gateway.add(activity3)
 
-        latest_activities = activity_gateway.get_latest_activity_per_plan()
+        latest_activities = activity_gateway.get_latest_activities()
         assert len(latest_activities) == 2
         assert {activity1_id, activity3_id} == {a.id for a in latest_activities.values()}
         assert {plan.id, plan2.id} == {p.id for p in latest_activities.keys()}
 
         activity_gateway.add(activity2)
 
-        latest_activities = activity_gateway.get_latest_activity_per_plan()
+        latest_activities = activity_gateway.get_latest_activities()
         assert len(latest_activities) == 2
         assert {activity2_id, activity3_id} == {a.id for a in latest_activities.values()}
         assert {plan.id, plan2.id} == {p.id for p in latest_activities.keys()}
-
-
-def test_activity_gateway_get_latest_plan_usages(dummy_database_injection_manager):
-    """Test getting latest activity for a plan."""
-
-    plan = Plan(id=Plan.generate_id(), name="plan")
-    plan2 = Plan(id=Plan.generate_id(), name="plan2")
-
-    activity1 = create_dummy_activity(plan=plan, usages=["in1"])
-    activity2 = create_dummy_activity(plan=plan, usages=["in1"])
-    activity3 = create_dummy_activity(plan=plan2, usages=["in2"])
-
-    with dummy_database_injection_manager(None):
-        activity_gateway = ActivityGateway()
-
-        activity_gateway.add(activity1)
-        activity_gateway.add(activity2)
-        activity_gateway.add(activity3)
-
-        latest_usages = activity_gateway.get_plans_and_usages_for_latest_activities()
-
-        assert len(latest_usages) == 2
-        assert latest_usages[plan] == activity2.usages
-        assert latest_usages[plan2] == activity3.usages
 
 
 def test_activity_gateway_downstream_activities(dummy_database_injection_manager):


### PR DESCRIPTION
Adds an index of (generations...):lastest_activity and uses that for checking `renku status` and `renku update`