### PR TITLE
fix(core): preserve dataset ids for KG migrations

### DIFF
--- a/renku/cli/migrate.py
+++ b/renku/cli/migrate.py
@@ -56,7 +56,13 @@ from renku.core.errors import MigrationRequired, ProjectNotSupported
     "-d", "--skip-docker-update", is_flag=True, hidden=True, help="Do not update Dockerfile to current renku version."
 )
 @click.option("-s", "--strict", is_flag=True, hidden=True, help="Abort migrations if an error is raised.")
-def migrate(check, skip_template_update, skip_docker_update, strict):
+@click.option(
+    "--preserve-identifiers",
+    is_flag=True,
+    hidden=True,
+    help="Keep original dataset identifier when KG migrates a project.",
+)
+def migrate(check, skip_template_update, skip_docker_update, strict, preserve_identifiers):
     """Check for migration and migrate to the latest Renku project version."""
     from renku.core.commands.migrate import (
         AUTOMATED_TEMPLATE_UPDATE_SUPPORTED,
@@ -107,7 +113,10 @@ def migrate(check, skip_template_update, skip_docker_update, strict):
 
     command = migrate_project().with_communicator(communicator).with_commit()
     result = command.build().execute(
-        skip_template_update=skip_template_update, skip_docker_update=skip_docker_update, strict=strict
+        skip_template_update=skip_template_update,
+        skip_docker_update=skip_docker_update,
+        strict=strict,
+        preserve_identifiers=preserve_identifiers,
     )
 
     result, _, _ = result.output

--- a/renku/core/commands/migrate.py
+++ b/renku/core/commands/migrate.py
@@ -157,6 +157,7 @@ def _migrate_project(
     skip_docker_update=False,
     skip_migrations=False,
     strict=False,
+    preserve_identifiers=False,
 ):
     """Migrate all project's entities."""
     from renku.core.management.migrate import migrate
@@ -167,6 +168,7 @@ def _migrate_project(
         skip_docker_update=skip_docker_update,
         skip_migrations=skip_migrations,
         strict=strict,
+        preserve_identifiers=preserve_identifiers,
     )
 
 

--- a/renku/core/management/migrate.py
+++ b/renku/core/management/migrate.py
@@ -103,6 +103,7 @@ def migrate(
     max_version=None,
     strict=False,
     migration_type=MigrationType.ALL,
+    preserve_identifiers=False,
 ):
     """Apply all migration files to the project."""
     client = client_dispatcher.current_client
@@ -142,7 +143,7 @@ def migrate(
     project_version = project_version or get_project_version()
     n_migrations_executed = 0
 
-    migration_options = MigrationOptions(strict=strict, type=migration_type)
+    migration_options = MigrationOptions(strict=strict, type=migration_type, preserve_identifiers=preserve_identifiers)
     migration_context = MigrationContext(client=client, options=migration_options)
 
     version = 1

--- a/renku/core/management/migrations/utils/__init__.py
+++ b/renku/core/management/migrations/utils/__init__.py
@@ -50,6 +50,7 @@ class MigrationOptions(NamedTuple):
     """Migration options."""
 
     strict: bool
+    preserve_identifiers: bool
     type: MigrationType = MigrationType.ALL
 
 

--- a/renku/core/models/dataset.py
+++ b/renku/core/models/dataset.py
@@ -513,7 +513,7 @@ class Dataset(Persistent):
 
         self.dataset_files = files
 
-    def update_metadata_from(self, other: "Dataset"):
+    def update_metadata_from(self, other: "Dataset", exclude=None):
         """Update metadata from another dataset."""
         editable_fields = [
             "creators",
@@ -531,6 +531,8 @@ class Dataset(Persistent):
         ]
         for name in editable_fields:
             value = getattr(other, name)
+            if exclude and name in exclude:
+                continue
             setattr(self, name, value)
 
         if self.date_published is not None:

--- a/tests/cli/fixtures/cli_old_projects.py
+++ b/tests/cli/fixtures/cli_old_projects.py
@@ -78,13 +78,13 @@ def old_workflow_project(request, tmp_path):
         }
 
 
-@pytest.fixture
-def old_dataset_project(tmp_path):
+@pytest.fixture(params=["old-datasets-v0.9.1.git"])
+def old_dataset_project(request, tmp_path):
     """Prepares a testing repo created by old version of renku."""
     from renku.core.management.client import LocalClient
     from renku.core.utils.contexts import chdir
 
-    name = "old-datasets-v0.9.1.git"
+    name = request.param
     base_path = tmp_path / name
     repository = clone_compressed_repository(base_path=base_path, name=name)
 
@@ -125,17 +125,3 @@ def unsupported_project(client, client_database_injection_manager):
     client.repository.commit("update renku.ini", no_verify=True)
 
     yield client
-
-
-@pytest.fixture
-def old_client_before_database(tmp_path):
-    """A renku project from last version without Database."""
-    from renku.core.management.client import LocalClient
-    from renku.core.utils.contexts import chdir
-
-    name = "old-datasets-v0.16.0.git"
-    base_path = tmp_path / name
-    repository = clone_compressed_repository(base_path=base_path, name=name)
-
-    with chdir(repository.path):
-        yield LocalClient(path=repository.path)

--- a/tests/cli/test_migrate.py
+++ b/tests/cli/test_migrate.py
@@ -255,25 +255,45 @@ def test_comprehensive_dataset_migration(
 
 
 @pytest.mark.migration
-def test_migrate_renku_dataset_same_as(isolated_runner, old_client_before_database, load_dataset_with_injection):
+@pytest.mark.parametrize(
+    "old_dataset_project, name, same_as",
+    [
+        ("old-datasets-v0.9.1.git", "dataverse", "https://doi.org/10.7910/DVN/EV6KLF"),
+        ("old-datasets-v0.16.0.git", "renku-dataset", "https://dev.renku.ch/datasets/860f6b5b46364c83b6a9b38ef198bcc0"),
+    ],
+    indirect=["old_dataset_project"],
+)
+def test_migrate_renku_dataset_same_as(
+    isolated_runner, old_dataset_project, load_dataset_with_injection, name, same_as
+):
     """Test migration of imported renku datasets remove dashes from the same_as field."""
     result = isolated_runner.invoke(cli, ["migrate", "--strict"])
     assert 0 == result.exit_code, format_result_exception(result)
 
-    dataset = load_dataset_with_injection("renku-dataset", old_client_before_database)
+    dataset = load_dataset_with_injection(name, old_dataset_project)
 
-    assert "https://dev.renku.ch/datasets/860f6b5b46364c83b6a9b38ef198bcc0" == dataset.same_as.value
+    assert same_as == dataset.same_as.value
 
 
 @pytest.mark.migration
-def test_migrate_renku_dataset_derived_from(isolated_runner, old_client_before_database, load_dataset_with_injection):
+@pytest.mark.parametrize(
+    "old_dataset_project, name, derived_from",
+    [
+        ("old-datasets-v0.9.1.git", "mixed", "/datasets/f77be1a1d3adfa99bc84f463ad134ced"),
+        ("old-datasets-v0.16.0.git", "local", "/datasets/535b6e1ddb85442a897b2b3c72aec0c6"),
+    ],
+    indirect=["old_dataset_project"],
+)
+def test_migrate_renku_dataset_derived_from(
+    isolated_runner, old_dataset_project, load_dataset_with_injection, name, derived_from
+):
     """Test migration of datasets remove dashes from the derived_from field."""
     result = isolated_runner.invoke(cli, ["migrate", "--strict"])
     assert 0 == result.exit_code, format_result_exception(result)
 
-    dataset = load_dataset_with_injection("local", old_client_before_database)
+    dataset = load_dataset_with_injection(name, old_dataset_project)
 
-    assert "/datasets/535b6e1ddb85442a897b2b3c72aec0c6" == dataset.derived_from.url_id
+    assert derived_from == dataset.derived_from.url_id
 
 
 @pytest.mark.migration
@@ -401,3 +421,20 @@ def test_commit_hook_with_immutable_modified_files(runner, local_client, mocker,
         result = runner.invoke(cli, ["check-immutable-template-files", "README.md"])
         assert result.exit_code == 1
         assert "README.md" in result.output
+
+
+@pytest.mark.migration
+@pytest.mark.parametrize("name", ["mixed", "dataverse"])
+def test_migrate_and_preserve_dataset_ids(isolated_runner, old_dataset_project, load_dataset_with_injection, name):
+    """Test migrate can preserve old datasets' ids."""
+    result = isolated_runner.invoke(cli, ["migrate", "--strict", "--preserve-identifiers"])
+    assert 0 == result.exit_code, format_result_exception(result)
+
+    dataset = load_dataset_with_injection(name, old_dataset_project)
+
+    assert dataset.identifier == dataset.initial_identifier
+    assert dataset.derived_from is None
+
+    result = isolated_runner.invoke(cli, ["graph", "export", "--strict"])
+
+    assert 0 == result.exit_code, format_result_exception(result)


### PR DESCRIPTION
# Description

Adds an `--preserve-identifiers` flag to the `migrate` command which keeps original datasets' identifiers when migrating. This option is intended only for KG during indexing to keep the identifiers consistent with the project's metadata.

Fixes #2511 
