### PR TITLE
fix(core): fix hash calculation when git returns too many paths

### DIFF
--- a/renku/core/metadata/repository.py
+++ b/renku/core/metadata/repository.py
@@ -462,7 +462,7 @@ class BaseRepository:
         if not revision:
             uncommitted_hashes = _get_uncommitted_file_hashes(absolute_paths)
 
-            hashes.update({path_mapping[p]: h for p, h in uncommitted_hashes.items()})
+            hashes.update({path_mapping.get(p, p): h for p, h in uncommitted_hashes.items()})
 
             if len(hashes) == len(absolute_paths):
                 # NOTE: there were only uncommitted files
@@ -495,7 +495,7 @@ class BaseRepository:
         if main_repo_paths:
             # NOTE: Get hashes for paths in the main repository
             revision_hashes = _get_hashes_from_revision(main_repo_paths, revision, self)
-            hashes.update({path_mapping[get_absolute_path(p, self.path)]: h for p, h in revision_hashes.items()})
+            hashes.update({path_mapping.get(get_absolute_path(p, self.path), p): h for p, h in revision_hashes.items()})
 
         if not submodule_paths:
             return hashes
@@ -503,7 +503,9 @@ class BaseRepository:
         # NOTE: Get hashes for paths in submodules
         for submodule, submodule_paths in submodule_paths.items():
             submodule_hashes = submodule.get_object_hashes(paths=submodule_paths, revision="HEAD")
-            hashes.update({path_mapping[get_absolute_path(p, self.path)]: h for p, h in submodule_hashes.items()})
+            hashes.update(
+                {path_mapping.get(get_absolute_path(p, self.path), p): h for p, h in submodule_hashes.items()}
+            )
 
         return hashes
 


### PR DESCRIPTION
Sometimes, git ls-tree returns more than the paths that were sent to it, for some reason. This fixes it.