### PR TITLE
fix(core): fix project creator path in old project schema

### DIFF
--- a/renku/core/management/migrations/models/v9.py
+++ b/renku/core/management/migrations/models/v9.py
@@ -164,9 +164,10 @@ class Project:
     def __attrs_post_init__(self):
         """Initialize computed attributes."""
         if not self.creator and self.client:
-            if self.client.database_path.exists():
+            old_metadata_path = self.client.renku_path.joinpath(OLD_METADATA_PATH)
+            if old_metadata_path.exists():
                 self.creator = Person.from_commit(
-                    self.client.repository.get_previous_commit(self.client.database_path, first=True)
+                    self.client.repository.get_previous_commit(old_metadata_path, first=True)
                 )
             else:
                 # this assumes the project is being newly created


### PR DESCRIPTION
Fixes kg issue 2 with project eawagrs/lake-greifen-profiles, namely:

```
File "<attrs generated init renku.core.management.migrations.models.v9.Project>", line 23, in __init__;
self.__attrs_post_init__();
File "/usr/lib/python3.8/site-packages/renku/core/management/migrations/models/v9.py", line 169, in __attrs_post_init__;
self.client.repository.get_previous_commit(self.client.database_path, first=True);
File "/usr/lib/python3.8/site-packages/renku/core/metadata/repository.py", line 298, in get_previous_commit;
raise errors.GitCommitNotFoundError(f"Cannot find previous commit for '{path}' from '{revision}'");
renku.core.errors.GitCommitNotFoundError: Cannot find previous commit for '/tmp/lake-greifen-profiles-6123667132990583931/.renku/metadata' from 'HEAD';
```