### PR TITLE
feat(workflow): show created plan after renku run

### DIFF
--- a/renku/cli/dataset.py
+++ b/renku/cli/dataset.py
@@ -682,8 +682,8 @@ def edit(name, title, description, creators, metadata, keyword):
 @click.argument("name", shell_complete=_complete_datasets)
 def show(name):
     """Show metadata of a dataset."""
+    from renku.cli.utils.terminal import print_markdown
     from renku.core.commands.dataset import show_dataset_command
-    from renku.core.utils.os import print_markdown
 
     result = show_dataset_command().build().execute(name=name)
     ds = result.output

--- a/renku/cli/exception_handler.py
+++ b/renku/cli/exception_handler.py
@@ -93,7 +93,7 @@ class RenkuExceptionsHandler(click.Group):
         except RenkuException as e:
             click.echo(ERROR + str(e), err=True)
             if e.__cause__ is not None:
-                click.echo(f"\n{traceback.format_exc()}", err=True)
+                click.echo(f"\n{traceback.format_exc()}")
             exit_code = 1
             if isinstance(e, (ParameterError, UsageError)):
                 exit_code = 2
@@ -131,8 +131,7 @@ class IssueFromTraceback(RenkuExceptionsHandler):
         except (filelock.Timeout, portalocker.LockException, portalocker.AlreadyLocked):
             click.echo(
                 click.style("Unable to acquire lock.\n", fg=color.RED) + "Hint: Please wait for another renku "
-                "process to finish and then try again.",
-                err=True,
+                "process to finish and then try again."
             )
 
         except Exception:
@@ -140,8 +139,6 @@ class IssueFromTraceback(RenkuExceptionsHandler):
                 self._handle_sentry()
 
             if not (sys.stdin.isatty() and sys.stdout.isatty()):
-                if not sys.stderr.isatty():
-                    click.echo(f"\n{traceback.format_exc()}", err=True)
                 raise
 
             self._handle_github()

--- a/renku/cli/run.py
+++ b/renku/cli/run.py
@@ -114,8 +114,8 @@ The detection might not work as expected if:
 
 .. note:: ``renku run`` prints the generated plan after execution if you pass
     ``--verbose`` to it. You can check the generated plan to verify that the
