### PR TITLE
test(service): fix cleanup of temporary IT branches

### DIFF
--- a/tests/service/controllers/test_templates_create_project.py
+++ b/tests/service/controllers/test_templates_create_project.py
@@ -28,7 +28,7 @@ def test_template_create_project_ctrl(ctrl_init, svc_client_templates_creation, 
     from renku.service.controllers.templates_create_project import TemplatesCreateProjectCtrl
 
     cache, user_data = ctrl_init
-    _svc_client, _headers, payload, _rm_remote = svc_client_templates_creation
+    _, _, payload, _ = svc_client_templates_creation
 
     ctrl = TemplatesCreateProjectCtrl(cache, user_data, payload)
     ctrl_mock = mocker.patch.object(ctrl, "new_project_push", return_value=None)
@@ -136,7 +136,7 @@ def test_project_name_handler(project_name, expected_name, ctrl_init, svc_client
     from renku.service.controllers.templates_create_project import TemplatesCreateProjectCtrl
 
     cache, user_data = ctrl_init
-    svc_client, headers, payload, rm_remote = svc_client_templates_creation
+    _, _, payload, _ = svc_client_templates_creation
     payload["project_name"] = project_name
 
     ctrl = TemplatesCreateProjectCtrl(cache, user_data, payload)
@@ -155,7 +155,7 @@ def test_except_project_name_handler(project_name, ctrl_init, svc_client_templat
     from renku.service.controllers.templates_create_project import TemplatesCreateProjectCtrl
 
     cache, user_data = ctrl_init
-    _svc_client, _headers, payload, _rm_remote = svc_client_templates_creation
+    _, _, payload, _ = svc_client_templates_creation
     payload["project_name"] = project_name
 
     with pytest.raises(ValidationError) as exc_info:

--- a/tests/service/fixtures/service_client.py
+++ b/tests/service/fixtures/service_client.py
@@ -241,3 +241,5 @@ def svc_client_templates_creation(svc_client_with_templates):
         return True
 
     yield svc_client, authentication_headers, payload, remove_project
+
+    remove_project()

--- a/tests/service/views/test_templates_views.py
+++ b/tests/service/views/test_templates_views.py
@@ -150,4 +150,3 @@ def test_create_project_from_template(svc_client_templates_creation):
     assert response
     assert {"result"} == set(response.json.keys())
     assert expected_url == response.json["result"]["url"]
-    assert rm_remote() is True


### PR DESCRIPTION
The fixture has code to cleanup temporary branches, but in 3/4 tests, this wasn't actually called. I've now added it to teardown.