### PR TITLE
chore: update rqmetrics to 0.0.2

### DIFF
--- a/helm-chart/renku-core/values.yaml
+++ b/helm-chart/renku-core/values.yaml
@@ -72,7 +72,7 @@ metrics:
   enabled: false
   image:
     repository: renku/rqmetrics
-    tag: latest
+    tag: 0.0.2
     pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
I did some housekeeping on the rqmetrics side. Namely:

- created a release
- switched to poetry
- updated outdated requirements that had security vulnerabilities

I also tested this locally and it works. We should always use a version for this if the image pull policy is IfNotPresent