### PR TITLE
fix(core): disable interpolation when loading/storing renku config

### DIFF
--- a/renku/core/management/config.py
+++ b/renku/core/management/config.py
@@ -83,7 +83,8 @@ class ConfigManagerMixin:
         except ImportError:
             import importlib.resources as importlib_resources
 
-        config = configparser.ConfigParser()
+        # NOTE: Use RawConfigParser because ConfigParser does non-standard INI interpolation of some values
+        config = configparser.RawConfigParser()
         ref = importlib_resources.files("renku.data") / "defaults.ini"
         with importlib_resources.as_file(ref) as default_ini:
             config_files = [default_ini]

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -259,3 +259,16 @@ def test_config_write_concurrency(monkeypatch, runner, project, client, run):
 
         # NOTE: assess the value was actually written
         assert CONFIG_VALUE in get_value()
+
+
+@pytest.mark.parametrize("value", ["%value", "${value}"])
+def test_config_interpolation_is_disabled(client, runner, value):
+    """Test ConfigParser interpolation is disabled."""
+    result = runner.invoke(cli, ["config", "set", "key", value])
+
+    assert 0 == result.exit_code, format_result_exception(result)
+
+    result = runner.invoke(cli, ["config", "show", "key"])
+
+    assert 0 == result.exit_code, format_result_exception(result)
+    assert f"{value}\n" == result.output


### PR DESCRIPTION
# Description

Interpolation is a non-standard INI feature seems to be only implemented by `ConfigParser`. `GitPython` does not use it either. This PR disables this feature.

Fixes #2486 
