### PR TITLE
docs: fix RTD build with poetry

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+        - tests

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,0 @@
--e .[docs,tests]


### PR DESCRIPTION
fixes poetry build not working due to editable flag.

Built here: https://renku.readthedocs.io/projects/renku-python/en/fix-rtd-poetry/introduction.html