### PR TITLE
chore: remove CI workflow requirements for publishing

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -571,7 +571,7 @@ jobs:
 
   build-images:
     runs-on: ubuntu-latest
-    needs: [docs-linux, test-linux-cli, test-linux-core, test-linux-service, test-macos-cli, test-macos-core, test-macos-service]
+    needs: [docs-linux]
     steps:
     - uses: actions/checkout@v2
     - name: build images
@@ -589,7 +589,7 @@ jobs:
 
   publish-chart:
     runs-on: ubuntu-latest
-    needs: [docs-linux, test-linux-cli, test-linux-core, test-linux-service, test-macos-cli, test-macos-core, test-macos-service, test-linux-integration, test-macos-integration]
+    needs: [docs-linux]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
     - uses: actions/checkout@v2
@@ -616,7 +616,6 @@ jobs:
 
   coveralls-final:
     name: Aggregate coveralls data
-    needs: [test-linux-cli, test-linux-core, test-linux-service, test-linux-api, test-linux-integration]
     runs-on: ubuntu-latest
     permissions:
         contents: read

--- a/renku/service/cache/config.py
+++ b/renku/service/cache/config.py
@@ -29,6 +29,7 @@ REDIS_IS_SENTINEL = os.environ.get("REDIS_IS_SENTINEL", "") == "true"
 REDIS_MASTER_SET = os.environ.get("REDIS_MASTER_SET", "mymaster")
 if REDIS_IS_SENTINEL:
     from redis.sentinel import Sentinel
+
     sentinel = Sentinel(
         [(REDIS_HOST, REDIS_PORT)],
         sentinel_kwargs={"password": REDIS_PASSWORD},


### PR DESCRIPTION
Two things:
1. Make image and chart publishing run without waiting for tests to pass (the test on this LTS branch are not up-to-date/compatible with new and/or backported changes)
2. Fix a very small style error (that I overlooked in the previous PR - only present in the lts branch)