### PR TITLE
chore: fix poetry deploy action

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -723,6 +723,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install poetry poetry-dynamic-versioning
           python -m pip install .[all]
           git config --global --add user.name "Renku @ SDSC"
           git config --global --add user.email "renku@datascience.ch"
@@ -733,9 +734,12 @@ jobs:
           export GIT_TAG=$(renku --version)
           git tag $GIT_TAG
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.9
-        with:
-          pypi_token: ${{ secrets.PYPI_ACCESS_TOKEN }}
+        env:
+          POETRY_VIRTUALENVS_CREATE: false
+        run: |
+          poetry config pypi-token.pypi ${{ secrets.TEST_PYPI_TOKEN }}
+          poetry build
+          poetry publish
 
   build-images:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The poetry-publish action doesn't work as it uses an older version of pip, instead, just call poetry manually.