### PR TITLE
fix: remove old scheduled jobs

### DIFF
--- a/renku/ui/service/scheduler.py
+++ b/renku/ui/service/scheduler.py
@@ -38,6 +38,10 @@ def schedule(connection=None):
     build_scheduler.log.debug = build_scheduler.log.info
     scheduler_log.info("scheduler created")
 
+    # remove old jobs from the queue
+    for job in build_scheduler.get_jobs():
+        build_scheduler.cancel(job)
+
     build_scheduler.schedule(
         scheduled_time=datetime.utcnow(),
         queue_name=CLEANUP_QUEUE_FILES,


### PR DESCRIPTION
Removes old jobs from the queue before scheduling new ones to avoid duplication. 

/deploy #persist