### PR TITLE
chore: fix caching of templates folder with Makefile

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -49,12 +49,13 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             renku/templates
-          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}
+          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}-${{hashFiles('Makefile')}}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
           python -m pip install coveralls poetry wheel twine
+          make download-templates
           python -m pip install .[all]
       - name: Install renku into cache
         if: steps.cache.outputs.cache-hit == 'true'
@@ -87,12 +88,13 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             renku/templates
-          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}
+          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}-${{hashFiles('Makefile')}}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
           python -m pip install coveralls poetry wheel twine
+          make download-templates
           python -m pip install .[all]
       - name: Install renku into cache
         if: steps.cache.outputs.cache-hit == 'true'
@@ -124,12 +126,13 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             renku/templates
-          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}
+          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}-${{hashFiles('Makefile')}}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
           python -m pip install coveralls poetry wheel twine
+          make download-templates
           pip install .[all]
       - name: Install renku into cache
         if: steps.cache.outputs.cache-hit == 'true'
@@ -166,7 +169,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             renku/templates
-          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}
+          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}-${{hashFiles('Makefile')}}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
@@ -221,7 +224,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             renku/templates
-          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}
+          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}-${{hashFiles('Makefile')}}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
@@ -282,7 +285,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             renku/templates
-          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}
+          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}-${{hashFiles('Makefile')}}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
@@ -343,7 +346,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             renku/templates
-          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}
+          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}-${{hashFiles('Makefile')}}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
@@ -551,7 +554,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             renku/templates
-          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}
+          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}-${{hashFiles('Makefile')}}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
@@ -622,7 +625,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}
             renku/templates
-          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}
+          key: ${{env.CACHE_PREFIX}}-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{hashFiles('poetry.lock')}}-${{hashFiles('Makefile')}}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |


### PR DESCRIPTION
templates weren't downloaded in all actions, so depending on which ran first, they might not be included in the cache.

Also, the Makefile has to be used as a cache key, as template version depends on it.