### PR TITLE
chore: fix poetry.lock check in CI

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -41,7 +41,7 @@ check_styles(){
     isort -c --df .
     flakehell lint renku/ tests/ conftest.py
     find . -path ./.eggs -prune -o -iname \*.sh -print0 | xargs -0 shellcheck
-    poetry lock --no-update && git diff --exit-code -- poetry.lock > /dev/null || echo "Poetry lock file out of date! Run 'poetry lock'"
+    poetry lock --no-update && (git diff --exit-code -- poetry.lock > /dev/null || (echo "Poetry lock file out of date! Run 'poetry lock'" && exit 1))
 }
 
 build_docs(){


### PR DESCRIPTION
Before the action checked the lock file but did not actually fail when it was out of date