### PR TITLE
fix(core): preserve dateCreated when migrating datasets

### DIFF
--- a/renku/core/management/migrations/models/v9.py
+++ b/renku/core/management/migrations/models/v9.py
@@ -1489,23 +1489,6 @@ def _convert_keyword(keywords):
 class Dataset(Entity, CreatorMixin):
     """Represent a dataset."""
 
-    SUPPORTED_SCHEMES = ("", "file", "http", "https", "git+https", "git+ssh")
-
-    EDITABLE_FIELDS = [
-        "creators",
-        "date_created",
-        "date_published",
-        "description",
-        "files",
-        "images",
-        "in_language",
-        "keywords",
-        "license",
-        "title",
-        "url",
-        "version",
-    ]
-
     _id = attr.ib(default=None, kw_only=True)
     _label = attr.ib(default=None, kw_only=True)
 
@@ -1584,13 +1567,6 @@ class Dataset(Entity, CreatorMixin):
         return ",".join(tag.name for tag in self.tags)
 
     @property
-    def editable(self):
-        """Subset of attributes which user can edit."""
-        obj = self.as_jsonld()
-        data = {field_: obj.pop(field_) for field_ in self.EDITABLE_FIELDS}
-        return data
-
-    @property
     def data_dir(self):
         """Directory where dataset files are stored."""
         if self.client:
@@ -1630,22 +1606,6 @@ class Dataset(Entity, CreatorMixin):
             if value and value != getattr(self, attribute):
                 self._modified = True
                 setattr(self, attribute, value)
-
-        return self
-
-    def update_metadata_from(self, other_dataset):
-        """Updates instance attributes with other dataset attributes.
-
-        :param other_dataset: `Dataset`
-        :return: self
-        """
-        for field_ in self.EDITABLE_FIELDS:
-            val = getattr(other_dataset, field_)
-            if val:
-                self._modified = True
-                setattr(self, field_, val)
-
-        self.same_as = other_dataset.same_as
 
         return self
 

--- a/renku/core/models/dataset.py
+++ b/renku/core/models/dataset.py
@@ -433,7 +433,9 @@ class Dataset(Persistent):
         self._assign_new_identifier(identifier)
         # NOTE: Do not unset `same_as` because it can be set for imported datasets
 
-    def derive_from(self, dataset: "Dataset", creator: Optional[Person], identifier: str = None):
+    def derive_from(
+        self, dataset: "Dataset", creator: Optional[Person], identifier: str = None, date_created: datetime = None
+    ):
         """Make `self` a derivative of `dataset` and update related fields."""
         assert dataset is not None, "Cannot derive from None"
 
@@ -442,7 +444,7 @@ class Dataset(Persistent):
         self.initial_identifier = dataset.initial_identifier
         self.derived_from = Url(url_id=dataset.id)
         self.same_as = None
-        self.date_created = local_now()
+        self.date_created = date_created or local_now()
         self.date_published = None
 
         if creator and hasattr(creator, "email") and not any(c for c in self.creators if c.email == creator.email):


### PR DESCRIPTION
# Description

During a migration, dataset's creation date was set to current date/time instead of the original creation date. This PR fixes this issue and also removed some unused code.