### PR TITLE
feat(core): ignore quotation mark in git user/email config

### DIFF
--- a/renku/core/metadata/repository.py
+++ b/renku/core/metadata/repository.py
@@ -589,6 +589,9 @@ class BaseRepository:
         if not email:  # pragma: no cover
             raise errors.GitMissingEmail
 
+        name = _sanitize_git_config_value(name)
+        email = _sanitize_git_config_value(email)
+
         return Actor(name=name, email=email)
 
     def get_configuration(self, writable=False, scope: str = None) -> "Configuration":
@@ -1376,3 +1379,8 @@ def _find_previous_commit_helper(
 
     if submodules:
         return get_previous_commit_from_submodules()
+
+
+def _sanitize_git_config_value(value: str) -> str:
+    """Remove quotation marks and whitespaces surrounding a config value."""
+    return value.strip(" \n\t\"'")

--- a/tests/core/metadata/test_repository.py
+++ b/tests/core/metadata/test_repository.py
@@ -227,3 +227,15 @@ def test_hash_directories(git_repository):
 
     with pytest.raises(errors.GitCommandError):
         Repository.hash_object("X")
+
+
+def test_get_user_with_quotation_mark(git_repository):
+    """Test quotation marks wrapping user/email are ignored."""
+    config = git_repository.get_configuration(writable=True)
+    config.set_value("user", "name", """ ' Renku the Frog' """)
+    config.set_value("user", "email", """ "renku@renku.ch " """)
+
+    user = git_repository.get_user()
+
+    assert "Renku the Frog" == user.name
+    assert "renku@renku.ch" == user.email


### PR DESCRIPTION
# Description

Removes quotation marks from user's name/email git config.

Fixes #2539 