### PR TITLE
docs: fix project_clone endpoint documentation

### DIFF
--- a/renku/service/views/cache.py
+++ b/renku/service/views/cache.py
@@ -115,7 +115,7 @@ def project_clone_view(user_data, cache):
       requestBody:
         content:
           application/json:
-            schema: ProjectCloneRequest
+            schema: RepositoryCloneRequest
       responses:
         200:
           description: Cloned project.


### PR DESCRIPTION
# Description

The request for cloning a remote project should follow `RepositoryCloneRequest` schema.