### PR TITLE
fix(core): fail gracefully when running non-existing commands

### DIFF
--- a/renku/core/commands/run.py
+++ b/renku/core/commands/run.py
@@ -146,9 +146,13 @@ def _run_command(
 
             started_at_time = local_now()
 
-            return_code = call(
-                factory.command_line, cwd=os.getcwd(), **{key: getattr(sys, key) for key in mapped_std.keys()}
-            )
+            try:
+                return_code = call(
+                    factory.command_line, cwd=os.getcwd(), **{key: getattr(sys, key) for key in mapped_std.keys()}
+                )
+            except FileNotFoundError:
+                command = " ".join(factory.base_command)
+                raise errors.ParameterError(f"Cannot execute command '{command}'")
 
             ended_at_time = local_now()
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -199,3 +199,11 @@ def test_run_argument_parameters(runner, client, client_database_injection_manag
     result = runner.invoke(cli, ["graph", "export", "--format", "jsonld", "--strict"])
 
     assert 0 == result.exit_code, format_result_exception(result)
+
+
+def test_run_non_existing_command(runner, client):
+    """Test run with a non-existing command."""
+    result = runner.invoke(cli, ["run", "non-existing_command"])
+
+    assert 2 == result.exit_code
+    assert "Cannot execute command 'non-existing_command'" in result.output


### PR DESCRIPTION
# Description

No crash when passing a non-existing command to `renku run`

Fixes #2474 
