### PR TITLE
fix(core): require click 8.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2419,7 +2419,7 @@ toil = ["toil"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "b801c39914abd9d8632c5df79457f55f36ab7f05af4c00548b60f3fcd40cb502"
+content-hash = "6ccc95d5a2243a17c93eb4142afa87b7def9528f79c71482f62117affa9881bb"
 
 [metadata.files]
 addict = [
@@ -3665,10 +3665,6 @@ rq-scheduler = [
     {file = "ruamel.yaml-0.16.5.tar.gz", hash = "sha256:412a6f5cfdc0525dee6a27c08f5415c7fd832a7afcb7a0ed7319628aed23d408"},
 ]
 "ruamel.yaml.clib" = [
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6e7be2c5bcb297f5b82fee9c665eb2eb7001d1050deaba8471842979293a80b0"},
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:221eca6f35076c6ae472a531afa1c223b9c29377e62936f61bc8e6e8bdc5f9e7"},
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-win32.whl", hash = "sha256:1070ba9dd7f9370d0513d649420c3b362ac2d687fe78c6e888f5b12bf8bc7bee"},
-    {file = "ruamel.yaml.clib-0.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:77df077d32921ad46f34816a9a16e6356d8100374579bc35e15bab5d4e9377de"},
     {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:cfdb9389d888c5b74af297e51ce357b800dd844898af9d4a547ffc143fa56751"},
     {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527"},
     {file = "ruamel.yaml.clib-0.2.6-cp35-cp35m-win32.whl", hash = "sha256:ada3f400d9923a190ea8b59c8f60680c4ef8a4b0dfae134d2f2ff68429adfab5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ black = { version = "==21.9b0", optional = true }
 calamus = "<0.4,>=0.3.13"
 check-manifest = { version = "<0.48,>=0.37", optional = true }
 circus = { version = "==0.17.1", optional = true }
-click = "<8.0.2,>=7.0"
+click = "<8.0.2,>=8.0"
 click-option-group = "<0.6.0,>=0.5.2"
 click-plugins = "==1.1.1"
 coverage = { version = "<6.2,>=4.5.3", optional = true }


### PR DESCRIPTION
# Description

`shell_complete` kwarg for `click` commands is only available in click 8.0.0 and later.