### PR TITLE
chore: add action to update develop on tags

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -850,7 +850,7 @@ jobs:
           ref: 'develop'
       - name: merge changes from master
         run: |
-          git merge master -X theirs
+          git merge master
           git push
 
   build-images:

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -840,6 +840,19 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: make publish-lock-package
 
+  update-develop-branch:
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: 'develop'
+      - name: merge changes from master
+        run: |
+          git merge master -X theirs
+          git push
+
   build-images:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
# Description

Automatically merge `master` to `develop` after tagging a new release.
This will keep the tag in the history of the `develop` branch and simplify creating PRs on `master`, overcoming the limitations we have in merging directly to the protected `develop` branch.
