### PR TITLE
feat(core): add missing module init for session package

### DIFF
--- a/renku/core/management/session/__init__.py
+++ b/renku/core/management/session/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renku interactive session module."""


### PR DESCRIPTION
# Description

This is for fixing the import error reported by @mohammad-sdsc:
```
___________ ERROR collecting renku/core/management/session/docker.py ___________
312 /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/_pytest/runner.py:340: in from_call
313 result: Optional[TResult] = func()
314 /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/_pytest/runner.py:371: in <lambda>
315 call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
316 /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/_pytest/doctest.py:545: in collect
317 module = import_path(self.path, root=self.config.rootpath)
318 /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/_pytest/pathlib.py:553: in import_path
319 raise ImportPathMismatchError(module_name, module_file, path)
320 _pytest.pathlib.ImportPathMismatchError: ('docker', '/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/docker', PosixPath('/home/runner/work/renku-python/renku-python/renku/core/management/session/docker.py'))
```