### PR TITLE
docs: add reference to the dummy plugin implementations

### DIFF
--- a/docs/how-to-guides/implementing_a_provider.rst
+++ b/docs/how-to-guides/implementing_a_provider.rst
@@ -53,7 +53,9 @@ The ``workflow_provider`` function shall return a tuple of ``(object, str)``,  w
 should be the plugin object, i.e. ``self`` and the string is a unique identifier of the
 provider plugin. This unique string will be the string that the user can provide to the
 ``--provider`` command line argument to select this plugin for executing the desired
-workflows.
+workflows. A dummy provider implementation is available
+`here <https://github.com/SwissDataScienceCenter/renku-dummy-provider>`_ in order to ease the
+initial implementation of a provider plugin.
 
 A provider HAS to set environment variables for a plans parameters, so they can be used by scripts.
 These environment variables have to be prefixed with the value of the

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -86,6 +86,23 @@ where `myproject.pluginmodule:mycmd` points to a click command e.g.:
 
 An example implementation of such plugin is available `here <https://github.com/SwissDataScienceCenter/renku-cli-plugin-example>`_.
 
+Workflow Converter Plugins
+--------------------------
+
+Additional workflow converters can be implemented by extending
+:class:`renku.core.models.workflow.converters.IWorkflowConverter`. By default renku
+provides a CWL converter plugins that is used when exporting a workflow:
+
+.. code-block:: console
+
+   $ renku workflow export --format cwl <my_workflow>
+
+.. autoclass:: renku.core.models.workflow.converters.IWorkflowConverter
+    :members:
+
+We created a `dummy <https://github.com/SwissDataScienceCenter/renku-dummy-format>`_ implementation of such
+converter plugin.
+
 Workflow Provider Plugins
 -------------------------
 

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -54,6 +54,8 @@ where `myproject.pluginmodule` points to a Renku `hookimpl` e.g.:
 .. automodule:: renku.core.plugins.run
    :members:
 
+`This <https://github.com/SwissDataScienceCenter/renku-dummy-annotator>`_ repository contains an implementation of
+an activity annotation plugin.
 
 CLI Plugins
 -----------
@@ -81,6 +83,8 @@ where `myproject.pluginmodule:mycmd` points to a click command e.g.:
     @click.command()
     def mycmd():
         ...
+
+An example implementation of such plugin is available `here <https://github.com/SwissDataScienceCenter/renku-cli-plugin-example>`_.
 
 Workflow Provider Plugins
 -------------------------

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -101,7 +101,7 @@ provides a CWL converter plugins that is used when exporting a workflow:
     :members:
 
 We created a `dummy <https://github.com/SwissDataScienceCenter/renku-dummy-format>`_ implementation of such
-converter plugin.
+a converter plugin.
 
 Workflow Provider Plugins
 -------------------------


### PR DESCRIPTION
# Description

This just extends the plugin documentation section with the dummy/example plugin repositories:
 - https://github.com/SwissDataScienceCenter/renku-dummy-provider
 - https://github.com/SwissDataScienceCenter/renku-dummy-annotator
 - https://github.com/SwissDataScienceCenter/renku-cli-plugin-example
 - https://github.com/SwissDataScienceCenter/renku-dummy-format

note before merging this PR the linked repositories visibility should be changed to public.
