### PR TITLE
chore: remove jinja from all

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,6 @@ all = [
     "freezegun",
     "gunicorn",
     "isort",
-    "jinja2",
     "marshmallow",
     "pexpect",
     "pillow",


### PR DESCRIPTION
Keeping duplicate packages in extras definition can cause problems during install. Removing `jinja` so it is installed even when extras are not used.  

closes #2613