### PR TITLE
feat(core): add /version endpoint

### DIFF
--- a/helm-chart/renku-core/templates/configmap.yaml
+++ b/helm-chart/renku-core/templates/configmap.yaml
@@ -19,10 +19,10 @@ data:
       tcp_nopush on;
       client_max_body_size 0; # Required for uploading large files
 
-      location /renku/versions {
+      location /renku/version {
         root /;
         add_header Content-Type application/json;
-        try_files /usr/share/nginx/html/versions.json =404;
+        try_files /usr/share/nginx/html/version.json =404;
       }
 
       {{- range $version := .Values.versions }}
@@ -38,7 +38,7 @@ data:
         proxy_pass http://{{ .Values.versions.latest.name }};
       }
     }
-  versions.json: |
+  version.json: |
     {
       "name": "renku-core",
       "versions": [
@@ -46,7 +46,10 @@ data:
         {{- range $key, $version := .Values.versions }}
         {{- if $printComma }},{{ else }} {{- $printComma = true }} {{ end }}
         {
-          "version": "{{ $version.image.tag }}"
+          "version": "{{ $version.image.tag }}",
+          "data": {
+            "metadata_version": "{{ $version.prefix }}"
+          }
         }
         {{- end }}
       ]

--- a/helm-chart/renku-core/templates/configmap.yaml
+++ b/helm-chart/renku-core/templates/configmap.yaml
@@ -40,9 +40,14 @@ data:
     }
   versions.json: |
     {
-      {{- $printComma := false -}}
-      {{- range $key, $version := .Values.versions }}
-      {{- if $printComma }},{{ else }} {{- $printComma = true }} {{ end }}
-      "{{ $version.prefix }}": "{{ include "renku-core.fullname" $ }}-{{ $version.name }}"
-      {{- end }}
+      "name": "renku-core",
+      "versions": [
+        {{- $printComma := false -}}
+        {{- range $key, $version := .Values.versions }}
+        {{- if $printComma }},{{ else }} {{- $printComma = true }} {{ end }}
+        {
+          "version": "{{ $version.image.tag }}"
+        }
+        {{- end }}
+      ]
     }

--- a/helm-chart/renku-core/templates/deployment-nginx.yaml
+++ b/helm-chart/renku-core/templates/deployment-nginx.yaml
@@ -37,8 +37,8 @@ spec:
               subPath: nginx-server-blocks.conf
             - name: nginx-volume
               readOnly: true
-              mountPath: /usr/share/nginx/html/versions.json
-              subPath: versions.json
+              mountPath: /usr/share/nginx/html/version.json
+              subPath: version.json
       volumes:
         - name: nginx-volume
           configMap:

--- a/helm-chart/renku-core/values.yaml
+++ b/helm-chart/renku-core/values.yaml
@@ -118,5 +118,5 @@ versions:
     fullnameOverride: ""
     image:
       repository: renku/renku-core
-      tag: "v0.16.5"
+      tag: "v0.16.6"
       pullPolicy: IfNotPresent

--- a/helm-chart/renku-core/values.yaml
+++ b/helm-chart/renku-core/values.yaml
@@ -16,7 +16,6 @@ global:
       tag: '0.0.1'
     customCAs: []
       # - secret:
-  
   ## Redis configuration. This is where renku-core expects to find
   ## a functioning redis instance and credentials to connect to it.
   redis:
@@ -27,7 +26,7 @@ global:
       coreService: "1"
     host: renku-redis
     port: 26379
-    clientLabel: 
+    clientLabel:
       renku-redis-host: "true"
     existingSecret: redis-secret
     existingSecretPasswordKey: redis-password

--- a/renku/service/views/version.py
+++ b/renku/service/views/version.py
@@ -24,7 +24,7 @@ VERSION_BLUEPRINT_TAG = "version"
 version_blueprint = VersionedBlueprint("version", __name__, url_prefix=SERVICE_PREFIX)
 
 
-@version_blueprint.route("/version", methods=["GET"], provide_automatic_options=False, versions=[V0_9, V1_0, V1_1])
+@version_blueprint.route("/apiversion", methods=["GET"], provide_automatic_options=False, versions=[V0_9, V1_0, V1_1])
 @handle_validation_except
 def version():
     """

--- a/tests/service/views/test_version_views.py
+++ b/tests/service/views/test_version_views.py
@@ -24,7 +24,7 @@ def test_version(svc_client):
     """Test expected response from version endpoint."""
     from renku import __version__
 
-    response = svc_client.get("/version")
+    response = svc_client.get("/apiversion")
     assert "result" in response.json
     data = response.json["result"]
 
@@ -36,7 +36,7 @@ def test_version(svc_client):
     assert MINIMUM_VERSION.name == data["minimum_api_version"]
     assert MAXIMUM_VERSION.name == data["maximum_api_version"]
 
-    response = svc_client.get("/0.9/version")
+    response = svc_client.get("/0.9/apiversion")
     assert "result" in response.json
     data = response.json["result"]
 
@@ -48,7 +48,7 @@ def test_version(svc_client):
     assert MINIMUM_VERSION.name == data["minimum_api_version"]
     assert MAXIMUM_VERSION.name == data["maximum_api_version"]
 
-    response = svc_client.get("/1.0/version")
+    response = svc_client.get("/1.0/apiversion")
     assert "result" in response.json
     data = response.json["result"]
 
@@ -60,7 +60,7 @@ def test_version(svc_client):
     assert MINIMUM_VERSION.name == data["minimum_api_version"]
     assert MAXIMUM_VERSION.name == data["maximum_api_version"]
 
-    response = svc_client.get("/1.1/version")
+    response = svc_client.get("/1.1/apiversion")
     assert "result" in response.json
     data = response.json["result"]
 


### PR DESCRIPTION
# Description

Renames `/versions` to `/version` and return renku CLI version information there. Renames `/version` to `/apiversion` in the core service.

Fixes #2593 
