### PR TITLE
feat(core): add check for invalid imported datasets

### DIFF
--- a/renku/cli/doctor.py
+++ b/renku/cli/doctor.py
@@ -23,21 +23,29 @@
    :description: Check your system and repository for potential problems.
    :extended:
 """
+
 import textwrap
 
 import click
 
-import renku.cli.utils.color as color
-
 
 @click.command()
 @click.pass_context
-def doctor(ctx):
+@click.option("--fix", is_flag=True, help="Fix issues when possible.")
+def doctor(ctx, fix):
     """Check your system and repository for potential problems."""
+    import renku.cli.utils.color as color
+    from renku.cli.utils.callback import ClickCallback
     from renku.core.commands.doctor import DOCTOR_INFO, doctor_check_command
 
+    communicator = ClickCallback()
+
     click.secho("\n".join(textwrap.wrap(DOCTOR_INFO)) + "\n", bold=True)
-    is_ok, problems = doctor_check_command().build().execute().output
+
+    command = doctor_check_command(with_fix=fix)
+    if fix:
+        command = command.with_communicator(communicator)
+    is_ok, problems = command.build().execute(fix=fix).output
 
     if is_ok:
         click.secho("Everything seems to be ok.", fg=color.GREEN)

--- a/renku/core/commands/checks/__init__.py
+++ b/renku/core/commands/checks/__init__.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 """Define repository checks for :program:`renku doctor`."""
 
-from .datasets import check_dataset_metadata, check_missing_files
+from .datasets import check_dataset_old_metadata_location, check_invalid_datasets_derivation, check_missing_files
 from .external import check_missing_external_files
 from .githooks import check_git_hooks_installed
 from .migration import check_migration
@@ -28,13 +28,14 @@ from .validate_shacl import check_datasets_structure, check_project_structure
 # Checks will be executed in the order as they are listed in __all__.
 # They are mostly used in ``doctor`` command to inspect broken things.
 __all__ = (
-    "check_migration",
+    "check_dataset_old_metadata_location",
+    "check_datasets_structure",
     "check_git_hooks_installed",
-    "check_dataset_metadata",
+    "check_invalid_datasets_derivation",
+    "check_lfs_info",
+    "check_migration",
+    "check_missing_external_files",
     "check_missing_files",
     "check_missing_references",
     "check_project_structure",
-    "check_datasets_structure",
-    "check_missing_external_files",
-    "check_lfs_info",
 )

--- a/renku/core/commands/checks/datasets.py
+++ b/renku/core/commands/checks/datasets.py
@@ -16,19 +16,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Checks needed to determine integrity of datasets."""
+
 import os
 from collections import defaultdict
 
 import click
 
+from renku.core import errors
+from renku.core.commands.echo import WARNING
 from renku.core.management.command_builder import inject
 from renku.core.management.interface.dataset_gateway import IDatasetGateway
 from renku.core.management.migrations.utils import get_pre_0_3_4_datasets_metadata
+from renku.core.utils import communication
 
-from ..echo import WARNING
 
-
-def check_dataset_metadata(client):
+def check_dataset_old_metadata_location(client, fix):
     """Check location of dataset metadata."""
     old_metadata = get_pre_0_3_4_datasets_metadata(client)
 
@@ -46,7 +48,7 @@ def check_dataset_metadata(client):
 
 
 @inject.autoparams()
-def check_missing_files(client, dataset_gateway: IDatasetGateway):
+def check_missing_files(client, fix, dataset_gateway: IDatasetGateway):
     """Find missing files listed in datasets."""
     missing = defaultdict(list)
 
@@ -69,5 +71,45 @@ def check_missing_files(client, dataset_gateway: IDatasetGateway):
             + ":\n\t  "
             + "\n\t  ".join(click.style(path, fg="red") for path in files)
         )
