### PR TITLE
chore: limit concurrent dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
       prefix: "build(deps): "
       include: "scope"
     target-branch: "dependabot-updates"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Limits number of open dependabot PRs to 1, so we don't have issues with Dependabot rebasing lots of PRs and using up github runners.