### PR TITLE
fix(core): Execution graph linking of plans

### DIFF
--- a/renku/core/models/workflow/plan.py
+++ b/renku/core/models/workflow/plan.py
@@ -210,7 +210,10 @@ class Plan(AbstractPlan):
 
     def find_parameter(self, parameter: CommandParameterBase) -> bool:
         """Find if a parameter exists on this plan."""
-        return any(parameter.id == p.id for p in self.inputs + self.outputs + self.parameters)
+        return any(
+            parameter.id == p.id and parameter.actual_value == p.actual_value
+            for p in self.inputs + self.outputs + self.parameters
+        )
 
     def get_parameter_path(self, parameter: CommandParameterBase):
         """Get the path to a parameter inside this plan."""


### PR DESCRIPTION
# Description

Fixes #2569

(especially) in case of a `renku workflow iterate`, a `CommandParameterBase` can share the same ID, but with different parameterization, i.e. different `actual_value`.  Hence `Plan::find_parameter` should only be true if both of the case matches (not only the ID)