### PR TITLE
fix(core): Wipe out .renku directory when initializing

### DIFF
--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -290,6 +290,8 @@ class RepositoryApiMixin(GitCore):
 
         # initialize repo and set user data
         path = self.path.absolute()
+        if force and (path / ".renku").exists():
+            shutil.rmtree(path / ".renku")
         self.repository = Repository.initialize(path=path, branch=initial_branch)
         if user:
             with self.repository.get_configuration(writable=True) as config_writer:

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -290,8 +290,8 @@ class RepositoryApiMixin(GitCore):
 
         # initialize repo and set user data
         path = self.path.absolute()
-        if force and (path / ".renku").exists():
-            shutil.rmtree(path / ".renku")
+        if force and (path / RENKU_HOME).exists():
+            shutil.rmtree(path / RENKU_HOME)
         self.repository = Repository.initialize(path=path, branch=initial_branch)
         if user:
             with self.repository.get_configuration(writable=True) as config_writer:


### PR DESCRIPTION
# Description

Fixes #2543