### PR TITLE
chore: update CI chart publish action

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -609,19 +609,12 @@ jobs:
         echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
         echo "GIT_EMAIL=renku@datascience.ch" >> $GITHUB_ENV
     - name: Push chart and images
-      uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.1.0
+      uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.5.0
       env:
         CHART_NAME: renku-core
-        GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Wait for chart to be available
-      run: sleep 120
-    - name: Update component version
-      uses: SwissDataScienceCenter/renku-actions/update-component-version@v0.1.0
-      env:
-        CHART_NAME: renku-core
-        GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
 
   coveralls-final:
     name: Aggregate coveralls data


### PR DESCRIPTION
# Description

This should allow chart publish action on `0.16-tls` branch to run successfully by:
- Using correct secret name in the chart publish action
- Removing unnecessary `renku` component update action