+
+    return False, problems
+
+
+@inject.autoparams()
+def check_invalid_datasets_derivation(client, fix, dataset_gateway: IDatasetGateway):
+    """Remove ``derived_from`` from import datasets."""
+    invalid_datasets = []
+
+    def fix_or_report(dataset):
+        if fix:
+            dataset.unfreeze()
+            dataset.derived_from = None
+            dataset.freeze()
+            communication.info(f"Fixing dataset '{dataset.name}'")
+        else:
+            invalid_datasets.append(dataset.name)
+
+    for dataset in dataset_gateway.get_provenance_tails():
+        while dataset.derived_from is not None:
+            if dataset.same_as or dataset.derived_from.url_id == dataset.id:
+                fix_or_report(dataset)
+                break
+
+            try:
+                dataset = dataset_gateway.get_by_id(dataset.derived_from.url_id)
+            except errors.ObjectNotFoundError:
+                fix_or_report(dataset)
+                break
+
+    if not invalid_datasets:
+        return True, None
+
+    problems = (
+        WARNING
+        + "There are invalid dataset metadata in the project (use 'renku doctor --fix' to fix them):"
+        + "\n\n\t"
+        + "\n\t".join(click.style(name, fg="yellow") for name in invalid_datasets)
+        + "\n"
+    )
 
     return False, problems

--- a/renku/core/commands/checks/external.py
+++ b/renku/core/commands/checks/external.py
@@ -24,7 +24,7 @@ from renku.core.management.interface.dataset_gateway import IDatasetGateway
 
 
 @inject.autoparams()
-def check_missing_external_files(client, dataset_gateway: IDatasetGateway):
+def check_missing_external_files(client, fix, dataset_gateway: IDatasetGateway):
     """Find external files that are missing."""
     missing = []
 

--- a/renku/core/commands/checks/githooks.py
+++ b/renku/core/commands/checks/githooks.py
@@ -29,7 +29,7 @@ except ImportError:
     import importlib.resources as importlib_resources
 
 
-def check_git_hooks_installed(client):
+def check_git_hooks_installed(client, fix):
     """Checks if all necessary hooks are installed."""
     for hook in HOOKS:
         hook_path = get_hook_path(name=hook, repository=client.repository)

--- a/renku/core/commands/checks/migration.py
+++ b/renku/core/commands/checks/migration.py
@@ -20,7 +20,7 @@ from renku.core.commands.echo import ERROR, WARNING
 from renku.core.management.migrate import is_migration_required, is_project_unsupported
 
 
-def check_migration(client):
+def check_migration(client, fix):
     """Check for project version."""
     if is_migration_required():
         problems = WARNING + "Project requires migration.\n" + '  (use "renku migrate" to fix this issue)\n'

--- a/renku/core/commands/checks/references.py
+++ b/renku/core/commands/checks/references.py
@@ -22,7 +22,7 @@ import click
 from ..echo import WARNING
 
 
-def check_missing_references(client):
+def check_missing_references(client, fix):
     """Find missing references."""
     from renku.core.models.refs import LinkReference
 

--- a/renku/core/commands/checks/storage.py
+++ b/renku/core/commands/checks/storage.py
@@ -20,7 +20,7 @@
 from renku.core.commands.echo import WARNING
 
 
-def check_lfs_info(client):
+def check_lfs_info(client, fix):
     """Checks if files in history should be in LFS."""
     if not client.check_external_storage():
         return True, None

--- a/renku/core/commands/checks/validate_shacl.py
+++ b/renku/core/commands/checks/validate_shacl.py
@@ -57,7 +57,7 @@ def _shacl_graph_to_string(graph):
     return "\n\t".join(problems)
 
 
-def check_project_structure(client):
+def check_project_structure(client, fix):
     """Validate project metadata against SHACL."""
     data = ProjectSchema().dump(client.project)
 
@@ -72,7 +72,7 @@ def check_project_structure(client):
 
 
 @inject.autoparams()
-def check_datasets_structure(client, dataset_gateway: IDatasetGateway):
+def check_datasets_structure(client, fix, dataset_gateway: IDatasetGateway):
     """Validate dataset metadata against SHACL."""
     ok = True
 