-    execution was done as you intended. Nothing will be printed if both
-    ``stdout`` and ``stderr`` are directed to file.
+    execution was done as you intended. The plan will always be printed to
+    ``stderr`` even if it's directed to a file.
 
 Detecting output paths
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -324,4 +324,4 @@ def run(
 
     if verbose:
         plan = result.output
-        print_plan(plan, require_tty=True)
+        print_plan(plan, err=True)

--- a/renku/cli/utils/terminal.py
+++ b/renku/cli/utils/terminal.py
@@ -17,9 +17,7 @@
 # limitations under the License.
 """Utility functions for ViewModels."""
 
-import contextlib
 import functools
-import sys
 from typing import TYPE_CHECKING
 
 import click
@@ -38,51 +36,28 @@ def print_markdown(text: str):
     Console().print(Markdown(text))
 
 
-def echo(message: str, err: bool = False, require_tty: bool = False, either: bool = False):
-    """Print a message to std output streams.
-
-    Args:
-        message: Message to print.
-        err: Whether to use stderr or not.
-        require_tty: Print only if output is a terminal.
-        either: Try both stdout and stderr to find a terminal; used only if ``require_tty`` is True; ignores ``err``.
-    """
-    if require_tty:
-        if either:
-            for stream in [sys.stdout, sys.stderr]:
-                if stream.isatty():
-                    click.echo(message=message, err=err)
-                    break
-        else:
-            stream = sys.stderr if err else sys.stdout
-            if stream.isatty():
-                click.echo(message=message, err=err)
-    else:
-        click.echo(message=message, err=err)
-
-
-def print_plan(plan: "PlanViewModel", require_tty: bool = False):
+def print_plan(plan: "PlanViewModel", err: bool = False):
     """Print a plan to stderr.
 
     Args:
-        require_tty: Print only if output is a terminal.
+        err: Print to ``stderr``.
     """
     style_key = functools.partial(click.style, bold=True, fg=color.MAGENTA)
     style_value = functools.partial(click.style, bold=True)
 
     def print_key_value(key, value, print_empty: bool = True):
         if print_empty or value:
-            echo(style_key(key) + style_value(value), require_tty=require_tty, either=True)
+            click.echo(style_key(key) + style_value(value), err=err)
 
     def print_key(key):
-        echo(style_key(key), require_tty=require_tty, either=True)
+        click.echo(style_key(key), err=err)
 
     def print_value(value):
-        echo(style_value(value), require_tty=require_tty, either=True)
+        click.echo(style_value(value), err=err)
 
     def print_description(description):
         if description:
-            echo(f"\t\t{description}", require_tty=require_tty, either=True)
+            click.echo(f"\t\t{description}", err=err)
 
     print_key_value("Id: ", plan.id)
     print_key_value("Name: ", plan.name)

--- a/renku/cli/utils/terminal.py
+++ b/renku/cli/utils/terminal.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2021- Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility functions for ViewModels."""
+
+import contextlib
+import functools
+import sys
+from typing import TYPE_CHECKING
+
+import click
+
+from renku.cli.utils import color
+
+if TYPE_CHECKING:
+    from renku.core.commands.view_model.plan import PlanViewModel
+
+
+def print_markdown(text: str):
+    """Print markdown text to console."""
+    from rich.console import Console
+    from rich.markdown import Markdown
+
+    Console().print(Markdown(text))
+
+
+def echo(message: str, err: bool = False, require_tty: bool = False, either: bool = False):
+    """Print a message to std output streams.
+
+    Args:
+        message: Message to print.
+        err: Whether to use stderr or not.
+        require_tty: Print only if output is a terminal.
+        either: Try both stdout and stderr to find a terminal; used only if ``require_tty`` is True; ignores ``err``.
+    """
+    if require_tty:
+        if either:
+            for stream in [sys.stdout, sys.stderr]:
+                if stream.isatty():
+                    click.echo(message=message, err=err)
+                    break
+        else:
+            stream = sys.stderr if err else sys.stdout
+            if stream.isatty():
+                click.echo(message=message, err=err)
+    else:
+        click.echo(message=message, err=err)
+
+
+def print_plan(plan: "PlanViewModel", require_tty: bool = False):
+    """Print a plan to stderr.
+
+    Args:
+        require_tty: Print only if output is a terminal.
+    """
+    style_key = functools.partial(click.style, bold=True, fg=color.MAGENTA)
+    style_value = functools.partial(click.style, bold=True)
+
+    def print_key_value(key, value, print_empty: bool = True):
+        if print_empty or value:
+            echo(style_key(key) + style_value(value), require_tty=require_tty, either=True)
+
+    def print_key(key):
+        echo(style_key(key), require_tty=require_tty, either=True)
+
+    def print_value(value):
+        echo(style_value(value), require_tty=require_tty, either=True)
+
+    def print_description(description):
+        if description:
+            echo(f"\t\t{description}", require_tty=require_tty, either=True)
+
+    print_key_value("Id: ", plan.id)
+    print_key_value("Name: ", plan.name)
+
+    if plan.description:
+        print_markdown(plan.description)
+
+    print_key_value("Command: ", plan.full_command)
+    print_key_value("Success Codes: ", plan.success_codes)
+
+    if plan.inputs:
+        print_key("Inputs:")
+        for run_input in plan.inputs:
+            print_value(f"\t- {run_input.name}:")
+            print_description(run_input.description)
+            print_key_value("\t\tDefault Value: ", run_input.default_value)
+            print_key_value("\t\tPosition: ", run_input.position, print_empty=False)
+            print_key_value("\t\tPrefix: ", run_input.prefix, print_empty=False)
+
+    if plan.outputs:
+        print_key("Outputs:")
+        for run_output in plan.outputs:
+            print_value(f"\t- {run_output.name}:")
+            print_description(run_output.description)
+            print_key_value("\t\tDefault Value: ", run_output.default_value)
+            print_key_value("\t\tPosition: ", run_output.position, print_empty=False)
+            print_key_value("\t\tPrefix: ", run_output.prefix, print_empty=False)
+
+    if plan.parameters:
+        print_key("Parameters:")
+        for run_parameter in plan.parameters:
+            print_value(f"\t- {run_parameter.name}:")
+            print_description(run_parameter.description)
+            print_key_value("\t\tDefault Value: ", run_parameter.default_value)
+            print_key_value("\t\tPosition: ", run_parameter.position, print_empty=False)
+            print_key_value("\t\tPrefix: ", run_parameter.prefix, print_empty=False)

--- a/renku/cli/workflow.py
+++ b/renku/cli/workflow.py
@@ -644,7 +644,6 @@ from renku.core.commands.view_model.activity_graph import ACTIVITY_GRAPH_COLUMNS
 
 if TYPE_CHECKING:
     from renku.core.commands.view_model.composite_plan import CompositePlanViewModel
-    from renku.core.commands.view_model.plan import PlanViewModel
 
 
 def _complete_workflows(ctx, param, incomplete):
@@ -657,96 +656,9 @@ def _complete_workflows(ctx, param, incomplete):
         return []
 
 
-def _print_plan(plan: "PlanViewModel"):
-    """Print a plan to stdout."""
-    from renku.core.utils.os import print_markdown
-
-    click.echo(click.style("Id: ", bold=True, fg=color.MAGENTA) + click.style(plan.id, bold=True))
-    click.echo(click.style("Name: ", bold=True, fg=color.MAGENTA) + click.style(plan.name, bold=True))
-
-    if plan.description:
-        print_markdown(plan.description)
-
-    click.echo(click.style("Command: ", bold=True, fg=color.MAGENTA) + click.style(plan.full_command, bold=True))
-    click.echo(click.style("Success Codes: ", bold=True, fg=color.MAGENTA) + click.style(plan.success_codes, bold=True))
-
-    if plan.inputs:
-        click.echo(click.style("Inputs: ", bold=True, fg=color.MAGENTA))
-        for run_input in plan.inputs:
-            click.echo(click.style(f"\t- {run_input.name}:", bold=True))
-
-            if run_input.description:
-                click.echo(click.style(f"\t\t{run_input.description}"))
-
-            click.echo(
-                click.style("\t\tDefault Value: ", bold=True, fg=color.MAGENTA)
-                + click.style(run_input.default_value, bold=True)
-            )
-
-            if run_input.position:
-                click.echo(
-                    click.style("\t\tPosition: ", bold=True, fg=color.MAGENTA)
-                    + click.style(run_input.position, bold=True)
-                )
-
-            if run_input.prefix:
-                click.echo(
-                    click.style("\t\tPrefix: ", bold=True, fg=color.MAGENTA) + click.style(run_input.prefix, bold=True)
-                )
-
-    if plan.outputs:
-        click.echo(click.style("Outputs: ", bold=True, fg=color.MAGENTA))
-        for run_output in plan.outputs:
-            click.echo(click.style(f"\t- {run_output.name}:", bold=True))
-
-            if run_output.description:
-                click.echo(click.style(f"\t\t{run_output.description}"))
-
-            click.echo(
-                click.style("\t\tDefault Value: ", bold=True, fg=color.MAGENTA)
-                + click.style(run_output.default_value, bold=True)
-            )
-
-            if run_output.position:
-                click.echo(
-                    click.style("\t\tPosition: ", bold=True, fg=color.MAGENTA)
-                    + click.style(run_output.position, bold=True)
-                )
-
-            if run_output.prefix:
-                click.echo(
-                    click.style("\t\tPrefix: ", bold=True, fg=color.MAGENTA) + click.style(run_output.prefix, bold=True)
-                )
-
-    if plan.parameters:
-        click.echo(click.style("Parameters: ", bold=True, fg=color.MAGENTA))
-        for run_parameter in plan.parameters:
-            click.echo(click.style(f"\t- {run_parameter.name}:", bold=True))
-
-            if run_parameter.description:
-                click.echo(click.style(f"\t\t{run_parameter.description}"))
-
-            click.echo(
-                click.style("\t\tDefault Value: ", bold=True, fg=color.MAGENTA)
-                + click.style(run_parameter.default_value, bold=True)
-            )
-
-            if run_parameter.position:
-                click.echo(
-                    click.style("\t\tPosition: ", bold=True, fg=color.MAGENTA)
-                    + click.style(run_parameter.position, bold=True)
-                )
-
-            if run_parameter.prefix:
-                click.echo(
-                    click.style("\t\tPrefix: ", bold=True, fg=color.MAGENTA)
-                    + click.style(run_parameter.prefix, bold=True)
-                )
-
-
 def _print_composite_plan(composite_plan: "CompositePlanViewModel"):
     """Print a CompositePlan to stdout."""
-    from renku.core.utils.os import print_markdown
+    from renku.cli.utils.terminal import print_markdown
 
     click.echo(click.style("Id: ", bold=True, fg=color.MAGENTA) + click.style(composite_plan.id, bold=True))
     click.echo(click.style("Name: ", bold=True, fg=color.MAGENTA) + click.style(composite_plan.name, bold=True))
@@ -813,6 +725,7 @@ def list_workflows(format, columns):
 @click.argument("name_or_id", metavar="<name_or_id>", shell_complete=_complete_workflows)
 def show(name_or_id):
     """Show details for workflow <name_or_id>."""
+    from renku.cli.utils.terminal import print_plan
     from renku.core.commands.view_model.plan import PlanViewModel
     from renku.core.commands.workflow import show_workflow_command
 
@@ -820,7 +733,7 @@ def show(name_or_id):
 
     if plan:
         if isinstance(plan, PlanViewModel):
-            _print_plan(plan)
+            print_plan(plan)
         else:
             _print_composite_plan(plan)
     else:
@@ -954,6 +867,7 @@ def compose(
 )
 def edit(workflow_name, name, description, set_params, map_params, rename_params, describe_params):
     """Edit workflow details."""
+    from renku.cli.utils.terminal import print_plan
     from renku.core.commands.view_model.plan import PlanViewModel
     from renku.core.commands.workflow import edit_workflow_command
 
@@ -973,7 +887,7 @@ def edit(workflow_name, name, description, set_params, map_params, rename_params
     if not result.error:
         plan = result.output
         if isinstance(plan, PlanViewModel):
-            _print_plan(plan)
+            print_plan(plan)
         else:
             _print_composite_plan(plan)
 
@@ -1234,6 +1148,7 @@ def visualize(sources, columns, exclude_files, ascii, interactive, no_color, pag
 @click.argument("name_or_id", required=True, shell_complete=_complete_workflows)
 def iterate(name_or_id, mappings, mapping_path, dry_run, provider, config):
     """Execute a workflow by iterating through a range of provided parameters."""
+    from renku.cli.utils.terminal import print_plan
     from renku.core.commands.view_model.plan import PlanViewModel
     from renku.core.commands.workflow import iterate_workflow_command, show_workflow_command
 
@@ -1244,7 +1159,7 @@ def iterate(name_or_id, mappings, mapping_path, dry_run, provider, config):
 
     if plan:
         if isinstance(plan, PlanViewModel):
-            _print_plan(plan)
+            print_plan(plan)
         else:
             _print_composite_plan(plan)
 

--- a/renku/core/commands/run.py
+++ b/renku/core/commands/run.py
@@ -24,6 +24,7 @@ from subprocess import call
 import click
 
 from renku.core import errors
+from renku.core.commands.view_model.plan import PlanViewModel
 from renku.core.management.command_builder import inject
 from renku.core.management.command_builder.command import Command
 from renku.core.management.git import get_mapped_std_streams
@@ -57,7 +58,7 @@ def _run_command(
     client_dispatcher: IClientDispatcher,
     activity_gateway: IActivityGateway,
     plan_gateway: IPlanGateway,
-):
+) -> PlanViewModel:
     # NOTE: validate name as early as possible
     client = client_dispatcher.current_client
 
@@ -199,6 +200,8 @@ def _run_command(
             plan=plan, started_at_time=started_at_time, ended_at_time=ended_at_time, annotations=tool.annotations
         )
         activity_gateway.add(activity)
+
+        return PlanViewModel.from_plan(plan)
 
     finally:
         if system_stdout:

--- a/renku/core/utils/contexts.py
+++ b/renku/core/utils/contexts.py
@@ -76,9 +76,9 @@ class Isolation(contextlib.ExitStack):
     """Isolate execution."""
 
     CONTEXTS = {
-        "stdin": _wrap_path_or_stream(redirect_stdin, "rb"),
-        "stdout": _wrap_path_or_stream(contextlib.redirect_stdout, "wb"),
-        "stderr": _wrap_path_or_stream(contextlib.redirect_stderr, "wb"),
+        "stdin": _wrap_path_or_stream(redirect_stdin, "r"),
+        "stdout": _wrap_path_or_stream(contextlib.redirect_stdout, "w"),
+        "stderr": _wrap_path_or_stream(contextlib.redirect_stderr, "w"),
         "cwd": chdir,
     }
 

--- a/renku/core/utils/os.py
+++ b/renku/core/utils/os.py
@@ -113,14 +113,6 @@ def is_path_empty(path: Union[Path, str]) -> bool:
     return not any(subpaths)
 
 
-def print_markdown(text: str):
-    """Print markdown text to console."""
-    from rich.console import Console
-    from rich.markdown import Markdown
-
-    Console().print(Markdown(text))
-
-
 def is_ascii(data):
     """Check if provided string contains only ascii characters."""
     return len(data) == len(data.encode())

--- a/tests/cli/test_graph.py
+++ b/tests/cli/test_graph.py
@@ -26,7 +26,7 @@ from renku.core.management.repository import DEFAULT_DATA_DIR as DATA_DIR
 from tests.utils import format_result_exception, modified_environ
 
 
-@pytest.mark.parametrize("revision", [None, "HEAD", "HEAD^", "HEAD^..HEAD"])
+@pytest.mark.parametrize("revision", ["", "HEAD", "HEAD^", "HEAD^..HEAD"])
 @pytest.mark.parametrize("format", ["json-ld", "rdf", "nt"])
 def test_graph_export_validation(runner, client, directory_tree, run, revision, format):
     """Test graph validation when exporting."""

--- a/tests/cli/test_output_option.py
+++ b/tests/cli/test_output_option.py
@@ -21,7 +21,7 @@ import os
 from pathlib import Path
 
 from renku.cli import cli
-from tests.utils import write_and_commit_file
+from tests.utils import format_result_exception, write_and_commit_file
 
 
 def test_run_succeeds_normally(renku_cli, client, subdirectory):
@@ -243,19 +243,19 @@ def test_explicit_inputs_in_subdirectories(client, runner):
     result = runner.invoke(
         cli, ["run", "--input", "foo/bar", "--input", "script.sh", "sh", "script.sh"], stdout="output"
     )
-    assert 0 == result.exit_code
+    assert 0 == result.exit_code, format_result_exception(result)
 
     # Status must be dirty if foo/bar changes
     write_and_commit_file(client.repository, client.path / "foo" / "bar", "new changes")
 
-    assert 0 == result.exit_code, result.output
+    assert 0 == result.exit_code, format_result_exception(result)
 
     result = runner.invoke(cli, ["status"])
 
-    assert 1 == result.exit_code
+    assert 1 == result.exit_code, format_result_exception(result)
 
     result = runner.invoke(cli, ["update", "--all"])
-    assert 0 == result.exit_code
+    assert 0 == result.exit_code, format_result_exception(result)
     assert (client.path / "foo" / "bar").exists()
     assert (client.path / "script.sh").exists()
     assert (client.path / "output").exists()

--- a/tests/cli/test_output_option.py
+++ b/tests/cli/test_output_option.py
@@ -21,6 +21,7 @@ import os
 from pathlib import Path
 
 from renku.cli import cli
+from tests.utils import write_and_commit_file
 
 
 def test_run_succeeds_normally(renku_cli, client, subdirectory):
@@ -232,24 +233,29 @@ def test_explicit_inputs_can_be_in_inputs(renku_cli, client, subdirectory):
     assert plan.inputs[0].position is not None
 
 
-def test_explicit_inputs_in_subdirectories(renku_cli, client):
+def test_explicit_inputs_in_subdirectories(client, runner):
     """Test explicit inputs that are in sub-dirs are made accessible"""
-
     # Set up a script with hard dependency
-    renku_cli("run", "--no-output", "mkdir", "foo")
-    renku_cli("run", "echo", "some changes", stdout="foo/bar")
-    renku_cli("run", "echo", "cat foo/bar", stdout="script.sh")
+    assert 0 == runner.invoke(cli, ["run", "--no-output", "mkdir", "foo"]).exit_code
+    assert 0 == runner.invoke(cli, ["run", "echo", "some changes"], stdout="foo/bar").exit_code
+    assert 0 == runner.invoke(cli, ["run", "echo", "cat foo/bar"], stdout="script.sh").exit_code
 
-    exit_code, _ = renku_cli("run", "--input", "foo/bar", "--input", "script.sh", "sh", "script.sh", stdout="output")
-    assert 0 == exit_code
+    result = runner.invoke(
+        cli, ["run", "--input", "foo/bar", "--input", "script.sh", "sh", "script.sh"], stdout="output"
+    )
+    assert 0 == result.exit_code
 
     # Status must be dirty if foo/bar changes
-    renku_cli("run", "echo", "new changes", stdout="foo/bar")
-    exit_code, _ = renku_cli("status")
-    assert 1 == exit_code
+    write_and_commit_file(client.repository, client.path / "foo" / "bar", "new changes")
 
-    exit_code, _ = renku_cli("update", "--all")
-    assert 0 == exit_code
+    assert 0 == result.exit_code, result.output
+
+    result = runner.invoke(cli, ["status"])
+
+    assert 1 == result.exit_code
+
+    result = runner.invoke(cli, ["update", "--all"])
+    assert 0 == result.exit_code
     assert (client.path / "foo" / "bar").exists()
     assert (client.path / "script.sh").exists()
     assert (client.path / "output").exists()

--- a/tests/cli/test_rerun.py
+++ b/tests/cli/test_rerun.py
@@ -23,7 +23,6 @@ import time
 from pathlib import Path
 
 import pytest
-from click.testing import CliRunner
 
 from renku.cli import cli
 from renku.core.metadata.repository import Repository
@@ -129,10 +128,8 @@ def test_rerun_with_from(project, renku_cli, provider, source, content):
 
 
 @pytest.mark.skip(reason="renku rerun not implemented with --edit-inputs yet, reenable later")
-def test_rerun_with_edited_inputs(project, run, no_lfs_warning):
+def test_rerun_with_edited_inputs(project, run, no_lfs_warning, split_runner):
     """Test input modification."""
-    runner = CliRunner(mix_stderr=False)
-
     cwd = Path(project)
     data = cwd / "examples"
     data.mkdir()
@@ -164,7 +161,7 @@ def test_rerun_with_edited_inputs(project, run, no_lfs_warning):
         # Make sure the input path is relative to the current directory.
         os.chdir(str(data))
 
-        result = runner.invoke(
+        result = split_runner.invoke(
             cli, ["rerun", "--show-inputs", "--from", str(first), str(second)], catch_exceptions=False
         )
         assert 0 == result.exit_code, format_result_exception(result)

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -234,5 +234,4 @@ def test_run_prints_plan_when_stderr_redirected(split_runner, client):
 
     assert 0 == result.exit_code, result.output + result.stderr
     assert "Name: echo-command" in (client.path / "output").read_text()
-    assert "Name:" not in result.stderr
     assert "Name:" not in result.output

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -214,7 +214,8 @@ def test_run_prints_plan(split_runner, client):
     result = split_runner.invoke(cli, ["run", "--verbose", "--name", "echo-command", "--no-output", "echo", "data"])
 
     assert 0 == result.exit_code
-    assert "Name: echo-command" in result.output
+    assert "Name: echo-command" in result.stderr
+    assert "Name:" not in result.output
 
 
 def test_run_prints_plan_when_stdout_redirected(split_runner, client):
@@ -222,23 +223,16 @@ def test_run_prints_plan_when_stdout_redirected(split_runner, client):
     result = split_runner.invoke(cli, ["run", "--verbose", "--name", "echo-command", "echo", "data"], stdout="output")
 
     assert 0 == result.exit_code
-    assert "Name:" not in (client.path / "output").read_text()
     assert "Name: echo-command" in result.stderr
+    assert "Name:" not in result.output
+    assert "Name:" not in (client.path / "output").read_text()
 
 
 def test_run_prints_plan_when_stderr_redirected(split_runner, client):
     """Test run shows the generated plan in stdout if stderr is redirected to a file."""
     result = split_runner.invoke(cli, ["run", "--verbose", "--name", "echo-command", "echo", "data"], stderr="output")
 
-    assert 0 == result.exit_code
-    assert "Name:" not in (client.path / "output").read_text()
-    assert "Name: echo-command" in result.output
-
-
-def test_run_prints_nothing_when_both_redirected(split_runner, client):
-    """Test run doesn't print the plan if both stdout and stderr are redirected to a file."""
-    result = split_runner.invoke(cli, ["run", "--verbose", "echo", "data"], stdout="out", stderr="err")
-
-    assert 0 == result.exit_code
-    assert "Name:" not in (client.path / "out").read_text()
-    assert "Name:" not in (client.path / "err").read_text()
+    assert 0 == result.exit_code, result.output + result.stderr
+    assert "Name: echo-command" in (client.path / "output").read_text()
+    assert "Name:" not in result.stderr
+    assert "Name:" not in result.output

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -205,7 +205,7 @@ def test_run_non_existing_command(runner, client):
     """Test run with a non-existing command."""
     result = runner.invoke(cli, ["run", "non-existing_command"])
 
-    assert 2 == result.exit_code
+    assert 2 == result.exit_code, format_result_exception(result)
     assert "Cannot execute command 'non-existing_command'" in result.output
 
 
@@ -213,7 +213,7 @@ def test_run_prints_plan(split_runner, client):
     """Test run shows the generated plan with --verbose."""
     result = split_runner.invoke(cli, ["run", "--verbose", "--name", "echo-command", "--no-output", "echo", "data"])
 
-    assert 0 == result.exit_code
+    assert 0 == result.exit_code, format_result_exception(result)
     assert "Name: echo-command" in result.stderr
     assert "Name:" not in result.output
 
@@ -222,7 +222,7 @@ def test_run_prints_plan_when_stdout_redirected(split_runner, client):
     """Test run shows the generated plan in stderr if stdout is redirected to a file."""
     result = split_runner.invoke(cli, ["run", "--verbose", "--name", "echo-command", "echo", "data"], stdout="output")
 
-    assert 0 == result.exit_code
+    assert 0 == result.exit_code, format_result_exception(result)
     assert "Name: echo-command" in result.stderr
     assert "Name:" not in result.output
     assert "Name:" not in (client.path / "output").read_text()
@@ -232,6 +232,6 @@ def test_run_prints_plan_when_stderr_redirected(split_runner, client):
     """Test run shows the generated plan in stdout if stderr is redirected to a file."""
     result = split_runner.invoke(cli, ["run", "--verbose", "--name", "echo-command", "echo", "data"], stderr="output")
 
-    assert 0 == result.exit_code, result.output + result.stderr
+    assert 0 == result.exit_code, format_result_exception(result)
     assert "Name: echo-command" in (client.path / "output").read_text()
     assert "Name:" not in result.output

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -207,3 +207,38 @@ def test_run_non_existing_command(runner, client):
 
     assert 2 == result.exit_code
     assert "Cannot execute command 'non-existing_command'" in result.output
+
+
+def test_run_prints_plan(split_runner, client):
+    """Test run shows the generated plan with --verbose."""
+    result = split_runner.invoke(cli, ["run", "--verbose", "--name", "echo-command", "--no-output", "echo", "data"])
+
+    assert 0 == result.exit_code
+    assert "Name: echo-command" in result.output
+
+
+def test_run_prints_plan_when_stdout_redirected(split_runner, client):
+    """Test run shows the generated plan in stderr if stdout is redirected to a file."""
+    result = split_runner.invoke(cli, ["run", "--verbose", "--name", "echo-command", "echo", "data"], stdout="output")
+
+    assert 0 == result.exit_code
+    assert "Name:" not in (client.path / "output").read_text()
+    assert "Name: echo-command" in result.stderr
+
+
+def test_run_prints_plan_when_stderr_redirected(split_runner, client):
+    """Test run shows the generated plan in stdout if stderr is redirected to a file."""
+    result = split_runner.invoke(cli, ["run", "--verbose", "--name", "echo-command", "echo", "data"], stderr="output")
+
+    assert 0 == result.exit_code
+    assert "Name:" not in (client.path / "output").read_text()
+    assert "Name: echo-command" in result.output
+
+
+def test_run_prints_nothing_when_both_redirected(split_runner, client):
+    """Test run doesn't print the plan if both stdout and stderr are redirected to a file."""
+    result = split_runner.invoke(cli, ["run", "--verbose", "echo", "data"], stdout="out", stderr="err")
+
+    assert 0 == result.exit_code
+    assert "Name:" not in (client.path / "out").read_text()
+    assert "Name:" not in (client.path / "err").read_text()

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -27,7 +27,6 @@ from pathlib import Path
 from time import time
 
 import pytest
-from click.testing import CliRunner
 
 from renku import __version__
 from renku.cli import cli
@@ -431,11 +430,9 @@ def test_status_with_submodules(isolated_runner, monkeypatch, project_init):
     assert 0 == result.exit_code, format_result_exception(result)
 
 
-def test_status_consistency(client, project):
+def test_status_consistency(client, split_runner):
     """Test if the renku status output is consistent when running the
     command from directories other than the repository root."""
-    runner = CliRunner(mix_stderr=False)
-
     os.mkdir("somedirectory")
     with open("somedirectory/woop", "w") as fp:
         fp.write("woop")
@@ -443,7 +440,7 @@ def test_status_consistency(client, project):
     client.repository.add("somedirectory/woop")
     client.repository.commit("add woop")
 
-    result = runner.invoke(cli, ["run", "cp", "somedirectory/woop", "somedirectory/meeh"])
+    result = split_runner.invoke(cli, ["run", "cp", "somedirectory/woop", "somedirectory/meeh"])
     assert 0 == result.exit_code, format_result_exception(result)
 
     with open("somedirectory/woop", "w") as fp:
@@ -452,9 +449,9 @@ def test_status_consistency(client, project):
     client.repository.add("somedirectory/woop")
     client.repository.commit("fix woop")
 
-    base_result = runner.invoke(cli, ["status"])
+    base_result = split_runner.invoke(cli, ["status"])
     os.chdir("somedirectory")
-    comp_result = runner.invoke(cli, ["status"])
+    comp_result = split_runner.invoke(cli, ["status"])
 
     assert 1 == base_result.exit_code, format_result_exception(base_result)
     assert 1 == comp_result.exit_code, format_result_exception(comp_result)

--- a/tests/fixtures/runners.py
+++ b/tests/fixtures/runners.py
@@ -48,11 +48,13 @@ class OutputStreamProxy:
     def write(self, value: str):
         """Write to the output stream."""
         # NOTE: Disabled the write if stream is a TTY to avoid cluttering the screen during tests.
-        if self._stream.isatty():
-            self._buffer += value.encode("utf-8")
-            return len(value)
-        else:
-            return self._stream.write(value)
+        if not self._stream.isatty():
+            self._stream.write(value)
+
+        value = value.encode("utf-8")
+        self._buffer += value
+
+        return len(value)
 
     def getvalue(self) -> bytes:
         """Return everything that has been written to the stream."""

--- a/tests/fixtures/runners.py
+++ b/tests/fixtures/runners.py
@@ -47,11 +47,9 @@ class OutputStreamProxy:
 
     def write(self, value: str):
         """Write to the output stream."""
-        value = value.encode("utf-8")
-
         # NOTE: Disabled the write if stream is a TTY to avoid cluttering the screen during tests.
         if self._stream.isatty():
-            self._buffer += value
+            self._buffer += value.encode("utf-8")
             return len(value)
         else:
             return self._stream.write(value)

--- a/tests/fixtures/runners.py
+++ b/tests/fixtures/runners.py
@@ -16,10 +16,98 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Renku common configurations."""
-import subprocess
-import time
 
+import contextlib
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import IO, Any, Mapping, Optional, Sequence, Union
+
+import click
 import pytest
+from click.testing import CliRunner, Result
+
+
+class OutputStreamProxy:
+    """A proxy class to allow reading from stdout/stderr objects."""
+
+    def __init__(self, stream):
+        self._stream = stream
+        self._buffer: bytes = b""
+
+    def __getattr__(self, name):
+        return getattr(self._stream, name)
+
+    def __setattr__(self, name, value):
+        if name == "_stream":
+            super().__setattr__(name, value)
+        else:
+            setattr(self._stream, name, value)
+
+    def write(self, value: str):
+        """Write to the output stream."""
+        self._buffer += value.encode("utf-8")
+        # NOTE: Disabled the actual write to avoid cluttering the screen during tests.
+        # self._stream.write(value)
+
+    def getvalue(self):
+        """Return everything that has been written to the stream."""
+        return self._buffer
+
+
+class RenkuRunner(CliRunner):
+    """Custom CliRunner that allows passing stdout and stderr to the ``invoke`` method."""
+
+    @contextlib.contextmanager
+    def isolation(self, input=None, env=None, color: bool = False):
+        """See ``click.testing.CliRunner::isolation``."""
+        # Preserve original stdout and stderr
+        stdout = OutputStreamProxy(sys.stdout)
+        stderr = stdout if self.mix_stderr else OutputStreamProxy(sys.stderr)
+
+        # NOTE: CliRunner.isolation replaces original stdout and stderr with BytesIO so that it can read program
+        # outputs from them. This causes Renku CLI to create custom terminal (since stdout and stderr are not tty)
+        # and therefore, tests fail because nothing is printed to the outputs. We use a proxy around the original
+        # stderr and stdout so that we can read from them without a need for BytesIO objects.
+        with super().isolation(input=input, env=env, color=color):
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                yield stdout, stderr
+
+    def invoke(
+        self,
+        cli: click.BaseCommand,
+        args: Optional[Union[str, Sequence[Union[Path, str]]]] = None,
+        input: Optional[Union[str, bytes, IO]] = None,
+        env: Optional[Mapping[str, Optional[str]]] = None,
+        catch_exceptions: bool = True,
+        color: bool = False,
+        stdin: Optional[Union[str, Path, IO]] = None,
+        stdout: Optional[Union[str, Path, IO]] = None,
+        stderr: Optional[Union[str, Path, IO]] = None,
+        **extra: Any,
+    ) -> Result:
+        """See ``click.testing.CliRunner::invoke``."""
+        from renku.core.utils.contexts import Isolation
+        from renku.core.utils.util import to_string
+
+        assert not input or not stdin, "Cannot set both ``stdin`` and ``input``"
+
+        if isinstance(args, Path):
+            args = str(args)
+        elif not isinstance(args, str):
+            args = [to_string(a) for a in args]
+
+        with Isolation(stdout=stdout, stderr=stderr):
+            return super().invoke(
+                cli=cli,
+                args=args,
+                input=stdin or input,
+                env=env,
+                catch_exceptions=catch_exceptions,
+                color=color,
+                **extra,
+            )
 
 
 @pytest.fixture()
@@ -53,9 +141,13 @@ def run_shell():
 @pytest.fixture()
 def runner():
     """Create a runner on isolated filesystem."""
-    from click.testing import CliRunner
+    return RenkuRunner()
 
-    return CliRunner()
+
+@pytest.fixture()
+def split_runner():
+    """A RenkuRunner with split stdout and stderr streams."""
+    return RenkuRunner(mix_stderr=False)
 
 
 @pytest.fixture()
@@ -81,8 +173,6 @@ def run(runner, capsys):
 @pytest.fixture()
 def isolated_runner():
     """Create a runner on isolated filesystem."""
-    from click.testing import CliRunner
-
-    runner_ = CliRunner()
+    runner_ = RenkuRunner()
     with runner_.isolated_filesystem():
         yield runner_

--- a/tests/fixtures/runners.py
+++ b/tests/fixtures/runners.py
@@ -47,11 +47,16 @@ class OutputStreamProxy:
 
     def write(self, value: str):
         """Write to the output stream."""
-        self._buffer += value.encode("utf-8")
-        # NOTE: Disabled the actual write to avoid cluttering the screen during tests.
-        # self._stream.write(value)
+        value = value.encode("utf-8")
 
-    def getvalue(self):
+        # NOTE: Disabled the write if stream is a TTY to avoid cluttering the screen during tests.
+        if self._stream.isatty():
+            self._buffer += value
+            return len(value)
+        else:
+            return self._stream.write(value)
+
+    def getvalue(self) -> bytes:
         """Return everything that has been written to the stream."""
         return self._buffer
 

--- a/tests/service/fixtures/service_integration.py
+++ b/tests/service/fixtures/service_integration.py
@@ -199,13 +199,13 @@ def svc_protected_old_repo(svc_synced_client, it_protected_repo_url):
 @pytest.fixture()
 def local_remote_repository(svc_client, tmp_path, mock_redis, identity_headers, real_sync):
     """Client with a local remote to test pushes."""
-    from click.testing import CliRunner
     from marshmallow import pre_load
 
     from renku.cli import cli
     from renku.core.utils.contexts import chdir
     from renku.service.config import PROJECT_CLONE_NO_DEPTH
     from renku.service.serializers import cache
+    from tests.fixtures.runners import RenkuRunner
 
     # NOTE: prevent service from adding an auth token as it doesn't work with local repos
     def _no_auth_format(self, data, **kwargs):
@@ -244,7 +244,7 @@ def local_remote_repository(svc_client, tmp_path, mock_redis, identity_headers, 
                 global_config.set_value("user", "email", "renku@datascience.ch")
 
             # NOTE: init "remote" repo
-            runner = CliRunner()
+            runner = RenkuRunner()
             with chdir(remote_repo_checkout_path):
 
                 result = runner.invoke(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -136,7 +136,12 @@ def format_result_exception(result):
     else:
         stacktrace = ""
 
-    return f"Stack Trace:\n{stacktrace}\n\nOutput:\n{result.output}"
+    try:
+        stderr = f"\n{result.stderr}"
+    except ValueError:
+        stderr = ""
+
+    return f"Stack Trace:\n{stacktrace}\n\nOutput:\n{result.output + stderr}"
 
 
 def load_dataset(name: str) -> Optional[Dataset]:


### PR DESCRIPTION
# Description

Adds a `--verbose` flag to the `renku run` command that prints the generated plan after execution.

Fixes #2732 
