### PR TITLE
chore: prep 0.16.5 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,19 @@
 Changes
 =======
 
+`0.16.5 <https://github.com/SwissDataScienceCenter/renku-python/compare/v0.16.4...v0.16.5>`__ (2022-02-28)
+----------------------------------------------------------------------------------------------------------
+
+This is a backport release that contains changes necessary for compatibility with a global highly-avaialble
+Renku Redis distribution.
+
+Bug Fixes
+~~~~~~~~~
+
+-  **core:** Work with redis sentinel
+   (`#2700 <https://github.com/SwissDataScienceCenter/renku-python/issues/2700>`__)
+   (`2ea18c6 <https://github.com/SwissDataScienceCenter/renku-python/commit/2ea18c69efb9b2601da86208c1da7d987ae54521>`__)
+
 `0.16.4 <https://github.com/SwissDataScienceCenter/renku-python/compare/v0.16.3...v0.16.4>`__ (2022-01-25)
 ----------------------------------------------------------------------------------------------------------
 

--- a/helm-chart/renku-core/Chart.yaml
+++ b/helm-chart/renku-core/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: renku-core
 icon: https://avatars0.githubusercontent.com/u/53332360?s=400&u=a4311d22842343604ef61a8c8a1e5793209a67e9&v=4
-version: 0.16.4
+version: 0.16.5


### PR DESCRIPTION
Preparing 0.16.5 on the 0.16-lts branch.

NOTE: The target branch is `0.16-lts`.