### PR TITLE
fix(core): fix workflow iterate working with int params

### DIFF
--- a/renku/core/commands/view_model/log.py
+++ b/renku/core/commands/view_model/log.py
@@ -137,7 +137,7 @@ class LogViewModel:
 
         return ActivityLogViewModel(
             id=activity.id,
-            date=activity.ended_at_time,
+            date=activity.ended_at_time or activity.started_at_time or datetime.utcfromtimestamp(0),
             description=command,
             details=details,
             agents=[a.full_identity for a in activity.agents],
@@ -256,7 +256,11 @@ class LogViewModel:
 
         return DatasetLogViewModel(
             id=dataset.name,
-            date=dataset.date_removed if dataset.date_removed else dataset.date_modified,
+            date=dataset.date_removed
+            if dataset.date_removed
+            else (
+                dataset.date_modified or dataset.date_created or dataset.date_published or datetime.utcfromtimestamp(0)
+            ),
             description=descriptions[0] + ", ".join(descriptions[1:]),
             details=details,
             agents=[c.full_identity for c in dataset.creators],

--- a/renku/core/commands/workflow.py
+++ b/renku/core/commands/workflow.py
@@ -759,12 +759,15 @@ def _iterate_workflow(
                     f"The value of '{param_name}' parameter is neither a list nor templated variable!"
                 )
 
-            if len(param_value) == 1:
+            if isinstance(param_value, list) and len(param_value) == 1:
                 communication.warn(
                     f"The parameter '{param_name}' has only one element '{param_value}', "
                     "changing it to be a fixed parameter!"
                 )
                 workflow_params[param_name] = param_value[0]
+                continue
+            elif not isinstance(param_value, list):
+                workflow_params[param_name] = param_value
                 continue
 
             if TAG_SEPARATOR in param_name:

--- a/renku/core/management/workflow/providers/toil.py
+++ b/renku/core/management/workflow/providers/toil.py
@@ -97,13 +97,13 @@ class AbstractToilJob(Job):
             )
             _read_input(i.actual_value, file_metadata)
 
-            self._environment[f"{RENKU_ENV_PREFIX}{i.name}"] = i.actual_value
+            self._environment[f"{RENKU_ENV_PREFIX}{i.name}"] = str(i.actual_value)
 
             if i.mapped_to:
                 mapped_std[i.mapped_to.stream_type] = i.actual_value
 
         for o in self.workflow.outputs:
-            self._environment[f"{RENKU_ENV_PREFIX}{o.name}"] = o.actual_value
+            self._environment[f"{RENKU_ENV_PREFIX}{o.name}"] = str(o.actual_value)
             output_path = Path(o.actual_value)
             if len(output_path.parts) > 1:
                 output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -112,7 +112,7 @@ class AbstractToilJob(Job):
                 mapped_std[o.mapped_to.stream_type] = o.actual_value
 
         for p in self.workflow.parameters:
-            self._environment[f"{RENKU_ENV_PREFIX}{p.name}"] = p.actual_value
+            self._environment[f"{RENKU_ENV_PREFIX}{p.name}"] = str(p.actual_value)
 
         # construct cmd
         cmd = []
@@ -206,7 +206,6 @@ def process_children(parent: Job, dag: nx.DiGraph, jobs: Dict[str, Job], basedir
 
 def initialize_jobs(job, basedir, dag):
     """Creates the Toil execution plan for the given workflow DAG."""
-
     job.fileStore.logToMaster("executing renku DAG")
     outputs = list()
     jobs = {id(n): SubprocessToilJob(n) for n in dag.nodes}


### PR DESCRIPTION
closes #2697 

Int parameters were set directly in the environment variables, but environment can only contain strings.
There was also a bug with single values being passed to `--map` being treated as list and giving an access error.

Also fixed a bug where old datasets didn't have date_modified, added some fallback dates.