### PR TITLE
chore(refactor): make entity mandatory on DatasetFile

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -696,7 +696,7 @@ python-dateutil = ">=2.7"
 
 [[package]]
 name = "frozendict"
-version = "2.3.0"
+version = "2.3.1"
 description = "A simple immutable dictionary"
 category = "main"
 optional = false
@@ -1417,14 +1417,14 @@ test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]
 name = "pyparsing"
-version = "3.0.7"
-description = "Python parsing module"
+version = "3.0.8"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pyreadline"
@@ -1463,7 +1463,7 @@ jsonld = ["rdflib-jsonld (>=0.4.0,<0.6)"]
 
 [[package]]
 name = "pyte"
-version = "0.8.0"
+version = "0.8.1"
 description = "Simple VTXXX-compatible terminal emulator."
 category = "main"
 optional = true
@@ -2486,15 +2486,15 @@ uvloop = ["uvloop (>=0.5.1)"]
 
 [[package]]
 name = "zipp"
-version = "3.7.0"
+version = "3.8.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "zodb"
@@ -2595,7 +2595,7 @@ toil = ["toil"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "3ad0d6f7f93c0b349e0c26f3952d3834c18b00d6e16a4fb1f47697587c917e67"
+content-hash = "4a652118d4a8e0d4cbbcf02b09215ec7016c359b6b31af0cc80fbb19b0e973e5"
 
 [metadata.files]
 addict = [
@@ -2970,23 +2970,23 @@ freezegun = [
     {file = "freezegun-1.1.0.tar.gz", hash = "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3"},
 ]
 frozendict = [
-    {file = "frozendict-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e18e2abd144a9433b0a8334582843b2aa0d3b9ac8b209aaa912ad365115fe2e1"},
-    {file = "frozendict-2.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96dc7a02e78da5725e5e642269bb7ae792e0c9f13f10f2e02689175ebbfedb35"},
-    {file = "frozendict-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:752a6dcfaf9bb20a7ecab24980e4dbe041f154509c989207caf185522ef85461"},
-    {file = "frozendict-2.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:5346d9fc1c936c76d33975a9a9f1a067342963105d9a403a99e787c939cc2bb2"},
-    {file = "frozendict-2.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60dd2253f1bacb63a7c486ec541a968af4f985ffb06602ee8954a3d39ec6bd2e"},
-    {file = "frozendict-2.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:b2e044602ce17e5cd86724add46660fb9d80169545164e763300a3b839cb1b79"},
-    {file = "frozendict-2.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a27a69b1ac3591e4258325108aee62b53c0eeb6ad0a993ae68d3c7eaea980420"},
-    {file = "frozendict-2.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f45ef5f6b184d84744fff97b61f6b9a855e24d36b713ea2352fc723a047afa5"},
-    {file = "frozendict-2.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2d3f5016650c0e9a192f5024e68fb4d63f670d0ee58b099ed3f5b4c62ea30ecb"},
-    {file = "frozendict-2.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6cf605916f50aabaaba5624c81eb270200f6c2c466c46960237a125ec8fe3ae0"},
-    {file = "frozendict-2.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6da06e44904beae4412199d7e49be4f85c6cc168ab06b77c735ea7da5ce3454"},
-    {file = "frozendict-2.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:1f34793fb409c4fa70ffd25bea87b01f3bd305fb1c6b09e7dff085b126302206"},
-    {file = "frozendict-2.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fd72494a559bdcd28aa71f4aa81860269cd0b7c45fff3e2614a0a053ecfd2a13"},
-    {file = "frozendict-2.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00ea9166aa68cc5feed05986206fdbf35e838a09cb3feef998cf35978ff8a803"},
-    {file = "frozendict-2.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:9ffaf440648b44e0bc694c1a4701801941378ba3ba6541e17750ae4b4aeeb116"},
-    {file = "frozendict-2.3.0-py3-none-any.whl", hash = "sha256:8578fe06815fcdcc672bd5603eebc98361a5317c1c3a13b28c6c810f6ea3b323"},
-    {file = "frozendict-2.3.0.tar.gz", hash = "sha256:da4231adefc5928e7810da2732269d3ad7b5616295b3e693746392a8205ea0b5"},
+    {file = "frozendict-2.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:63ababdd78eed2974aeec86518ea7a53187c0258118d25bc0ccbefc52c75a8d6"},
+    {file = "frozendict-2.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6b14817b2299c4902b4c5b2d17a6586c4a1ebf9601dec87cce217465e8aad3a"},
+    {file = "frozendict-2.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:99bb1c7104ac936e8ab47e046c2b96576918b20074f4b9cfd22aa0741d338395"},
+    {file = "frozendict-2.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dac109414f63f8b5efa2768ea143d15679734e7b9c04f0d7b0898e801ff71d3f"},
+    {file = "frozendict-2.3.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f8c88ff2cc48630c144d6a6dd619a14e2d5c695900373b262ffc89346d42b41"},
+    {file = "frozendict-2.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:7835db3e7e21ae93540c11606724a9476f020a637eb9f5651c7947d7a9fc13c5"},
+    {file = "frozendict-2.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e1b281ab8b9ad0a5b2dfb057c964561813755412c17d07e4052dd286f6bb4646"},
+    {file = "frozendict-2.3.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46985ff5ea173e9281b8a9c59badcd46c2630704b3ec2549a93d5b279c37d4a8"},
+    {file = "frozendict-2.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:286ebd679638fe10b9ff394847108ade2bc6da42435b646e374138e573a2207c"},
+    {file = "frozendict-2.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c17d40b232ae0d506e2c550ff77a54d932e6340aab639e5369449122bf148159"},
+    {file = "frozendict-2.3.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e711aa962f6d41eabb98493421eab4306c26c8448e5bd61aca8c83dc8a6f728b"},
+    {file = "frozendict-2.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:b827a8b8c2356bc7d73228e019b7b3e561fe283d5a614f6085bdd65e6b41cabf"},
+    {file = "frozendict-2.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ac8781c7eca5f01a7097d20c5ca05e5b30220560a7d684165b7d0dfadd7c0352"},
+    {file = "frozendict-2.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b53d518e5542d1ac1843877657f7ffe5fc1b7ee8d62e2e4c18d0f22c34923e61"},
+    {file = "frozendict-2.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:75bf7995e3574e814229a95d094522866523e34d93327d063d3d6f97ec7d48df"},
+    {file = "frozendict-2.3.1-py3-none-any.whl", hash = "sha256:1fb6ee91b0bcd35068911cf46ea7ce1bde6a0e605acf5e8852d2a78cc1192cc9"},
+    {file = "frozendict-2.3.1.tar.gz", hash = "sha256:bc91c69233eb916bb6ebc40988b6d849735770240efc9c60be45b4ab919c1bde"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
@@ -3642,8 +3642,8 @@ pyopenssl = [
     {file = "pyOpenSSL-22.0.0.tar.gz", hash = "sha256:660b1b1425aac4a1bea1d94168a85d99f0b3144c869dd4390d27629d0087f1bf"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
-    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
+    {file = "pyparsing-3.0.8-py3-none-any.whl", hash = "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"},
+    {file = "pyparsing-3.0.8.tar.gz", hash = "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954"},
 ]
 pyreadline = [
     {file = "pyreadline-2.1.win-amd64.exe", hash = "sha256:9ce5fa65b8992dfa373bddc5b6e0864ead8f291c94fbfec05fbd5c836162e67b"},
@@ -3659,7 +3659,7 @@ pyshacl = [
     {file = "pyshacl-0.17.2.tar.gz", hash = "sha256:46f31c7a7f7298aa5b483d92dbc850ff79a144d26f1f41e83267ed84b4d6ae23"},
 ]
 pyte = [
-    {file = "pyte-0.8.0.tar.gz", hash = "sha256:7e71d03e972d6f262cbe8704ff70039855f05ee6f7ad9d7129df9c977b5a88c5"},
+    {file = "pyte-0.8.1-py3-none-any.whl", hash = "sha256:d760ea9a7d455d179d9d7a4288fac3d231190b5226715f1fe8c62547bed9b9aa"},
 ]
 pytest = [
     {file = "pytest-7.0.1-py3-none-any.whl", hash = "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db"},
@@ -4289,8 +4289,8 @@ zeo = [
     {file = "ZEO-5.3.0.tar.gz", hash = "sha256:ffc54334f8384d6faf1693dce823c0a5fcd429fa015c47d2d49d1bd689997157"},
 ]
 zipp = [
-    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
-    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
+    {file = "zipp-3.8.0-py3-none-any.whl", hash = "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"},
+    {file = "zipp-3.8.0.tar.gz", hash = "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad"},
 ]
 zodb = [
     {file = "ZODB-5.6.0-py2.py3-none-any.whl", hash = "sha256:b34fe2515c4f18cf247989b891254a64a0835c7d80a450f461efe8fd843e18d0"},
@@ -4304,12 +4304,9 @@ zodbpickle = [
     {file = "zodbpickle-2.2.0-cp27-cp27m-win32.whl", hash = "sha256:45bb1b0701d7fffbf0a594a5ea4572fedd60b084a579f9605054fba9c832cae7"},
     {file = "zodbpickle-2.2.0-cp27-cp27m-win_amd64.whl", hash = "sha256:1f148b90c562af56cbb385d1b897aa6126acc7aa0048dd4a0e0ec4a3be87ba57"},
     {file = "zodbpickle-2.2.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:2191008a102785396eced7f026f7e9f5857afc3f53a76c4d449e90e1b3689afd"},
-    {file = "zodbpickle-2.2.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:78cfb28b39b815daee1beac37f8966e3e172313b47b9bfc3713fff1dced04942"},
     {file = "zodbpickle-2.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6c1dc9460bf2d732ebc3bef086a129a0ca2d10c9c7646ccab7c21a5d6ad4111"},
     {file = "zodbpickle-2.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0e7ba6e065a1a29d8de8cc4b5e2bdacaeaa3927833892df6bfbbf6d820478227"},
     {file = "zodbpickle-2.2.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e0640e426416fb9efa23b2b2a08fe5472fa361de78322e444072f4d73dc1996e"},
-    {file = "zodbpickle-2.2.0-cp310-cp310-win32.whl", hash = "sha256:cae05054de6eb5cd708ff9275db7cc99410328541f82569215c3046805287cc4"},
-    {file = "zodbpickle-2.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:4882612fa8b4177a914dca001aa4126f3bfba15102df017752b794e718caedd6"},
     {file = "zodbpickle-2.2.0-cp35-cp35m-win32.whl", hash = "sha256:e33639e1db54b0d049cd50b924cc3ce61f62bbab2f68fc0831805cacef02cad2"},
     {file = "zodbpickle-2.2.0-cp35-cp35m-win_amd64.whl", hash = "sha256:5811d503db8995642d9dca18a396c5054366d26e1e633b249e151f80d88151b0"},
     {file = "zodbpickle-2.2.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:d163877427b574633c867f981c7657c595e293a4bf3e5639d895b1e644bc526a"},
@@ -4331,7 +4328,6 @@ zodbpickle = [
     {file = "zodbpickle-2.2.0-cp38-cp38-win32.whl", hash = "sha256:3f33cd0f3c941f65ef65568f32a5552d54daead0e7d3039e28f9508be800c46e"},
     {file = "zodbpickle-2.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:b3360b47b9968f16519edc9aaca49689bd1ee4926fb5cc1e6088fc20355238fb"},
     {file = "zodbpickle-2.2.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:1706674abc6fc63d0db81ba3bf641c088591f89927058c1915d316873cd477d7"},
-    {file = "zodbpickle-2.2.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:84c65732868b29bde9bcde9611b62a072f4ebae6907467a1713df3c5f00924ca"},
     {file = "zodbpickle-2.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff95ffabbee1751ae793f969fadcf1a78244bb451d1274ac49aaf62dba7379f7"},
     {file = "zodbpickle-2.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:3bc7adcfe38b9632876f3b993d19f12bd69ef801789faa5f2384b88201891023"},
     {file = "zodbpickle-2.2.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8126ab6e18478a5aa4b4fee066bdf3615a61f91924492162c471453a0340877c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ python = "^3.7.1"
 apispec = { version = "<5.2.0,>=4.0.0", optional = true }
 apispec-webframeworks = { version = "<0.6,>=0.5.2", optional = true }
 appdirs = "<=1.4.4,>=1.4.3"
-attrs = "<21.5.0,>=19.3.0"
+attrs = "<21.5.0,>=21.1.0"
 black = { version = "==22.1.0", optional = true }
 calamus = "<0.4,>=0.3.13"
 check-manifest = { version = "<0.48,>=0.37", optional = true }

--- a/renku/command/graph.py
+++ b/renku/command/graph.py
@@ -181,7 +181,8 @@ def _get_graph_for_all_objects(
 
         current_dataset = dataset
         while current_dataset.is_derivation():
-            current_dataset = dataset_gateway.get_by_id(current_dataset.derived_from.url_id)  # type: ignore
+            assert current_dataset.derived_from is not None
+            current_dataset = dataset_gateway.get_by_id(current_dataset.derived_from.value)
             objects.append(current_dataset)
 
     return _convert_entities_to_graph(objects, project)

--- a/renku/command/log.py
+++ b/renku/command/log.py
@@ -66,7 +66,8 @@ def _log(
             yield current_dataset
 
             if current_dataset.is_derivation():
-                current_dataset = dataset_gateway.get_by_id(current_dataset.derived_from.url_id)  # type: ignore
+                assert current_dataset.derived_from is not None
+                current_dataset = dataset_gateway.get_by_id(current_dataset.derived_from.value)
             else:
                 return
 

--- a/renku/command/view_model/dataset.py
+++ b/renku/command/view_model/dataset.py
@@ -49,7 +49,7 @@ class DatasetFileViewModel:
     def from_dataset_file(cls, dataset_file: DatasetFile, dataset: Dataset) -> "DatasetFileViewModel":
         """Create view model from ``DatasetFile``."""
         return cls(
-            path=dataset_file.entity.path,  # type: ignore
+            path=dataset_file.entity.path,
             source=dataset_file.source,
             external=dataset_file.is_external,
             deleted=dataset_file.date_removed is not None,

--- a/renku/command/view_model/log.py
+++ b/renku/command/view_model/log.py
@@ -221,14 +221,14 @@ class LogViewModel:
                 new_files = current_files
 
             descriptions.append(f"{len(new_files)} file(s) added")
-            details.files_added = [str(f.entity.path) for f in new_files]  # type: ignore
+            details.files_added = [str(f.entity.path) for f in new_files]
             details.modified = True
 
         if previous_files and {f.id for f in previous_files}.difference({f.id for f in current_files}):
             # NOTE: Files removed
             removed_files = previous_files - current_files
             descriptions.append(f"{len(removed_files)} file(s) removed")
-            details.files_removed = [str(f.entity.path) for f in removed_files]  # type: ignore
+            details.files_removed = [str(f.entity.path) for f in removed_files]
             details.modified = True
 
         if not previous_dataset:

--- a/renku/core/dataset/dataset.py
+++ b/renku/core/dataset/dataset.py
@@ -34,6 +34,7 @@ from renku.core.dataset.constant import renku_dataset_images_path, renku_pointer
 from renku.core.dataset.datasets_provenance import DatasetsProvenance
 from renku.core.dataset.pointer_file import create_external_file, is_external_file_updated, update_external_file
 from renku.core.dataset.providers import ProviderFactory
+from renku.core.dataset.providers.models import ProviderDataset, ProviderDatasetFile
 from renku.core.dataset.request_model import ImageRequestModel
 from renku.core.dataset.tag import add_dataset_tag, prompt_access_token, prompt_tag_selection
 from renku.core.interface.client_dispatcher import IClientDispatcher
@@ -438,6 +439,7 @@ def import_dataset(
         gitlab_token: Gitlab OAuth2 token (Default value = None).
     """
     from renku.core.dataset.dataset_add import add_data_to_dataset
+    from renku.core.dataset.providers.renku import RenkuProvider, RenkuRecordSerializer
 
     client = client_dispatcher.current_client
 
@@ -445,10 +447,12 @@ def import_dataset(
     if err and provider is None:
         raise errors.ParameterError(f"Could not process '{uri}'.\n{err}")
 
+    assert provider is not None
+
     try:
         record = provider.find_record(uri, gitlab_token=gitlab_token)
-        dataset = record.as_dataset(client)
-        files = record.files_info
+        provider_dataset: ProviderDataset = record.as_dataset(client)
+        files: List[ProviderDatasetFile] = record.files_info
         total_size = 0
 
         if not yes:
@@ -487,20 +491,22 @@ def import_dataset(
     if not files:
         raise errors.ParameterError(f"Dataset '{uri}' has no files.")
 
-    if not provider.is_git_based:
-        if not name:
-            name = generate_default_name(dataset.title, dataset.version)
+    new_dataset: Dataset
 
-        dataset.same_as = Url(url_id=remove_credentials(uri))
-        if is_doi(dataset.identifier):
-            dataset.same_as = Url(url_str=urllib.parse.urljoin("https://doi.org", dataset.identifier))
+    if not isinstance(provider, RenkuProvider):
+        if not name:
+            name = generate_default_name(provider_dataset.title, provider_dataset.version)
+
+        provider_dataset.same_as = Url(url_id=remove_credentials(uri))
+        if is_doi(provider_dataset.identifier):
+            provider_dataset.same_as = Url(url_str=urllib.parse.urljoin("https://doi.org", provider_dataset.identifier))
 
         urls, names = zip(*[(f.source, f.filename) for f in files])
-        dataset = add_data_to_dataset(
+        new_dataset = add_data_to_dataset(
             urls=urls,
             dataset_name=name,
             create=not previous_dataset,
-            with_metadata=dataset,
+            with_metadata=provider_dataset,
             force=True,
             extract=extract,
             all_at_once=True,
@@ -511,37 +517,40 @@ def import_dataset(
         )
 
         if previous_dataset:
-            dataset = _update_datasets_metadata(dataset, previous_dataset, delete, dataset.same_as)
+            new_dataset = _update_datasets_metadata(new_dataset, previous_dataset, delete, new_dataset.same_as)
 
-        if dataset.version:
-            tag_name = re.sub("[^a-zA-Z0-9.-_]", "_", dataset.version)
+        if provider_dataset.version:
+            tag_name = re.sub("[^a-zA-Z0-9.-_]", "_", provider_dataset.version)
             add_dataset_tag(
-                dataset_name=dataset.name, tag=tag_name, description=f"Tag {dataset.version} created by renku import"
+                dataset_name=new_dataset.name,
+                tag=tag_name,
+                description=f"Tag {provider_dataset.version} created by renku import",
             )
     else:
-        name = name or dataset.name
+        record = cast(RenkuRecordSerializer, record)
+        name = name or provider_dataset.name
 
-        dataset.same_as = Url(url_id=record.latest_uri)
+        provider_dataset.same_as = Url(url_id=record.latest_uri)
 
-        if not dataset.data_dir:
-            raise errors.OperationError(f"Data directory for dataset must be set: {dataset.name}")
+        if not provider_dataset.data_dir:
+            raise errors.OperationError(f"Data directory for dataset must be set: {provider_dataset.name}")
 
         sources = []
 
         if record.datadir_exists:
-            sources = [f"{dataset.data_dir}/*"]
+            sources = [f"{provider_dataset.data_dir}/*"]
 
-        for file in dataset.files:
+        for file in files:
             try:
-                Path(file.entity.path).relative_to(dataset.data_dir)
+                Path(file.path).relative_to(provider_dataset.data_dir)
             except ValueError:  # Files that are not in dataset's data directory
-                sources.append(file.entity.path)
+                sources.append(file.path)
 
         new_dataset = add_data_to_dataset(
             urls=[record.project_url],
             dataset_name=name,
             sources=sources,
-            with_metadata=dataset,
+            with_metadata=provider_dataset,
             create=not previous_dataset,
             overwrite=True,
             repository=record.repository,
@@ -549,10 +558,9 @@ def import_dataset(
         )
 
         if previous_dataset:
-            _update_datasets_metadata(new_dataset, previous_dataset, delete, dataset.same_as)
+            _update_datasets_metadata(new_dataset, previous_dataset, delete, provider_dataset.same_as)
 
-    if provider.supports_images:
-        record.import_images(dataset)
+        record.import_images(new_dataset)
 
     database_dispatcher.current_database.commit()
 
@@ -1059,7 +1067,7 @@ def update_external_files(client: "LocalClient", records: List[DynamicProxy], dr
     """Update files linked to external storage.
 
     Args:
-        client("LocalClient"): The ``LocalCLient``.
+        client("LocalClient"): The ``LocalClient``.
         records(List[DynamicProxy]): File records to update.
         dry_run(bool): Whether to return a preview of what would be updated.
     """
@@ -1133,6 +1141,7 @@ def filter_dataset_files(
                 match = _include_exclude(path, include, exclude)
 
                 if creators:
+                    c: Person
                     dataset_creators = {c.name for c in dataset.creators}
                     match = match and creators.issubset(dataset_creators)
 

--- a/renku/core/dataset/providers/__init__.py
+++ b/renku/core/dataset/providers/__init__.py
@@ -16,9 +16,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Third party data registry integration."""
+
+from typing import TYPE_CHECKING, Optional, Tuple
 from urllib.parse import urlparse
 
 from renku.core.util.doi import is_doi
+
+if TYPE_CHECKING:
+    from renku.core.dataset.providers.api import ProviderApi
 
 
 class ProviderFactory:
@@ -35,7 +40,7 @@ class ProviderFactory:
         return {"OLOS": OLOSProvider, "Renku": RenkuProvider, "Zenodo": ZenodoProvider, "Dataverse": DataverseProvider}
 
     @staticmethod
-    def from_uri(uri):
+    def from_uri(uri) -> Tuple[Optional["ProviderApi"], str]:
         """Get provider type based on uri."""
         is_doi_ = is_doi(uri)
         if is_doi_ is None:
@@ -78,7 +83,7 @@ class ProviderFactory:
             return provider(is_doi=is_doi_), warning
 
     @staticmethod
-    def from_id(provider_id):
+    def from_id(provider_id) -> "ProviderApi":
         """Get provider type based on identifier."""
         provider = next((p for n, p in ProviderFactory.providers().items() if n.lower() == provider_id.lower()), None)
 

--- a/renku/core/dataset/providers/dataverse.py
+++ b/renku/core/dataset/providers/dataverse.py
@@ -16,13 +16,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Dataverse API integration."""
+
 import json
 import pathlib
 import re
 import urllib
 from pathlib import Path
 from string import Template
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, Dict
 from urllib import parse as urlparse
 
 import attr
@@ -30,7 +31,7 @@ from tqdm import tqdm
 
 from renku.command.command_builder import inject
 from renku.core import errors
-from renku.core.dataset.providers.api import ExporterApi, ProviderApi
+from renku.core.dataset.providers.api import ExporterApi, ProviderApi, ProviderRecordSerializerApi
 from renku.core.dataset.providers.dataverse_metadata_templates import (
     AUTHOR_METADATA_TEMPLATE,
     CONTACT_METADATA_TEMPLATE,
@@ -41,7 +42,6 @@ from renku.core.interface.client_dispatcher import IClientDispatcher
 from renku.core.util import communication
 from renku.core.util.doi import extract_doi, is_doi
 from renku.core.util.file_size import bytes_to_unit
-from renku.infrastructure.immutable import DynamicProxy
 
 if TYPE_CHECKING:
     from renku.core.dataset.providers.models import ProviderDataset
@@ -143,8 +143,6 @@ class DataverseProvider(ProviderApi):
 
     is_doi = attr.ib(default=False)
 
-    _accept = attr.ib(default="application/json")
-
     _server_url = attr.ib(default=None)
 
     _dataverse_name = attr.ib(default=None)
@@ -183,16 +181,7 @@ class DataverseProvider(ProviderApi):
         parsed = urlparse.urlparse(uri)
         return urlparse.parse_qs(parsed.query)["persistentId"][0]
 
-    def _make_request(self, uri):
-        """Execute network request."""
-        from renku.core.util import requests
-
-        response = requests.get(uri, headers={"Accept": self._accept})
-        if response.status_code != 200:
-            raise LookupError("record not found. Status: {}".format(response.status_code))
-        return response
-
-    def find_record(self, uri, **kwargs):
+    def find_record(self, uri, **kwargs) -> "DataverseRecordSerializer":
         """Retrieves a record from Dataverse.
 
         Args:
@@ -207,20 +196,16 @@ class DataverseProvider(ProviderApi):
             uri = doi.url
 
         uri = self._get_export_uri(uri)
+        response = _make_request(uri)
 
-        return self._get_record(uri)
+        return DataverseRecordSerializer(json=response.json(), uri=uri)
 
-    def _get_export_uri(self, uri):
+    @staticmethod
+    def _get_export_uri(uri):
         """Gets a dataverse api export URI from a dataverse entry."""
         record_id = DataverseProvider.record_id(uri)
         uri = make_records_url(record_id, uri)
         return uri
-
-    def _get_record(self, uri):
-        """Retrieve metadata and return ``DataverseRecordSerializer``."""
-        response = self._make_request(uri)
-
-        return DataverseRecordSerializer(json=response.json(), dataverse=self, uri=uri)
 
     def get_exporter(self, dataset, access_token):
         """Create export manager for given dataset."""
@@ -231,14 +216,14 @@ class DataverseProvider(ProviderApi):
     @inject.autoparams()
     def set_parameters(self, client_dispatcher: IClientDispatcher, *, dataverse_server, dataverse_name, **kwargs):
         """Set and validate required parameters for a provider."""
-        CONFIG_BASE_URL = "server_url"
+        config_base_url = "server_url"
 
         client = client_dispatcher.current_client
 
         if not dataverse_server:
-            dataverse_server = client.get_value("dataverse", CONFIG_BASE_URL)
+            dataverse_server = client.get_value("dataverse", config_base_url)
         else:
-            client.set_value("dataverse", CONFIG_BASE_URL, dataverse_server, global_only=True)
+            client.set_value("dataverse", config_base_url, dataverse_server, global_only=True)
 
         if not dataverse_server:
             raise errors.ParameterError("Dataverse server URL is required.")
@@ -250,35 +235,23 @@ class DataverseProvider(ProviderApi):
         self._dataverse_name = dataverse_name
 
 
-@attr.s
-class DataverseRecordSerializer:
+class DataverseRecordSerializer(ProviderRecordSerializerApi):
     """Dataverse record Serializer."""
 
-    _dataverse = attr.ib(default=None, kw_only=True)
-
-    _uri = attr.ib(default=None, kw_only=True)
-
-    _json = attr.ib(default=None, kw_only=True)
-
-    _files_info = attr.ib(default=None, kw_only=True)
+    def __init__(self, uri: str, json: Dict[str, Any]):
+        super().__init__(uri=uri)
+        self._json: Dict[str, Any] = json
 
     def is_last_version(self, uri):
         """Check if record is at last possible version."""
         return True
 
-    def _convert_json_property_name(self, property_name):
+    @staticmethod
+    def _convert_json_property_name(property_name):
         """Removes '@' and converts names to snake_case."""
         property_name = property_name.strip("@")
         property_name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", property_name)
         return re.sub("([a-z0-9])([A-Z])", r"\1_\2", property_name).lower()
-
-    @property
-    def files_info(self) -> List[DynamicProxy]:
-        """Return list of dataset file proxies.
-
-        This is only valid after a call to ``as_dataset``.
-        """
-        return self._files_info
 
     @property
     def files(self):
@@ -295,7 +268,7 @@ class DataverseRecordSerializer:
     def version(self):
         """Get the major and minor version of this dataset."""
         uri = make_versions_url(DataverseProvider.record_id(self._uri), self._uri)
-        response = self._dataverse._make_request(uri).json()
+        response = _make_request(uri).json()
         newest_version = response["data"][0]
         return "{}.{}".format(newest_version["versionNumber"], newest_version["versionMinorNumber"])
 
@@ -318,8 +291,7 @@ class DataverseRecordSerializer:
         from marshmallow import pre_load
 
         from renku.command.schema.agent import PersonSchema
-        from renku.core.dataset.providers.models import ProviderDataset, ProviderDatasetSchema
-        from renku.domain_model.dataset import DatasetFile
+        from renku.core.dataset.providers.models import ProviderDataset, ProviderDatasetFile, ProviderDatasetSchema
 
         class _DataverseDatasetSchema(ProviderDatasetSchema):
             """Schema for Dataverse datasets."""
@@ -358,22 +330,17 @@ class DataverseRecordSerializer:
             if creator.affiliation == "":
                 creator.affiliation = None
 
-        dataset_files = []
-        files_info = []
-        for file in files:
-            remote = file.remote_url
-            dataset_file = DatasetFile(entity=None, source=remote.geturl())
-            file_info = DynamicProxy(dataset_file)
-            file_info.filename = Path(file.name).name
-            file_info.checksum = ""
-            file_info.size_in_mb = bytes_to_unit(file.content_size, "mi")
-            file_info.filetype = file.file_format
-
-            dataset_files.append(dataset_file)
-            files_info.append(file_info)
-
-        dataset.dataset_files = dataset_files
-        self._files_info = files_info
+        self._files_info = [
+            ProviderDatasetFile(
+                source=file.remote_url.geturl(),
+                filename=Path(file.name).name,
+                checksum="",
+                size_in_mb=bytes_to_unit(file.content_size, "mi"),
+                filetype=file.file_format,
+                path="",
+            )
+            for file in files
+        ]
 
         return dataset
 
@@ -474,7 +441,8 @@ class DataverseExporter(ExporterApi):
         )
         return json.loads(metadata)
 
-    def _get_subject(self):
+    @staticmethod
+    def _get_subject():
         text_prompt = "Subject of this dataset: \n\n"
         text_prompt += "\n".join(f"{s}\t[{i}]" for i, s in enumerate(DATAVERSE_SUBJECTS, start=1))
         text_prompt += "\n\nSubject"
@@ -594,3 +562,13 @@ def _escape_json_string(value):
     if isinstance(value, str):
         return json.dumps(value)[1:-1]
     return value
+
+
+def _make_request(uri):
+    """Execute network request."""
+    from renku.core.util import requests
+
+    response = requests.get(uri, headers={"Accept": "application/json"})
+    if response.status_code != 200:
+        raise LookupError("record not found. Status: {}".format(response.status_code))
+    return response

--- a/renku/core/dataset/providers/doi.py
+++ b/renku/core/dataset/providers/doi.py
@@ -16,11 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """DOI API integration."""
+
 import urllib
 
-import attr
-
-from renku.core.dataset.providers.api import ProviderApi
+from renku.core.dataset.providers.api import ProviderApi, ProviderRecordSerializerApi
 from renku.core.errors import RenkuImportError
 from renku.core.util.doi import extract_doi, is_doi
 
@@ -29,54 +28,77 @@ DOI_BASE_URL = "https://dx.doi.org"
 
 def make_doi_url(doi):
     """Create URL to access DOI metadata."""
-    urlparts = urllib.parse.urlparse(doi)
-    if urlparts.scheme == "doi":
-        urlparts = urlparts._replace(scheme="")
-        doi = urlparts.geturl()
+    parsed_url = urllib.parse.urlparse(doi)
+    if parsed_url.scheme == "doi":
+        parsed_url = parsed_url._replace(scheme="")
+        doi = parsed_url.geturl()
     return urllib.parse.urljoin(DOI_BASE_URL, doi)
 
 
-@attr.s
-class DOIMetadataSerializer:
+class DOIMetadataSerializer(ProviderRecordSerializerApi):
     """Response from doi.org for DOI metadata."""
 
-    id = attr.ib(kw_only=True)
+    def __init__(
+        self,
+        id,
+        doi,
+        url,
+        abstract=None,
+        author=None,
+        categories=None,
+        container_title=None,
+        contributor=None,
+        copyright=None,
+        issued=None,
+        language=None,
+        publisher=None,
+        title=None,
+        type=None,
+        version=None,
+    ):
+        super().__init__(uri=url)
 
-    doi = attr.ib(kw_only=True)
+        self.id = id
+        self.doi = doi
 
-    url = attr.ib(kw_only=True)
+        self.abstract = abstract
+        self.author = author
+        self.categories = categories
+        self.container_title = container_title
+        self.contributor = contributor
+        self.copyright = copyright
+        self.issued = issued
+        self.language = language
+        self.publisher = publisher
+        self.title = title
+        self.type = type
+        self._version = version
 
-    type = attr.ib(kw_only=True, default=None)
+    @property
+    def version(self) -> str:
+        """Get record version."""
+        return self._version
 
-    categories = attr.ib(kw_only=True, default=None)
+    @property
+    def latest_uri(self) -> str:
+        """Get uri of the latest version."""
+        return self.url
 
-    author = attr.ib(kw_only=True, default=None)
+    def as_dataset(self, client):
+        """Deserialize this record to a ``ProviderDataset``."""
+        raise NotImplementedError
 
-    contributor = attr.ib(kw_only=True, default=None)
-
-    version = attr.ib(kw_only=True, default=None)
-
-    issued = attr.ib(kw_only=True, default=None)
-
-    title = attr.ib(kw_only=True, default=None)
-
-    abstract = attr.ib(kw_only=True, default=None)
-
-    language = attr.ib(kw_only=True, default=None)
-
-    publisher = attr.ib(kw_only=True, default=None)
-
-    container_title = attr.ib(kw_only=True, default=None)
-
-    copyright = attr.ib(kw_only=True, default=None)
+    def is_last_version(self, uri) -> bool:
+        """Check if record is at last possible version."""
+        return True
 
 
-@attr.s
 class DOIProvider(ProviderApi):
     """doi.org registry API provider."""
 
-    headers = attr.ib(default={"accept": "application/vnd.citationstyles.csl+json"})
-    timeout = attr.ib(default=3)
+    def __init__(self, headers=None, timeout=3):
+        self.timeout = timeout
+        self.headers = headers if headers is not None else {"accept": "application/vnd.citationstyles.csl+json"}
 
     @staticmethod
     def supports(uri):
@@ -106,7 +128,7 @@ class DOIProvider(ProviderApi):
 
         return response
 
-    def find_record(self, uri, client=None, **kwargs):
+    def find_record(self, uri, client=None, **kwargs) -> DOIMetadataSerializer:
         """Finds DOI record."""
         response = self._query(uri).json()
         return DOIProvider._serialize(response)

--- a/renku/core/dataset/providers/models.py
+++ b/renku/core/dataset/providers/models.py
@@ -27,15 +27,59 @@ class ProviderDataset(Dataset):
     def __init__(self, **kwargs):
         kwargs.setdefault("initial_identifier", "invalid-initial-id")
         super().__init__(**kwargs)
+        self.dataset_files = []  # TODO Make this a property
 
     @classmethod
-    def from_jsonld(cls, data, schema_class=None):
+    def from_jsonld(cls, data, schema_class=None) -> "ProviderDataset":
         """Create an instance from JSON-LD data."""
         assert isinstance(data, (dict, list)), f"Invalid data type: {data}"
 
         schema_class = schema_class or DatasetSchema
         self = schema_class(flattened=True).load(data)
         return self
+
+    @classmethod
+    def from_dataset(cls, dataset: Dataset) -> "ProviderDataset":
+        """Create an instance from a Dataset."""
+        return ProviderDataset(
+            annotations=dataset.annotations,
+            creators=dataset.creators,
+            dataset_files=[],
+            date_created=dataset.date_created,
+            date_published=dataset.date_published,
+            date_removed=dataset.date_removed,
+            derived_from=dataset.derived_from,
+            description=dataset.description,
+            id=dataset.id,
+            identifier=dataset.identifier,
+            images=dataset.images,
+            in_language=dataset.in_language,
+            initial_identifier=dataset.initial_identifier,
+            keywords=dataset.keywords,
+            license=dataset.license,
+            name=dataset.name,
+            project_id=dataset.project_id,
+            same_as=dataset.same_as,
+            title=dataset.title,
+            version=dataset.version,
+        )
+
+    @property
+    def files(self):
+        """Return list of existing files."""
+        raise NotImplementedError("ProviderDataset has no files.")
+
+
+class ProviderDatasetFile:
+    """Store metadata for dataset files that will be downloaded from a provider."""
+
+    def __init__(self, source: str, filename: str, checksum: str, size_in_mb: int, filetype: str, path: str):
+        self.source: str = source
+        self.filename: str = filename
+        self.checksum: str = checksum
+        self.size_in_mb: int = size_in_mb
+        self.filetype: str = filetype
+        self.path: str = path
 
 
 class ProviderDatasetSchema(DatasetSchema):

--- a/renku/core/dataset/providers/renku.py
+++ b/renku/core/dataset/providers/renku.py
@@ -23,7 +23,7 @@ import shutil
 import urllib
 from pathlib import Path
 from subprocess import PIPE, SubprocessError, run
-from typing import List
+from typing import TYPE_CHECKING, List, Optional
 
 import attr
 
@@ -31,13 +31,15 @@ from renku.command.command_builder.command import inject
 from renku.command.login import read_renku_token
 from renku.core import errors
 from renku.core.dataset.datasets_provenance import DatasetsProvenance
-from renku.core.dataset.providers.api import ProviderApi
+from renku.core.dataset.providers.api import ProviderApi, ProviderRecordSerializerApi
 from renku.core.interface.client_dispatcher import IClientDispatcher
 from renku.core.interface.database_dispatcher import IDatabaseDispatcher
 from renku.core.util import communication
 from renku.core.util.file_size import bytes_to_unit
 from renku.core.util.git import clone_renku_repository, get_cache_directory_for_repository
-from renku.infrastructure.immutable import DynamicProxy
+
+if TYPE_CHECKING:
+    from renku.core.dataset.providers.models import ProviderDataset, ProviderDatasetFile
 
 
 @attr.s
@@ -74,7 +76,7 @@ class RenkuProvider(ProviderApi):
             uri: URL to search for.
 
         Returns:
-            _RenkuRecordSerializer: Serializer containing record data.
+            RenkuRecordSerializer: Serializer containing record data.
         """
         self._uri = uri
         self._gitlab_token = kwargs.get("gitlab_token")
@@ -85,7 +87,7 @@ class RenkuProvider(ProviderApi):
 
         project_url_ssh, project_url_http = self._get_project_urls(kg_url)
 
-        return _RenkuRecordSerializer(
+        return RenkuRecordSerializer(
             uri=uri,
             name=name,
             identifier=identifier,
@@ -218,14 +220,15 @@ class RenkuProvider(ProviderApi):
         self._authorization_header = {"Authorization": f"Bearer {token}"} if token else {}
 
 
-class _RenkuRecordSerializer:
+class RenkuRecordSerializer(ProviderRecordSerializerApi):
     """Renku record Serializer."""
 
     def __init__(
         self, uri, identifier, name, latest_version_uri, project_url_ssh, project_url_http, gitlab_token, renku_token
     ):
-        """Create a _RenkuRecordSerializer from a Dataset."""
-        self._uri = uri
+        """Create a RenkuRecordSerializer from a Dataset."""
+        super().__init__(uri=uri)
+
         self._identifier = identifier
         self._name = name
         self._latest_version_uri = latest_version_uri
@@ -234,11 +237,11 @@ class _RenkuRecordSerializer:
         self._gitlab_token = gitlab_token
         self._renku_token = renku_token
 
-        self._dataset = None
+        self._dataset: Optional["ProviderDataset"] = None
         self._project_url = None
         self._project_repo = None
         self._remote_client = None
-        self._files_info = []
+        self._files_info: List["ProviderDatasetFile"] = []
 
     @staticmethod
     def _get_file_size(remote_client, path):
@@ -280,22 +283,17 @@ class _RenkuRecordSerializer:
         full_path = remote_client.path / path
         return float(os.path.getsize(full_path))
 
-    @property
-    def files_info(self) -> List[DynamicProxy]:
-        """Return list of dataset file proxies.
-
-        This is only valid after a call to ``as_dataset``.
-        """
-        return self._files_info
-
-    def as_dataset(self, client):
+    def as_dataset(self, client) -> "ProviderDataset":
         """Return encapsulated dataset instance."""
-        self._fetch_dataset()
-        return self._dataset
+        provider_dataset = self._fetch_dataset()
+        self._dataset = provider_dataset
+        return provider_dataset
 
     @inject.autoparams()
     def import_images(self, dataset, client_dispatcher: IClientDispatcher):
         """Add images from remote dataset."""
+        assert self._dataset is not None, "Dataset was not fetched"
+
         client = client_dispatcher.current_client
 
         if not self._dataset.images:
@@ -350,6 +348,7 @@ class _RenkuRecordSerializer:
 
     @inject.autoparams()
     def _fetch_dataset(self, client_dispatcher: IClientDispatcher, database_dispatcher: IDatabaseDispatcher):
+        from renku.core.dataset.providers.models import ProviderDataset, ProviderDatasetFile
         from renku.core.management.client import LocalClient
         from renku.domain_model.dataset import get_dataset_data_dir
 
@@ -388,29 +387,32 @@ class _RenkuRecordSerializer:
             self._migrate_project()
             self._project_repo = repository
 
-            self._dataset = DatasetsProvenance().get_by_name(self._name)
+            dataset = DatasetsProvenance().get_by_name(self._name)
+            if not dataset:
+                raise errors.ParameterError(f"Cannot find dataset '{self._name}' in project '{self._project_url}'")
+            provider_dataset = ProviderDataset.from_dataset(dataset)
         finally:
             database_dispatcher.pop_database()
             client_dispatcher.pop_client()
 
-        if not self._dataset:
-            raise errors.ParameterError(f"Cannot find dataset '{self._name}' in project '{self._project_url}'")
+        provider_dataset.data_dir = get_dataset_data_dir(self._remote_client, provider_dataset)
+        provider_dataset.derived_from = None
 
-        self._dataset.data_dir = get_dataset_data_dir(self._remote_client, self._dataset)
-        self._dataset.derived_from = None
-
-        files_info = []
-        for file in self._dataset.files:
-            file_info = DynamicProxy(file)
-            file_info.checksum = file.entity.checksum
-            file_info.filename = Path(file.entity.path).name
-            file_info.size_in_mb = bytes_to_unit(
-                _RenkuRecordSerializer._get_file_size(self._remote_client, file.entity.path), "mi"
+        self._files_info = [
+            ProviderDatasetFile(
+                source=file.source,
+                filename=Path(file.entity.path).name,
+                checksum=file.entity.checksum,
+                size_in_mb=bytes_to_unit(
+                    RenkuRecordSerializer._get_file_size(self._remote_client, file.entity.path), "mi"
+                ),
+                filetype=Path(file.entity.path).suffix.replace(".", ""),
+                path=file.entity.path,
             )
-            file_info.filetype = Path(file.entity.path).suffix.replace(".", "")
-            files_info.append(file_info)
+            for file in dataset.files
+        ]
 
-        self._files_info = files_info
+        return provider_dataset
 
     @staticmethod
     def _migrate_project():

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -58,7 +58,7 @@ def _path_converter(path) -> Path:
 class PathMixin:
     """Define a default path attribute."""
 
-    path: Path = attr.ib(default=default_path, converter=_path_converter)
+    path: Path = attr.ib(default=default_path, converter=_path_converter)  # type: ignore
 
     @path.validator
     def _check_path(self, _, value):

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -58,7 +58,7 @@ def _path_converter(path) -> Path:
 class PathMixin:
     """Define a default path attribute."""
 
-    path: Path = attr.ib(default=default_path, converter=_path_converter)  # type: ignore
+    path: Path = attr.ib(default=default_path, converter=_path_converter)
 
     @path.validator
     def _check_path(self, _, value):

--- a/renku/core/workflow/providers/toil.py
+++ b/renku/core/workflow/providers/toil.py
@@ -153,7 +153,7 @@ class SubprocessToilJob(AbstractToilJob):
         return call(
             command_line,
             cwd=os.getcwd(),
-            **{
+            **{  # type: ignore
                 key: open(value, mode="r" if key == "stdin" else "w")
                 for key, value in mapped_std.items()  # type: ignore
             },

--- a/renku/data/shacl_shape.json
+++ b/renku/data/shacl_shape.json
@@ -408,7 +408,7 @@
                   "@id": "xsd:string"
                },
                "maxCount": 1,
-               "sh:pattern": "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+\\d{2}:\\d{2}"
+               "sh:pattern": "\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}\\+\\d{2}:\\d{2})?"
             },
             {
                "nodeKind": "sh:Literal",

--- a/renku/domain_model/dataset.py
+++ b/renku/domain_model/dataset.py
@@ -234,10 +234,10 @@ class DatasetFile(Slots):
     def __init__(
         self,
         *,
+        entity: "Entity",
         based_on: Optional[RemoteEntity] = None,
         date_added: Optional[datetime] = None,
         date_removed: Optional[datetime] = None,
-        entity: Optional["Entity"] = None,
         id: Optional[str] = None,
         is_external: Optional[bool] = False,
         source: Optional[Union[Path, str]] = None,
@@ -251,7 +251,7 @@ class DatasetFile(Slots):
         self.based_on: Optional[RemoteEntity] = based_on
         self.date_added: datetime = fix_datetime(date_added) or local_now()
         self.date_removed: Optional[datetime] = fix_datetime(date_removed)
-        self.entity: Optional["Entity"] = entity
+        self.entity: "Entity" = entity
         self.id: str = id or DatasetFile.generate_id()
         self.is_external: bool = is_external or False
         self.source: Optional[str] = str(source)
@@ -495,7 +495,7 @@ class Dataset(Persistent):
         """Find a file in the dataset using its relative path."""
         path = str(path)
         for file in self.dataset_files:
-            if str(file.entity.path) == path and not file.is_removed():  # type: ignore
+            if str(file.entity.path) == path and not file.is_removed():
                 return file
 
         return None
@@ -582,13 +582,10 @@ class Dataset(Persistent):
         new_files = []
 
         for file in files:
-            existing_file = self.find_file(file.entity.path)  # type: ignore
+            existing_file = self.find_file(file.entity.path)
             if not existing_file:
                 new_files.append(file)
-            elif (
-                file.entity.checksum != existing_file.entity.checksum  # type: ignore
-                or file.date_added != existing_file.date_added
-            ):
+            elif file.entity.checksum != existing_file.entity.checksum or file.date_added != existing_file.date_added:
                 self.dataset_files.remove(existing_file)
                 new_files.append(file)
 

--- a/renku/domain_model/provenance/agent.py
+++ b/renku/domain_model/provenance/agent.py
@@ -66,7 +66,7 @@ class Person(Agent):
 
     __slots__ = ("affiliation", "alternate_name", "email")
 
-    affiliation: str
+    affiliation: Optional[str]
     alternate_name: str
     email: str
 

--- a/renku/ui/api/models/dataset.py
+++ b/renku/ui/api/models/dataset.py
@@ -145,8 +145,7 @@ class DatasetFile:
         self = cls()
         self._dataset_file = dataset_file
 
-        if dataset_file.entity:
-            self.full_path = project.path / dataset_file.entity.path
+        self.full_path = project.path / dataset_file.entity.path
 
         return self
 

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -495,8 +495,8 @@ def test_add_an_empty_directory(runner, client, directory_tree):
     path.mkdir()
 
     result = runner.invoke(cli, ["dataset", "add", "--create", "local", str(path)])
-    assert 1 == result.exit_code, format_result_exception(result)
-    assert "Error: There is nothing to commit." in result.output
+    assert 2 == result.exit_code, format_result_exception(result)
+    assert "Error: There are no files to create a dataset" in result.output
 
 
 def test_repository_file_to_dataset(runner, client, subdirectory, load_dataset_with_injection):
@@ -1172,6 +1172,7 @@ def test_dataset_provider_resolution_zenodo(doi_responses, uri):
         "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/TJCLKP",
     ],
 )
+@pytest.mark.integration
 def test_dataset_provider_resolution_dataverse(doi_responses, uri):
     """Check that dataverse URIs resolve to ``DataverseProvider``."""
     provider, _ = ProviderFactory.from_uri(uri)

--- a/tests/core/commands/test_log.py
+++ b/tests/core/commands/test_log.py
@@ -25,6 +25,7 @@ from renku.command.command_builder.command import inject, remove_injector
 from renku.command.log import _log
 from renku.command.view_model.log import DatasetLogViewModel, LogType
 from renku.core.interface.dataset_gateway import IDatasetGateway
+from renku.domain_model.dataset import Url
 from renku.domain_model.provenance.activity import Activity, Association
 from renku.domain_model.provenance.agent import Person, SoftwareAgent
 
@@ -334,7 +335,7 @@ def test_log_dataset_deleted(mocker):
     new_dataset.name = "ds"
     new_dataset.title = None
     new_dataset.description = None
-    new_dataset.derived_from.url_id = "old"
+    new_dataset.derived_from = Url(url_id="old")
     new_dataset.same_as = None
     new_dataset.dataset_files = []
     new_dataset.date_removed = datetime.utcnow()
@@ -411,7 +412,7 @@ def test_log_dataset_files_removed(mocker):
     new_dataset.name = "ds"
     new_dataset.title = None
     new_dataset.description = None
-    new_dataset.derived_from.url_id = "old"
+    new_dataset.derived_from = Url(url_id="old")
     new_dataset.same_as = None
     new_dataset.dataset_files = [old_dataset.dataset_files[0]]
     new_dataset.date_modified = datetime.utcnow()
@@ -490,7 +491,7 @@ def test_log_dataset_metadata_modified(mocker):
     new_dataset.name = "ds"
     new_dataset.title = "new-title"
     new_dataset.description = "new-description"
-    new_dataset.derived_from.url_id = "old"
+    new_dataset.derived_from = Url(url_id="old")
     new_dataset.same_as = None
     new_dataset.creators = [mocker.MagicMock(full_identity="Jane")]
     new_dataset.keywords = ["a", "c"]

--- a/tests/fixtures/templates.py
+++ b/tests/fixtures/templates.py
@@ -184,7 +184,7 @@ def templates_source(tmp_path, monkeypatch):
 
         def get_latest_reference_and_version(
             self, id: str, reference: Optional[str], version: Optional[str]
-        ) -> Optional[Tuple[Optional[str], str]]:
+        ) -> Tuple[Optional[str], str]:
             """Return latest reference and version number of a template."""
             _ = self.get_template(id=id, reference=reference)
             version = str(max(self._versions))


### PR DESCRIPTION
# Description

Makes `entity` non-Optional in `DatasetFile`: Uses `ProviderRecordSerializerApi::files_info` to pass file information to the import logic and doesn't set `files` on `Dataset` instances.

Refactoring:
* Adds a `ProviderRecordSerializerApi` interface to be inherited in the import providers.
* Removes `attr` in some places
* Providers return a `ProviderDataset` that is a sub-class of `Dataset` but doesn't allow accessing its `files` property.

Fixes #2792 
