### PR TITLE
fix(core): fix regression due to git-lfs version 3.0.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2408,7 +2408,7 @@ toil = ["toil"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "76c05c8453900f7267d700f203ec170dd919f2ab9cae0c4974b2376b2e7df345"
+content-hash = "dfa8136895258f2fd2e0a01f81cfcdd994ca6d4b8c55204832d068346b5594ab"
 
 [metadata.files]
 addict = [

--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -85,7 +85,7 @@ class StorageApiMixin(RepositoryApiMixin):
 
     _CMD_STORAGE_MIGRATE_IMPORT = ["git", "lfs", "migrate", "import"]
 
-    _CMD_STORAGE_MIGRATE_INFO = ["git", "lfs", "migrate", "info", "--top", "42000"]
+    _CMD_STORAGE_MIGRATE_INFO = ["git", "lfs", "migrate", "info", "--pointers", "ignore", "--top", "42000"]
 
     _CMD_STORAGE_LIST = ["git", "lfs", "ls-files", "-n"]
 

--- a/renku/core/management/storage.py
+++ b/renku/core/management/storage.py
@@ -85,7 +85,7 @@ class StorageApiMixin(RepositoryApiMixin):
 
     _CMD_STORAGE_MIGRATE_IMPORT = ["git", "lfs", "migrate", "import"]
 
-    _CMD_STORAGE_MIGRATE_INFO = ["git", "lfs", "migrate", "info", "--pointers", "ignore", "--top", "42000"]
+    _CMD_STORAGE_MIGRATE_INFO = ["git", "lfs", "migrate", "info", "--top", "42000"]
 
     _CMD_STORAGE_LIST = ["git", "lfs", "ls-files", "-n"]
 
@@ -450,15 +450,26 @@ class StorageApiMixin(RepositoryApiMixin):
 
         includes, excludes, above = self.get_lfs_migrate_filters()
 
+        ignore_pointers = ["--pointers", "ignore"]
+
         command = self._CMD_STORAGE_MIGRATE_INFO + ref + above + includes + excludes
 
         try:
-            lfs_output = run(command, stdout=PIPE, stderr=STDOUT, cwd=self.path, universal_newlines=True)
+            lfs_output = run(
+                command + ignore_pointers, stdout=PIPE, stderr=STDOUT, cwd=self.path, universal_newlines=True
+            )
         except (KeyboardInterrupt, OSError) as e:
             raise errors.GitError(f"Couldn't run 'git lfs migrate info':\n{e}")
 
         if lfs_output.returncode != 0:
-            raise errors.GitLFSError(f"Error executing 'git lfs migrate info: \n {lfs_output.stdout}")
+            # NOTE: try running without --pointers (old versions of git lfs)
+            try:
+                lfs_output = run(command, stdout=PIPE, stderr=STDOUT, cwd=self.path, universal_newlines=True)
+            except (KeyboardInterrupt, OSError) as e:
+                raise errors.GitError(f"Couldn't run 'git lfs migrate info':\n{e}")
+
+            if lfs_output.returncode != 0:
+                raise errors.GitLFSError(f"Error executing 'git lfs migrate info: \n {lfs_output.stdout}")
 
         groups = []
         files_re = re.compile(r"(.*\s+[\d.]+\s+\S+).*")


### PR DESCRIPTION
git-lfs version 3.0.2 made some changes so the `git lfs migrate info` command, which is supposed to output files not in LFS that should be in LFS now also returns the "helpful" entry `LFS Objects    0 B       0/1 files(s)      0%`. This PR ignores that when processing LFS files.