### PR TITLE
chore: propagate use_remote flag up the chain

### DIFF
--- a/renku/command/login.py
+++ b/renku/command/login.py
@@ -146,8 +146,8 @@ def _login(endpoint, git_login, yes, client_dispatcher: IClientDispatcher):
             )
 
 
-def _parse_endpoint(endpoint):
-    parsed_endpoint = parse_authentication_endpoint(endpoint=endpoint)
+def _parse_endpoint(endpoint, use_remote=False):
+    parsed_endpoint = parse_authentication_endpoint(endpoint=endpoint, use_remote=use_remote)
     if not parsed_endpoint:
         raise errors.ParameterError("Parameter 'endpoint' is missing.")
 
@@ -193,22 +193,24 @@ def _set_renku_url_for_remote(repository: "Repository", remote_name: str, remote
 
 
 @inject.autoparams()
-def read_renku_token(endpoint, client_dispatcher: IClientDispatcher):
+def read_renku_token(endpoint: str, client_dispatcher: IClientDispatcher, get_endpoint_from_remote=False) -> str:
     """Read renku token from renku config file.
 
     Args:
-        endpoint:  Endpoint to get token for.
+        endpoint(str):  Endpoint to get token for.
         client_dispatcher(IClientDispatcher): Injected client dispatcher.
+    Keywords:
+        get_endpoint_from_remote: if no endpoint is specified, use the repository remote to infer one
 
     Returns:
         Token for endpoint.
     """
     try:
-        parsed_endpoint = _parse_endpoint(endpoint)
+        parsed_endpoint = _parse_endpoint(endpoint, use_remote=get_endpoint_from_remote)
     except errors.ParameterError:
-        return
+        return ""
     if not parsed_endpoint:
-        return
+        return ""
 
     return _read_renku_token_for_hostname(client_dispatcher.current_client, parsed_endpoint.netloc)
 

--- a/renku/core/util/urls.py
+++ b/renku/core/util/urls.py
@@ -73,7 +73,7 @@ def get_path(url: str) -> str:
 
 
 @inject.autoparams()
-def parse_authentication_endpoint(endpoint, client_dispatcher: IClientDispatcher, use_remote=False):
+def parse_authentication_endpoint(endpoint: str, client_dispatcher: IClientDispatcher, use_remote=False):
     """Return a parsed url.
 
     If an endpoint is provided then use it, otherwise, look for a configured endpoint. If no configured endpoint exists

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -29,7 +29,8 @@ from tests.utils import format_result_exception
 
 def test_login(runner, client_with_remote, mock_login, client_database_injection_manager):
     """Test login command."""
-    remote_url = client_with_remote.repository.remotes[0].url
+    remote_url = f"https://{ENDPOINT}/gitlab/namespace/project"
+    client_with_remote.repository.remotes[0].set_url(remote_url)
 
     result = runner.invoke(cli, ["login", "--git", ENDPOINT], input="y")
 
@@ -37,6 +38,7 @@ def test_login(runner, client_with_remote, mock_login, client_database_injection
 
     with client_database_injection_manager(client_with_remote):
         assert ACCESS_TOKEN == read_renku_token(ENDPOINT)
+        assert ACCESS_TOKEN == read_renku_token("", get_endpoint_from_remote=True)
         credential = client_with_remote.repository.get_configuration().get_value("credential", "helper")
         assert f"!renku credentials --hostname {ENDPOINT}" == credential
         assert {"origin", "renku-backup-origin"} == {r.name for r in client_with_remote.repository.remotes}


### PR DESCRIPTION
This makes it easier to use `read_renku_token` and avoids having to call `parse_authentication_endpoint` separately. 