### PR TITLE
chore(ci): update to renku actions 0.5.0

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -30,7 +30,7 @@ jobs:
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v0.3.2
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v0.5.0
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -42,7 +42,7 @@ jobs:
       name: renku-ci-rp-${{ github.event.number }}
     steps:
     - name: deploy-pr
-      uses: SwissDataScienceCenter/renku-actions/deploy-renku@v0.3.2
+      uses: SwissDataScienceCenter//deploy-renku@v0.5.0
       env:
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -84,43 +84,27 @@ jobs:
 
   test-pr:
     runs-on: ubuntu-20.04
-    if: github.event.action != 'closed'
+    if: ${{ github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true' }}
     needs: [check-deploy, deploy-pr]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: SwissDataScienceCenter/renku-actions/test-renku@v0.5.0
       with:
-        python-version: 3.8
-    - name: Test the PR
-      if: "needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true'"
-      env:
-        KUBECONFIG: ${{ github.workspace }}/renkubot-kube.config
-        RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
-        RENKU_RELEASE: renku-ci-rp-${{ github.event.number }}
-      run: |
-        echo "$RENKUBOT_KUBECONFIG" > ${{ github.workspace }}/renkubot-kube.config
-        helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 80m --logs
-    - name: Download artifact for packaging on failure
-      if: failure()
-      uses: SwissDataScienceCenter/renku-actions/download-test-artifacts@v0.3.2
-      env:
-        RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
-        TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
-    - name: Upload screenshots on failure
-      if: failure()
-      uses: actions/upload-artifact@v1
-      with:
-        name: acceptance-test-artifacts
-        path: ${{ github.workspace }}/test-artifacts/
+        renkubot-kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
+        renku-release: renku-ci-rp-${{ github.event.number }}
+        gitlab-token: ${{ secrets.DEV_GITLAB_TOKEN }}
+        persist: "${{ needs.check-deploy.outputs.persist }}"
+        ci-renku-values: ${{ secrets.CI_RENKU_VALUES }}
+
   cleanup:
-    if: github.event.action == 'closed'
+    needs: check-deploy
+    if: github.event.action == 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true'
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
     - name: renku teardown
-      uses: SwissDataScienceCenter/renku-actions/teardown-renku@v0.3.2
+      uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v0.5.0
       env:
+        HELM_RELEASE_REGEX: "^renku-ci-rp-${{ github.event.number }}$"
         GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
-        KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
-        RENKU_RELEASE: renku-ci-rp-${{ github.event.number }}
         RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
+        MAX_AGE_SECONDS: 0
+        DELETE_NAMESPACE: "true"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -28,6 +28,7 @@ jobs:
       renku-ui: ${{ steps.deploy-comment.outputs.renku-ui}}
       test-enabled: ${{ steps.deploy-comment.outputs.test-enabled}}
       extra-values: ${{ steps.deploy-comment.outputs.extra-values}}
+      persist: ${{ steps.deploy-comment.outputs.persist}}
     steps:
       - id: deploy-comment
         uses: SwissDataScienceCenter/renku-actions/check-pr-description@v0.5.0

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -42,7 +42,7 @@ jobs:
       name: renku-ci-rp-${{ github.event.number }}
     steps:
     - name: deploy-pr
-      uses: SwissDataScienceCenter//deploy-renku@v0.5.0
+      uses: SwissDataScienceCenter/renku-actions/deploy-renku@v0.5.0
       env:
         DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -889,7 +889,7 @@ jobs:
           echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
           echo "GIT_EMAIL=renku@datascience.ch" >> $GITHUB_ENV
       - name: Push chart and images
-        uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.3.2
+        uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.5.0
         env:
           CHART_NAME: renku-core
           GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
@@ -898,7 +898,7 @@ jobs:
       - name: Wait for chart to be available
         run: sleep 120
       - name: Update component version
-        uses: SwissDataScienceCenter/renku-actions/update-component-version@v0.3.2
+        uses: SwissDataScienceCenter/renku-actions/update-component-version@v0.5.0
         env:
           CHART_NAME: renku-core
           GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This updates the CI workflows to use the latest actions. It also enhances how the CI deployments are started and deleted.

The setup is as follows:

- if you do not provide `#persist` in the PR description when you specify `/deploy` then the CI deployment is deleted after the acceptance tests complete
- if you provide `#persist` the deployment is kept until the PR is closed.
- when the PR is closed the namespace of the deployment is also deleted
- when the acceptance tests complete AND `#persist` is not used the CI deployment is deleted but the namespace is not deleted in k8s - this makes it possible to reuse the TLS secret and not hit the limits for requesting certs with letsencrypt when the acceptance tests for the same PR are run many times
- artifacts from the acceptance tests are managed by the single (composite) test-renku action


## Type of change

chore

/deploy
