### PR TITLE
fix(service): cleanup project when origin is out of sync

### DIFF
--- a/renku/ui/service/controllers/api/mixins.py
+++ b/renku/ui/service/controllers/api/mixins.py
@@ -275,11 +275,10 @@ class RenkuOperationMixin(metaclass=ABCMeta):
                             repository.fetch("origin", repository.active_branch)
                             repository.reset(f"{origin}/{repository.active_branch}", hard=True)
                         except GitCommandError as e:
-                            if "fatal: ambiguous argument" in str(e):
-                                project.purge()
-                                raise IntermittentCacheError(e)
-                            else:
-                                raise
+                            project.purge()
+                            raise IntermittentCacheError(e)
+                        else:
+                            raise
                 project.last_fetched_at = datetime.utcnow()
                 project.save()
         except (portalocker.LockException, portalocker.AlreadyLocked) as e:

--- a/renku/ui/service/controllers/api/mixins.py
+++ b/renku/ui/service/controllers/api/mixins.py
@@ -36,6 +36,7 @@ from renku.ui.service.config import PROJECT_CLONE_DEPTH_DEFAULT, PROJECT_CLONE_N
 from renku.ui.service.controllers.utils.remote_project import RemoteProject
 from renku.ui.service.errors import (
     IntermittentAuthenticationError,
+    IntermittentCacheError,
     IntermittentLockError,
     ProgramRenkuError,
     UserAnonymousError,
@@ -269,9 +270,16 @@ class RenkuOperationMixin(metaclass=ABCMeta):
 
                         repository.reset(f"{origin}/{repository.active_branch}", hard=True)
                     else:
-                        repository.fetch("origin", repository.active_branch)
-                        repository.reset(f"{origin}/{repository.active_branch}", hard=True)
-
+                        try:
+                            # NOTE: it rarely happens that origin is not reachable. Try again if it fails.
+                            repository.fetch("origin", repository.active_branch)
+                            repository.reset(f"{origin}/{repository.active_branch}", hard=True)
+                        except GitCommandError as e:
+                            if "fatal: ambiguous argument" in str(e):
+                                project.purge()
+                                raise IntermittentCacheError(e)
+                            else:
+                                raise
                 project.last_fetched_at = datetime.utcnow()
                 project.save()
         except (portalocker.LockException, portalocker.AlreadyLocked) as e:

--- a/renku/ui/service/errors.py
+++ b/renku/ui/service/errors.py
@@ -742,3 +742,14 @@ class IntermittentRedisError(ServiceError):
 
     def __init__(self, exception=None):
         super().__init__(exception=exception)
+
+
+class IntermittentCacheError(ServiceError):
+    """An operation in the cache failed."""
+
+    code = SVC_ERROR_INTERMITTENT + 203
+    userMessage = "A server-side operation unexpectedly failed. Please try again."
+    devMessage = "Cache error. See Sentry exceptions for details."
+
+    def __init__(self, exception=None):
+        super().__init__(exception=exception)


### PR DESCRIPTION
After looking into this issue, it turns out that adding the `--` mentioned in the error message won't solve the problem. It seems the local repo is somehow out-of-sync with the origin and the branches are not found.
I couldn't find a way to fix it, but purging the local copy seems a good solution to unstuck the user trying to repeat the same action. Otherwise, they seem to be stuck with the same error https://sentry.dev.renku.ch/organizations/sentry/issues/362/events/?project=2&referrer=github_integration

P.S. This fix is not great since it doesn't include a proper test. Sadly, reproducing the issue, or a similar version, was a pain and required manually removing some code -- mocking it would require quite an effort (and the test may not be reliable anyway), probably not worth it for such a rare issue

fix #2826 


