### PR TITLE
feat(core): support forward compatibility of datasets

### DIFF
--- a/renku/core/models/dataset.py
+++ b/renku/core/models/dataset.py
@@ -396,28 +396,18 @@ class Dataset(Persistent):
 
     def copy(self) -> "Dataset":
         """Return a clone of this dataset."""
-        return Dataset(
-            annotations=[a.copy() for a in self.annotations],
-            creators=self.creators.copy(),
-            dataset_files=[f.copy() for f in self.dataset_files],
-            date_created=self.date_created,
-            date_published=self.date_published,
-            date_removed=self.date_removed,
-            derived_from=self.derived_from,
-            description=self.description,
-            id=self.id,
-            identifier=self.identifier,
-            images=list(self.images or []),
-            in_language=self.in_language,
-            initial_identifier=self.initial_identifier,
-            keywords=list(self.keywords or []),
-            license=self.license,
-            name=self.name,
-            project_id=self.project_id,
-            same_as=self.same_as,
-            title=self.title,
-            version=self.version,
-        )
+        try:
+            self.unfreeze()
+            dataset = copy.copy(self)
+        finally:
+            self.freeze()
+
+        dataset.annotations = [a.copy() for a in self.annotations]
+        dataset.creators = self.creators.copy()
+        dataset.dataset_files = [f.copy() for f in self.dataset_files]
+        dataset.images = list(dataset.images or [])
+        dataset.keywords = list(dataset.keywords or [])
+        return dataset
 
     def replace_identifier(self, identifier: str = None):
         """Replace dataset's identifier and update relevant fields.

--- a/renku/core/models/provenance/annotation.py
+++ b/renku/core/models/provenance/annotation.py
@@ -31,7 +31,7 @@ class Annotation:
 
     def copy(self):
         """Return a copy of this annotation."""
-        return copy.copy(self)
+        return copy.deepcopy(self)
 
     @staticmethod
     def generate_id():

--- a/renku/core/models/workflow/composite_plan.py
+++ b/renku/core/models/workflow/composite_plan.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """Represent a group of run templates."""
 
+import copy
 from collections import defaultdict
 from datetime import datetime
 from typing import Callable, Dict, List, Optional, Tuple, Union
@@ -358,16 +359,11 @@ class CompositePlan(AbstractPlan):
 
     def derive(self) -> "CompositePlan":
         """Create a new ``CompositePlan`` that is derived from self."""
-        derived = CompositePlan(
-            description=self.description,
-            id=self.id,
-            date_created=local_now(),
-            invalidated_at=self.invalidated_at,
-            name=self.name,
-            derived_from=self.derived_from,
-            plans=self.plans.copy(),
-            mappings=self.mappings.copy(),
-            links=self.links.copy(),
-        )
+        derived = copy.copy(self)
+        derived.derived_from = self.id
+        derived.date_created = local_now()
+        derived.plans = self.plans.copy()
+        derived.mappings = self.mappings.copy()
+        derived.links = self.links.copy()
         derived.assign_new_id()
         return derived

--- a/renku/core/models/workflow/parameter.py
+++ b/renku/core/models/workflow/parameter.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """Classes to represent inputs/outputs/parameters in a Plan."""
 
+import copy
 import urllib
 from abc import abstractmethod
 from pathlib import PurePosixPath
@@ -182,16 +183,9 @@ class CommandParameter(CommandParameterBase):
 
     def derive(self, plan_id: str) -> "CommandParameter":
         """Create a new ``CommandParameter`` that is derived from self."""
-        return CommandParameter(
-            default_value=self.default_value,
-            description=self.description,
-            id=CommandParameter.generate_id(plan_id=plan_id, position=self.position, postfix=self.postfix),
-            name=self.name,
-            position=self.position,
-            prefix=self.prefix,
-            derived_from=self.id,
-            postfix=self.postfix,
-        )
+        parameter = copy.copy(self)
+        parameter.id = CommandParameter.generate_id(plan_id=plan_id, position=self.position, postfix=self.postfix)
+        return parameter
 
 
 class CommandInput(CommandParameterBase):
@@ -239,18 +233,9 @@ class CommandInput(CommandParameterBase):
 
     def derive(self, plan_id: str) -> "CommandInput":
         """Create a new ``CommandInput`` that is derived from self."""
-        return CommandInput(
-            default_value=self.default_value,
-            description=self.description,
-            id=CommandInput.generate_id(plan_id=plan_id, position=self.position, postfix=self.postfix),
-            mapped_to=self.mapped_to,
-            name=self.name,
-            position=self.position,
-            prefix=self.prefix,
-            encoding_format=self.encoding_format,
-            derived_from=self.id,
-            postfix=self.postfix,
-        )
+        parameter = copy.copy(self)
+        parameter.id = CommandInput.generate_id(plan_id=plan_id, position=self.position, postfix=self.postfix)
+        return parameter
 
 
 class CommandOutput(CommandParameterBase):
@@ -303,18 +288,9 @@ class CommandOutput(CommandParameterBase):
 
     def derive(self, plan_id: str) -> "CommandOutput":
         """Create a new ``CommandOutput`` that is derived from self."""
-        return CommandOutput(
-            default_value=self.default_value,
-            description=self.description,
-            id=CommandOutput.generate_id(plan_id=plan_id, position=self.position, postfix=self.postfix),
-            mapped_to=self.mapped_to,
-            name=self.name,
-            position=self.position,
-            prefix=self.prefix,
-            encoding_format=self.encoding_format,
-            derived_from=self.id,
-            postfix=self.postfix,
-        )
+        parameter = copy.copy(self)
+        parameter.id = CommandOutput.generate_id(plan_id=plan_id, position=self.position, postfix=self.postfix)
+        return parameter
 
 
 class ParameterMapping(CommandParameterBase):

--- a/renku/core/models/workflow/plan.py
+++ b/renku/core/models/workflow/plan.py
@@ -97,6 +97,9 @@ class AbstractPlan(Persistent, ABC):
         new_uuid = uuid4().hex
         self.id = self.id.replace(current_uuid, new_uuid)
 
+        # NOTE: We also need to re-assign the _p_oid since identifier has changed
+        self.reassign_oid()
+
         return new_uuid
 
     def _extract_uuid(self) -> str:
@@ -240,20 +243,14 @@ class Plan(AbstractPlan):
 
     def derive(self) -> "Plan":
         """Create a new ``Plan`` that is derived from self."""
-        derived = Plan(
-            parameters=self.parameters.copy(),
-            command=self.command,
-            description=self.description,
-            id=self.id,
-            inputs=self.inputs.copy(),
-            date_created=local_now(),
-            invalidated_at=self.invalidated_at,
-            keywords=self.keywords.copy(),
-            name=self.name,
-            derived_from=self.id,
-            outputs=self.outputs.copy(),
-            success_codes=self.success_codes.copy(),
-        )
+        derived = copy.copy(self)
+        derived.derived_from = self.id
+        derived.date_created = local_now()
+        derived.parameters = self.parameters.copy()
+        derived.inputs = self.inputs.copy()
+        derived.keywords = self.keywords.copy()
+        derived.outputs = self.outputs.copy()
+        derived.success_codes = self.success_codes.copy()
         derived.assign_new_id()
         return derived
 


### PR DESCRIPTION
Our database already supported backwards compatibility (add properties at the class level) and forward compatibility (we're schemaless so additional properties are loaded just fine even if they don't exist in code).

The main issue was that newer properties were lost when editing datasets/plans, as we didn't do a deep copy on editing, causing fields from newer schemas to be lost. Now they are ported/copied to the derived objects properly.

closes #2516 