### PR TITLE
fix(workflow): crash with external files in a command

### DIFF
--- a/renku/core/dataset/dataset_add.py
+++ b/renku/core/dataset/dataset_add.py
@@ -248,10 +248,9 @@ def _create_destination_directory(
     # what will be its name
     dataset_datadir.mkdir(parents=True, exist_ok=True)
 
-    destination = destination or Path(".")
-    destination = cast(Path, get_relative_path(destination, base=dataset_datadir, strict=True))
-    destination = dataset_datadir / destination
-    return cast(Path, destination)
+    destination = destination or ""
+    relative_path = cast(str, get_relative_path(destination, base=dataset_datadir, strict=True))
+    return dataset_datadir / relative_path
 
 
 def _check_ignored_files(client: "LocalClient", files_to_commit: Set[str], files: List[Dict]):
@@ -365,7 +364,7 @@ def _add_from_git(
         if not sources:
             return
         for source in sources:
-            if get_relative_path(path=source, base=repository.path) is None:
+            if not is_subpath(path=source, base=repository.path):
                 raise errors.ParameterError(f"Path '{source}' is not within the repository")
 
     def get_paths_from_remote_repo() -> Set[Path]:

--- a/renku/core/util/os.py
+++ b/renku/core/util/os.py
@@ -57,11 +57,11 @@ def get_safe_relative_path(path: Union[Path, str], base: Union[Path, str]) -> Pa
         raise ValueError(f"Path '{path}' is not with base directory '{base}'")
 
 
-def get_relative_path(path: Union[Path, str], base: Union[Path, str], strict: bool = False) -> Optional[Path]:
+def get_relative_path(path: Union[Path, str], base: Union[Path, str], strict: bool = False) -> Optional[str]:
     """Return a relative path to the base if path is within base without resolving symlinks."""
     try:
         absolute_path = get_absolute_path(path=path, base=base)
-        return Path(absolute_path).relative_to(base)
+        return str(Path(absolute_path).relative_to(base))
     except ValueError:
         if strict:
             raise errors.ParameterError(f"File {path} is not within path {base}")
@@ -83,7 +83,7 @@ def get_relative_paths(base: Union[Path, str], paths: Sequence[Union[Path, str]]
         if relative_path is None:
             raise errors.ParameterError(f"Path '{path}' is not within base path '{base}'")
 
-        relative_paths.append(str(relative_path))
+        relative_paths.append(relative_path)
 
     return relative_paths
 

--- a/renku/data/shacl_shape.json
+++ b/renku/data/shacl_shape.json
@@ -152,6 +152,9 @@
                   },
                   {
                      "sh:pattern": "mailto:[^@\\s]+@\\S+\\.\\S+"
+                  },
+                  {
+                     "sh:pattern": "http(s)?://[\\S]*orcid.org/[0-9-]+"
                   }
                ]
             },
@@ -370,6 +373,9 @@
                   },
                   {
                      "sh:pattern": "mailto:[^@\\s]+@\\S+\\.\\S+"
+                  },
+                  {
+                     "sh:pattern": "http(s)?://[\\S]*orcid.org/[0-9-]+"
                   }
                ]
             },

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -120,8 +120,8 @@ def test_run_metadata(renku_cli, runner, client, client_database_injection_manag
     assert 0 == result.exit_code, format_result_exception(result)
 
 
-def test_run_external_file(renku_cli, runner, client, client_database_injection_manager, tmpdir):
-    """Test run with workflow metadata."""
+def test_run_with_outside_files(renku_cli, runner, client, client_database_injection_manager, tmpdir):
+    """Test run with files that are outside the project."""
 
     external_file = tmpdir.join("file_1")
     external_file.write(str(1))
@@ -265,3 +265,15 @@ def test_run_prints_plan_when_stderr_redirected(split_runner, client):
     assert 0 == result.exit_code, format_result_exception(result)
     assert "Name: echo-command" in (client.path / "output").read_text()
     assert "Name:" not in result.output
+
+
+def test_run_with_external_files(split_runner, client, directory_tree):
+    """Test run commands that use external files."""
+    assert 0 == split_runner.invoke(cli, ["dataset", "add", "-c", "--external", "my-dataset", directory_tree]).exit_code
+
+    path = client.path / "data" / "my-dataset" / "directory_tree" / "file1"
+
+    result = split_runner.invoke(cli, ["run", "tail", path], stdout="output")
+
+    assert 0 == result.exit_code, format_result_exception(result)
+    assert "file1" in (client.path / "output").read_text()

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -490,3 +490,21 @@ def test_update_with_execute(runner, client, renku_cli, client_database_injectio
 
     assert "content_aeven more modified\n" == (client.path / output1).read_text()
     assert "content_beven more modified\n" == (client.path / output2).read_text()
+
+
+def test_update_with_external_files(split_runner, client, directory_tree):
+    """Test update commands that use external files."""
+    assert 0 == split_runner.invoke(cli, ["dataset", "add", "-c", "--external", "my-dataset", directory_tree]).exit_code
+
+    path = client.path / "data" / "my-dataset" / "directory_tree" / "file1"
+
+    assert 0 == split_runner.invoke(cli, ["run", "tail", path], stdout="output").exit_code
+
+    (directory_tree / "file1").write_text("updated file1")
+
+    assert 0 == split_runner.invoke(cli, ["dataset", "update", "--all"]).exit_code
+
+    result = split_runner.invoke(cli, ["update", "--all"])
+
+    assert 0 == result.exit_code, format_result_exception(result)
+    assert "updated file1" in (client.path / "output").read_text()


### PR DESCRIPTION
# Description

Fixes an error where using external files in `renku run` caused a crash.
Allows orcid.org ids in SHACL.

Fixes #2796 
