### PR TITLE
fix(core): downgrade git-lfs to fix CI

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -351,6 +351,9 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libyaml-0-2 libyaml-dev
+          sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu jammy main restricted multiverse universe"
+          sudo apt-get update -y
+          sudo apt-get install -y --allow-downgrades -t jammy git-lfs=3.0.2-1
       - uses: actions/cache@master
         id: dependency-cache
         with:


### PR DESCRIPTION
Git LFS 3.1.x breaks our CI due to various issues, this is just a small PR to downgrade LFS to a version that works.

Ubuntu `focal` has git-lfs version 2.9.x, but the `--above` flag that we use was introduced in 2.13.x, so we need to install it from the `jammy` package repo, which has 3.0.2.