--- a/renku/core/commands/graph.py
+++ b/renku/core/commands/graph.py
@@ -146,7 +146,7 @@ def _get_graph_for_all_objects(
         objects.extend(dataset_gateway.get_all_tags(dataset))
 
         current_dataset = dataset
-        while current_dataset.derived_from:
+        while current_dataset.is_derivation():
             current_dataset = dataset_gateway.get_by_id(current_dataset.derived_from.url_id)
             objects.append(current_dataset)
 

--- a/renku/core/commands/log.py
+++ b/renku/core/commands/log.py
@@ -48,7 +48,7 @@ def _log(
         while current_dataset:
             yield current_dataset
 
-            if current_dataset.derived_from:
+            if current_dataset.is_derivation():
                 current_dataset = dataset_gateway.get_by_id(current_dataset.derived_from.url_id)
             else:
                 return

--- a/renku/core/commands/view_model/log.py
+++ b/renku/core/commands/view_model/log.py
@@ -156,7 +156,7 @@ class LogViewModel:
         if not dataset.derived_from and not dataset.same_as:
             descriptions.append("created")
             details.created = True
-        elif not dataset.derived_from and dataset.same_as:
+        elif dataset.same_as:
             descriptions.append("imported")
             details.imported = True
             details.source = dataset.same_as.value
@@ -166,7 +166,7 @@ class LogViewModel:
 
         previous_dataset = None
 
-        if dataset.derived_from:
+        if dataset.is_derivation():
             previous_dataset = dataset_gateway.get_by_id(dataset.derived_from.url_id)
 
         current_files = {f for f in dataset.dataset_files if not f.date_removed}

--- a/renku/core/management/dataset/dataset.py
+++ b/renku/core/management/dataset/dataset.py
@@ -698,9 +698,10 @@ def move_files(
         communication.finalize_progress(progress_name)
 
     datasets_provenance = DatasetsProvenance()
-    for dataset in modified_datasets.values():
+    modified_datasets = list(modified_datasets.values())
+    for dataset in modified_datasets:
         datasets_provenance.add_or_update(dataset, creator=get_git_user(client.repository))
-    if to_dataset:
+    if to_dataset and to_dataset not in modified_datasets:
         datasets_provenance.add_or_update(to_dataset, creator=get_git_user(client.repository))
 
 

--- a/renku/core/management/dataset/datasets_provenance.py
+++ b/renku/core/management/dataset/datasets_provenance.py
@@ -71,9 +71,8 @@ class DatasetsProvenance:
 
     def get_previous_version(self, dataset: Dataset) -> Optional[Dataset]:
         """Return the previous version of a dataset if any."""
-        if not dataset.derived_from:
-            return
-        return self.get_by_id(dataset.derived_from.url_id)
+        if dataset.is_derivation():
+            return self.get_by_id(dataset.derived_from.url_id)
 
     def add_or_update(self, dataset: Dataset, date: datetime = None, creator: Person = None):
         """Add/update a dataset according to its new content.

--- a/renku/core/management/migrations/utils/conversion.py
+++ b/renku/core/management/migrations/utils/conversion.py
@@ -153,9 +153,11 @@ def convert_dataset(dataset: old_datasets.Dataset, client, revision: str) -> Tup
 
         return dataset_files
 
-    def convert_derived_from(derived_from: Optional[old_datasets.Url]) -> Optional[Url]:
+    def convert_derived_from(
+        derived_from: Optional[old_datasets.Url], same_as: Optional[old_datasets.Url]
+    ) -> Optional[Url]:
         """Return Dataset.id from `derived_from` url."""
-        if not derived_from:
+        if not derived_from or same_as:
             return
 
         url = derived_from.url.get("@id")
@@ -187,7 +189,7 @@ def convert_dataset(dataset: old_datasets.Dataset, client, revision: str) -> Tup
             date_created=dataset.date_created,
             date_published=dataset.date_published,
             date_removed=None,
-            derived_from=convert_derived_from(dataset.derived_from),
+            derived_from=convert_derived_from(dataset.derived_from, dataset.same_as),
             description=dataset.description,
             id=None,
             identifier=_convert_dataset_identifier(dataset.identifier),

--- a/renku/core/models/dataset.py
+++ b/renku/core/models/dataset.py
@@ -86,6 +86,9 @@ class Url:
         if not self.id or self.id.startswith("_:"):
             self.id = Url.generate_id(url_str=self.url_str, url_id=self.url_id)
 
+    def __repr__(self) -> str:
+        return f"<Url {self.value}>"
+
     @staticmethod
     def generate_id(url_str, url_id):
         """Generate an identifier for Url."""
@@ -397,6 +400,10 @@ class Dataset(Persistent):
         """Comma-separated list of keywords associated with dataset."""
         return ", ".join(self.keywords)
 
+    def is_derivation(self) -> bool:
+        """Return if a dataset has correct derived_form."""
+        return self.derived_from and not self.same_as and self.id != self.derived_from.url_id
+
     def copy(self) -> "Dataset":
         """Return a clone of this dataset."""
         try:
@@ -431,6 +438,8 @@ class Dataset(Persistent):
     ):
         """Make `self` a derivative of `dataset` and update related fields."""
         assert dataset is not None, "Cannot derive from None"
+        assert self is not dataset, f"Cannot derive from the same dataset '{self.name}:{self.identifier}'"
+        assert not identifier or self.id != identifier, f"Cannot derive from the same id '{self.name}:{identifier}'"
 
         self._assign_new_identifier(identifier)
         # NOTE: Setting `initial_identifier` is required for migration of broken projects

--- a/renku/core/models/dataset.py
+++ b/renku/core/models/dataset.py
@@ -400,6 +400,9 @@ class Dataset(Persistent):
         """Comma-separated list of keywords associated with dataset."""
         return ", ".join(self.keywords)
 
+    def __repr__(self) -> str:
+        return f"<Dataset {self.identifier} {self.name}>"
+
     def is_derivation(self) -> bool:
         """Return if a dataset has correct derived_form."""
         return self.derived_from and not self.same_as and self.id != self.derived_from.url_id

--- a/tests/cli/test_move.py
+++ b/tests/cli/test_move.py
@@ -161,7 +161,8 @@ def test_move_in_the_same_dataset(runner, client_with_datasets, args, load_datas
     """Test move and overwrite a file in the same dataset."""
     src = os.path.join("data", "dataset-2", "file1")
     dst = os.path.join("data", "dataset-2", "dir1", "file2")
-    file_before = load_dataset_with_injection("dataset-2", client_with_datasets).find_file(dst)
+    dataset = load_dataset_with_injection("dataset-2", client_with_datasets)
+    file_before = dataset.find_file(dst)
 
     result = runner.invoke(cli, ["mv", "-f", src, dst] + args)
     assert 0 == result.exit_code, format_result_exception(result)

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -66,11 +66,6 @@ def test_data_add(scheme, path, overwrite, error, client_with_injection, directo
             path = str(directory_tree / "file1")
 
         dataset = add_data_to_dataset("dataset", [f"{scheme}{path}"], overwrite=overwrite, create=True)
-# =======
-#         with client_with_injection.with_dataset(name="dataset", create=True) as d:
-#             d.creators = [Person(name="me", email="me@example.com", id="me_id")]
-#             client_with_injection.add_data_to_dataset(d, ["{}{}".format(scheme, path)], overwrite=overwrite)
-# >>>>>>> 90a88d70 (feat(core): add check for invalid imported datasets)
 
         target_path = os.path.join(DATA_DIR, "dataset", "file1")
 
@@ -85,13 +80,9 @@ def test_data_add(scheme, path, overwrite, error, client_with_injection, directo
         # check the linking
         if scheme in ("", "file://"):
             shutil.rmtree("./data/dataset")
-            dataset = add_data_to_dataset("dataset", [f"{scheme}{path}"], overwrite=True)
-# =======
-#             with client_with_injection.with_dataset(name="dataset") as d:
-#                 d = d.copy()
-#                 d.creators = [Person(name="me", email="me@example.com", id="me_id")]
-#                 client_with_injection.add_data_to_dataset(d, ["{}{}".format(scheme, path)], overwrite=True)
-# >>>>>>> 90a88d70 (feat(core): add check for invalid imported datasets)
+            # NOTE: To simulate loading from persistent storage like what a separate renku command would do
+            dataset.freeze()
+            add_data_to_dataset("dataset", [f"{scheme}{path}"], overwrite=True)
             assert os.path.exists(target_path)
 
 
@@ -117,20 +108,16 @@ def test_creator_parse():
         Dataset(name="dataset", creators=["name"])
 
 
-# def test_creators_with_same_email(client_with_injection, load_dataset_with_injection):
-#     """Test creators with different names and same email address."""
-# <<<<<<< HEAD
-#     with DatasetContext(name="dataset", create=True, commit_database=True) as dataset:
-# =======
-#     with client_with_injection.with_dataset(name="dataset", create=True) as dataset:
-# >>>>>>> 90a88d70 (feat(core): add check for invalid imported datasets)
-#         dataset.creators = [Person(name="me", email="me@example.com"), Person(name="me2", email="me@example.com")]
-#         DatasetsProvenance().add_or_update(dataset)
-#
-#     dataset = load_dataset("dataset")
-#
-#     assert 2 == len(dataset.creators)
-#     assert {c.name for c in dataset.creators} == {"me", "me2"}
+def test_creators_with_same_email(client_with_injection, load_dataset_with_injection):
+    """Test creators with different names and same email address."""
+    with DatasetContext(name="dataset", create=True) as dataset:
+        dataset.creators = [Person(name="me", email="me@example.com"), Person(name="me2", email="me@example.com")]
+        DatasetsProvenance().add_or_update(dataset)
+
+    dataset = load_dataset("dataset")
+
+    assert 2 == len(dataset.creators)
+    assert {c.name for c in dataset.creators} == {"me", "me2"}
 
 
 def test_create_dataset_command_custom_message(project):

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -65,7 +65,12 @@ def test_data_add(scheme, path, overwrite, error, client_with_injection, directo
         if path == "temp":
             path = str(directory_tree / "file1")
 
-        dataset = add_data_to_dataset("dataset", ["{}{}".format(scheme, path)], overwrite=overwrite, create=True)
+        dataset = add_data_to_dataset("dataset", [f"{scheme}{path}"], overwrite=overwrite, create=True)
+# =======
+#         with client_with_injection.with_dataset(name="dataset", create=True) as d:
+#             d.creators = [Person(name="me", email="me@example.com", id="me_id")]
+#             client_with_injection.add_data_to_dataset(d, ["{}{}".format(scheme, path)], overwrite=overwrite)
+# >>>>>>> 90a88d70 (feat(core): add check for invalid imported datasets)
 
         target_path = os.path.join(DATA_DIR, "dataset", "file1")
 
@@ -80,8 +85,13 @@ def test_data_add(scheme, path, overwrite, error, client_with_injection, directo
         # check the linking
         if scheme in ("", "file://"):
             shutil.rmtree("./data/dataset")
-            dataset = add_data_to_dataset("dataset", ["{}{}".format(scheme, path)], overwrite=True)
-
+            dataset = add_data_to_dataset("dataset", [f"{scheme}{path}"], overwrite=True)
+# =======
+#             with client_with_injection.with_dataset(name="dataset") as d:
+#                 d = d.copy()
+#                 d.creators = [Person(name="me", email="me@example.com", id="me_id")]
+#                 client_with_injection.add_data_to_dataset(d, ["{}{}".format(scheme, path)], overwrite=True)
+# >>>>>>> 90a88d70 (feat(core): add check for invalid imported datasets)
             assert os.path.exists(target_path)
 
 
@@ -107,16 +117,20 @@ def test_creator_parse():
         Dataset(name="dataset", creators=["name"])
 
 
-def test_creators_with_same_email(client_with_injection, load_dataset_with_injection):
-    """Test creators with different names and same email address."""
-    with DatasetContext(name="dataset", create=True, commit_database=True) as dataset:
-        dataset.creators = [Person(name="me", email="me@example.com"), Person(name="me2", email="me@example.com")]
-        DatasetsProvenance().add_or_update(dataset)
-
-    dataset = load_dataset("dataset")
-
-    assert 2 == len(dataset.creators)
-    assert {c.name for c in dataset.creators} == {"me", "me2"}
+# def test_creators_with_same_email(client_with_injection, load_dataset_with_injection):
+#     """Test creators with different names and same email address."""
+# <<<<<<< HEAD
+#     with DatasetContext(name="dataset", create=True, commit_database=True) as dataset:
+# =======
+#     with client_with_injection.with_dataset(name="dataset", create=True) as dataset:
+# >>>>>>> 90a88d70 (feat(core): add check for invalid imported datasets)
+#         dataset.creators = [Person(name="me", email="me@example.com"), Person(name="me2", email="me@example.com")]
+#         DatasetsProvenance().add_or_update(dataset)
+#
+#     dataset = load_dataset("dataset")
+#
+#     assert 2 == len(dataset.creators)
+#     assert {c.name for c in dataset.creators} == {"me", "me2"}
 
 
 def test_create_dataset_command_custom_message(project):

--- a/tests/core/commands/test_log.py
+++ b/tests/core/commands/test_log.py
@@ -105,6 +105,7 @@ def test_log_dataset_create_simple(mocker):
     new_dataset.dataset_files = []
     new_dataset.date_removed = None
     new_dataset.date_modified = datetime.utcnow()
+    new_dataset.is_derivation.return_value = False
 
     dataset_gateway = mocker.MagicMock()
     dataset_gateway.get_provenance_tails.return_value = [new_dataset]
@@ -160,6 +161,7 @@ def test_log_dataset_create_complex(mocker):
     new_dataset.images = [mocker.MagicMock(content_url="./img/img1.png")]
     new_dataset.date_removed = None
     new_dataset.date_modified = datetime.utcnow()
+    new_dataset.is_derivation.return_value = False
 
     dataset_gateway = mocker.MagicMock()
     dataset_gateway.get_provenance_tails.return_value = [new_dataset]
@@ -217,6 +219,7 @@ def test_log_dataset_add_create(mocker):
     ]
     new_dataset.date_removed = None
     new_dataset.date_modified = datetime.utcnow()
+    new_dataset.is_derivation.return_value = False
 
     dataset_gateway = mocker.MagicMock()
     dataset_gateway.get_provenance_tails.return_value = [new_dataset]
@@ -273,6 +276,7 @@ def test_log_dataset_import(mocker):
     ]
     new_dataset.date_removed = None
     new_dataset.date_modified = datetime.utcnow()
+    new_dataset.is_derivation.return_value = False
 
     dataset_gateway = mocker.MagicMock()
     dataset_gateway.get_provenance_tails.return_value = [new_dataset]
@@ -323,6 +327,7 @@ def test_log_dataset_deleted(mocker):
     old_dataset.derived_from = None
     old_dataset.same_as = None
     old_dataset.dataset_files = []
+    old_dataset.is_derivation.return_value = False
 
     new_dataset = mocker.MagicMock()
     new_dataset.id = "new"
@@ -330,8 +335,10 @@ def test_log_dataset_deleted(mocker):
     new_dataset.title = None
     new_dataset.description = None
     new_dataset.derived_from.url_id = "old"
+    new_dataset.same_as = None
     new_dataset.dataset_files = []
     new_dataset.date_removed = datetime.utcnow()
+    new_dataset.is_derivation.return_value = True
 
     dataset_gateway = mocker.MagicMock()
     dataset_gateway.get_provenance_tails.return_value = [new_dataset]
@@ -397,6 +404,7 @@ def test_log_dataset_files_removed(mocker):
         mocker.MagicMock(date_removed=None, entity=mocker.MagicMock(path="file_a")),
         mocker.MagicMock(date_removed=None, entity=mocker.MagicMock(path="file_b")),
     ]
+    old_dataset.is_derivation.return_value = False
 
     new_dataset = mocker.MagicMock()
     new_dataset.id = "new"
@@ -404,9 +412,11 @@ def test_log_dataset_files_removed(mocker):
     new_dataset.title = None
     new_dataset.description = None
     new_dataset.derived_from.url_id = "old"
+    new_dataset.same_as = None
     new_dataset.dataset_files = [old_dataset.dataset_files[0]]
     new_dataset.date_modified = datetime.utcnow()
     new_dataset.date_removed = None
+    new_dataset.is_derivation.return_value = True
 
     dataset_gateway = mocker.MagicMock()
     dataset_gateway.get_provenance_tails.return_value = [new_dataset]
@@ -473,6 +483,7 @@ def test_log_dataset_metadata_modified(mocker):
     old_dataset.derived_from = None
     old_dataset.same_as = None
     old_dataset.dataset_files = []
+    old_dataset.is_derivation.return_value = False
 
     new_dataset = mocker.MagicMock()
     new_dataset.id = "new"
@@ -480,12 +491,14 @@ def test_log_dataset_metadata_modified(mocker):
     new_dataset.title = "new-title"
     new_dataset.description = "new-description"
     new_dataset.derived_from.url_id = "old"
+    new_dataset.same_as = None
     new_dataset.creators = [mocker.MagicMock(full_identity="Jane")]
     new_dataset.keywords = ["a", "c"]
     new_dataset.images = [mocker.MagicMock(content_url="./img/img2.png")]
     new_dataset.dataset_files = []
     new_dataset.date_modified = datetime.utcnow()
     new_dataset.date_removed = None
+    new_dataset.is_derivation.return_value = True
 
     dataset_gateway = mocker.MagicMock()
     dataset_gateway.get_provenance_tails.return_value = [new_dataset]

--- a/tests/core/fixtures/core_datasets.py
+++ b/tests/core/fixtures/core_datasets.py
@@ -63,6 +63,13 @@ def client_with_datasets(client, directory_tree, client_database_injection_manag
 
     with client_database_injection_manager(client):
         create_dataset(name="dataset-1", keywords=["dataset", "1"], creators=[person_1])
+# =======
+#         client.create_dataset(name="dataset-1", keywords=["dataset", "1"], creators=[person_1])
+#
+#         with client.with_dataset(name="dataset-2", create=True) as dataset:
+#             dataset.keywords = ["dataset", "2"]
+#             dataset.creators = [person_1, person_2]
+# >>>>>>> 90a88d70 (feat(core): add check for invalid imported datasets)
 
         dataset = add_data_to_dataset("dataset-2", urls=[str(p) for p in directory_tree.glob("*")], create=True)
         dataset.keywords = ["dataset", "2"]

--- a/tests/core/fixtures/core_datasets.py
+++ b/tests/core/fixtures/core_datasets.py
@@ -63,13 +63,6 @@ def client_with_datasets(client, directory_tree, client_database_injection_manag
 
     with client_database_injection_manager(client):
         create_dataset(name="dataset-1", keywords=["dataset", "1"], creators=[person_1])
-# =======
-#         client.create_dataset(name="dataset-1", keywords=["dataset", "1"], creators=[person_1])
-#
-#         with client.with_dataset(name="dataset-2", create=True) as dataset:
-#             dataset.keywords = ["dataset", "2"]
-#             dataset.creators = [person_1, person_2]
-# >>>>>>> 90a88d70 (feat(core): add check for invalid imported datasets)
 
         dataset = add_data_to_dataset("dataset-2", urls=[str(p) for p in directory_tree.glob("*")], create=True)
         dataset.keywords = ["dataset", "2"]


### PR DESCRIPTION
# Description

Adds a `--fix` option to the `renku doctor` command and implements a check/fix for datasets that have both `derived_from` and `same_as` set or are derived from themselves. Checks for invalid `derived_from` to avoid crashes in unfixed projects.

Fixes #2725
