### PR TITLE
feat(dataset): filter ls-files by tag

### DIFF
--- a/renku/command/format/dataset_files.py
+++ b/renku/command/format/dataset_files.py
@@ -52,42 +52,36 @@ def tabular(records, *, columns=None):
 
 
 @inject.autoparams()
-def get_lfs_tracking(records, client_dispatcher: IClientDispatcher):
-    """Check if files are tracked in git lfs.
-
-    Args:
-        records: File records to check.
-        client_dispatcher(IClientDispatcher):  Injected client dispatcher.
-    """
-    client = client_dispatcher.current_client
-
-    paths = (r.path for r in records)
-    attrs = client.repository.get_attributes(*paths)
-
-    for record in records:
-        if attrs.get(str(record.path), {}).get("filter") == "lfs":
-            record.is_lfs = True
-        else:
-            record.is_lfs = False
-
-
-@inject.autoparams()
-def get_lfs_file_sizes(records, client_dispatcher: IClientDispatcher):
-    """Try to get file size from Git LFS.
+def get_lfs_tracking_and_file_sizes(records, has_tag: bool, client_dispatcher: IClientDispatcher):
+    """Try to get file size from Git LFS and check if files are tracked in git lfs.
 
     Args:
         records: File records tog et size for.
+        has_tag(bool): Whether sizes are retrieved for a given tag instead of HEAD commit
         client_dispatcher(IClientDispatcher):  Injected client dispatcher.
     """
     from humanize import naturalsize  # Slow import
 
     client = client_dispatcher.current_client
 
+    def get_lfs_tracking():
+        paths = (r.path for r in records)
+        attrs = client.repository.get_attributes(*paths)
+
+        for record in records:
+            if attrs.get(str(record.path), {}).get("filter") == "lfs":
+                record.is_lfs = True
+            else:
+                record.is_lfs = False
+
     lfs_files_sizes = {}
 
     try:
         lfs_run = run(
-            ("git", "lfs", "ls-files", "--name-only", "--size"), stdout=PIPE, cwd=client.path, universal_newlines=True
+            ("git", "lfs", "ls-files", "--name-only", "--size", "--deleted"),
+            stdout=PIPE,
+            cwd=client.path,
+            universal_newlines=True,
         )
     except SubprocessError:
         pass
@@ -106,14 +100,28 @@ def get_lfs_file_sizes(records, client_dispatcher: IClientDispatcher):
                 size = size.replace(" B", "  B")
             lfs_files_sizes[path] = size
 
-    non_lfs_files_sizes = {
-        o.path: o.size for o in client.repository.head.commit.traverse() if o.path not in lfs_files_sizes
-    }
-    non_lfs_files_sizes = {k: naturalsize(v).upper().replace("BYTES", " B") for k, v in non_lfs_files_sizes.items()}
+    if has_tag:
+        checksums = [r.entity.checksum for r in records]
+        sizes = client.repository.get_sizes(*checksums)
+        non_lfs_files_sizes = {
+            r.entity.path: naturalsize(s).upper().replace("BYTES", " B") for r, s in zip(records, sizes)
+        }
+    else:
+        non_lfs_files_sizes = {
+            o.path: o.size for o in client.repository.head.commit.traverse() if o.path not in lfs_files_sizes
+        }
+        non_lfs_files_sizes = {k: naturalsize(v).upper().replace("BYTES", " B") for k, v in non_lfs_files_sizes.items()}
+
+        # NOTE: Check .gitattributes file to see if a file is in LFS
+        get_lfs_tracking()
 
     for record in records:
         size = lfs_files_sizes.get(record.path) or non_lfs_files_sizes.get(record.path)
         record.size = size
+
+        # NOTE: When listing a tag we assume that the file is in LFS if it was in LFS at some point in time
+        if has_tag:
+            record.is_lfs = lfs_files_sizes.get(record.path) is not None
 
 
 def jsonld(records, **kwargs):

--- a/renku/core/dataset/tag.py
+++ b/renku/core/dataset/tag.py
@@ -24,7 +24,8 @@ from renku.command.format.dataset_tags import DATASET_TAGS_FORMATS
 from renku.core import errors
 from renku.core.dataset.datasets_provenance import DatasetsProvenance
 from renku.core.util import communication
-from renku.domain_model.dataset import DatasetTag, Url
+from renku.domain_model.dataset import Dataset, DatasetTag, Url
+from renku.infrastructure.gateway.dataset_gateway import DatasetGateway
 from renku.infrastructure.immutable import DynamicProxy
 
 
@@ -92,6 +93,25 @@ def remove_dataset_tags(dataset_name: str, tags: List[str]):
     for tag in dataset_tags:
         if tag.name in tags:
             datasets_provenance.remove_tag(dataset, tag)
+
+
+def get_dataset_by_tag(dataset: Dataset, tag: str) -> Optional[Dataset]:
+    """Return a version of dataset that has a specific tag.
+
+    Args:
+        dataset(Dataset): A dataset to return its tagged version.
+        tag(str): Tag name to search for.
+
+    Returns:
+        Optional[Dataset]: The dataset pointed to by the tag or None if nothing found.
+    """
+    dataset_gateway = DatasetGateway()
+
+    tags = dataset_gateway.get_all_tags(dataset)
+    selected_tag = next((t for t in tags if t.name == tag), None)
+    if selected_tag is None:
+        return None
+    return dataset_gateway.get_by_id(selected_tag.dataset_id.value)
 
 
 def prompt_access_token(exporter):

--- a/renku/core/util/metadata.py
+++ b/renku/core/util/metadata.py
@@ -34,7 +34,9 @@ if TYPE_CHECKING:
     from renku.domain_model.provenance.agent import Person
 
 
-def construct_creators(creators: List[Union[dict, str]], ignore_email=False):
+def construct_creators(
+    creators: List[Union[dict, str]], ignore_email=False
+) -> Tuple[List["Person"], List[Union[dict, str]]]:
     """Parse input and return a list of Person."""
     creators = creators or []
 
@@ -46,7 +48,8 @@ def construct_creators(creators: List[Union[dict, str]], ignore_email=False):
     for creator in creators:
         person, no_email_warning = construct_creator(creator, ignore_email=ignore_email)
 
-        people.append(person)
+        if person:
+            people.append(person)
 
         if no_email_warning:
             no_email_warnings.append(no_email_warning)

--- a/renku/infrastructure/repository.py
+++ b/renku/infrastructure/repository.py
@@ -415,6 +415,48 @@ class BaseRepository:
             raise errors.GitCommitNotFoundError(f"Cannot find previous commit for '{path}' from '{revision}'")
         return commit
 
+    def get_revisions_paths(self, *checksums: str) -> List[Tuple[Optional[str], Optional[str]]]:
+        """Return a revision:path tuple for each checksum so that revision contains the given blob with the checksum."""
+
+        def parse_output(output) -> Tuple[Optional[str], Optional[str]]:
+            if output.lstrip().startswith("fatal:"):
+                return None, None
+            else:
+                return output.split(":", maxsplit=1)
+
+        outputs = []
+        for batch in split_paths(*checksums):
+            try:
+                outputs.extend(self.run_git_command("describe", "--always", *batch).split(os.linesep))
+            except errors.GitCommandError:
+                outputs.extend(["fatal:"] * len(batch))
+
+        return [parse_output(o) for o in outputs]
+
+    def get_sizes(self, *checksums: str) -> List[Optional[str]]:
+        """Return size of blobs given their checksum."""
+        revisions = []
+        for batch in split_paths(*checksums):
+            try:
+                revisions.extend(self.run_git_command("describe", "--always", *batch).split(os.linesep))
+            except errors.GitCommandError:
+                revisions.extend(["fatal:"] * len(batch))
+
+        try:
+            result = subprocess.run(
+                ["git", "cat-file", "--batch-check='%(objectsize)'"],
+                check=True,
+                input="\n".join(revisions),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                cwd=self.path,
+                text=True,
+            )
+        except subprocess.CalledProcessError:
+            return [""] * len(checksums)
+        else:
+            return ["" if "missing" in line else line.strip("\"'") for line in result.stdout.split(os.linesep)[:-1]]
+
     def iterate_commits(
         self,
         *paths: Union[Path, str],

--- a/renku/ui/cli/dataset.py
+++ b/renku/ui/cli/dataset.py
@@ -498,6 +498,11 @@ Sometimes you want to filter the files. For this we use ``--dataset``,
     my-dataset          2020-02-28 16:49:02  data/my-dataset/weather/file1  *
     my-dataset          2020-02-28 16:49:02  data/my-dataset/weather/file2  *
 
+Dataset files can be listed for a specific version (tag) of a dataset using the
+``--tag`` option. In this case, file from datasets that have that specific tag are
+displayed.
+
+
 Unlink a file from a dataset:
 
 .. code-block:: console
@@ -612,7 +617,7 @@ def create(name, title, description, creators, metadata, keyword):
     from renku.ui.cli.utils.callback import ClickCallback
 
     communicator = ClickCallback()
-    creators = creators or ()
+    creators = creators or []
 
     custom_metadata = None
 
@@ -668,11 +673,11 @@ def edit(name, title, description, creators, metadata, keyword):
     from renku.core.util.metadata import construct_creators
     from renku.ui.cli.utils.callback import ClickCallback
 
-    creators = creators or ()
-    keywords = keyword or ()
+    creators = creators or []
+    keywords = keyword or []
 
     custom_metadata = None
-    no_email_warnings = False
+    no_email_warnings = None
 
     if creators:
         creators, no_email_warnings = construct_creators(creators, ignore_email=True)
@@ -780,6 +785,7 @@ def add(name, urls, external, force, overwrite, create, sources, destination, re
 
 @dataset.command("ls-files")
 @click.argument("names", nargs=-1, shell_complete=_complete_datasets)
+@click.option("-t", "--tag", default=None, type=click.STRING, help="Tag for which to show dataset files.")
 @click.option(
     "--creators",
     help="Filter files which where authored by specific creators. Multiple creators are specified by comma.",
@@ -801,7 +807,7 @@ def add(name, urls, external, force, overwrite, create, sources, destination, re
     help="Comma-separated list of column to display: {}.".format(", ".join(DATASET_FILES_COLUMNS.keys())),
     show_default=True,
 )
-def ls_files(names, creators, include, exclude, format, columns):
+def ls_files(names, tag, creators, include, exclude, format, columns):
     """List files in dataset."""
     from renku.command.dataset import list_files_command
 
@@ -812,7 +818,7 @@ def ls_files(names, creators, include, exclude, format, columns):
         list_files_command()
         .lock_dataset()
         .build()
-        .execute(datasets=names, creators=creators, include=include, exclude=exclude)
+        .execute(datasets=names, tag=tag, creators=creators, include=include, exclude=exclude)
     )
 
     click.echo(DATASET_FILES_FORMATS[format](result.output, columns=columns))

--- a/renku/ui/cli/dataset.py
+++ b/renku/ui/cli/dataset.py
@@ -499,8 +499,8 @@ Sometimes you want to filter the files. For this we use ``--dataset``,
     my-dataset          2020-02-28 16:49:02  data/my-dataset/weather/file2  *
 
 Dataset files can be listed for a specific version (tag) of a dataset using the
-``--tag`` option. In this case, file from datasets that have that specific tag are
-displayed.
+``--tag`` option. In this case, files from datasets which have that specific
+tag are displayed.
 
 
 Unlink a file from a dataset:

--- a/renku/version.py
+++ b/renku/version.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     from importlib_metadata import distribution  # type: ignore
 
-__version__ = "0.0.0"
+__version__ = "1.4.0"
 __template_version__ = "0.3.1"
 __minimum_project_version__ = "1.2.0"
 

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1041,7 +1041,7 @@ def test_dataset_unlink_file_not_found(runner, project):
 
     result = runner.invoke(cli, ["dataset", "unlink", "my-dataset", "--include", "notthere.csv"])
 
-    assert 2 == result.exit_code
+    assert 2 == result.exit_code, format_result_exception(result)
 
 
 def test_dataset_unlink_file_abort_unlinking(tmpdir, runner, project):

--- a/tests/core/fixtures/core_database.py
+++ b/tests/core/fixtures/core_database.py
@@ -215,6 +215,21 @@ def dummy_database_injection_manager(dummy_database_injection_bindings, injectio
 
 
 @pytest.fixture
+def path_injection(injection_manager, database_injection_bindings, client_injection_bindings):
+    """Fixture that accepts a path and adds required renku binding."""
+
+    def create_client_and_bindings(path: Union[Path, str]):
+        from renku.core.management.client import LocalClient
+        from renku.core.util.contexts import chdir
+
+        with chdir(path):
+            client = LocalClient(path=path)
+            return injection_manager(database_injection_bindings(client_injection_bindings(client)))
+
+    return create_client_and_bindings
+
+
+@pytest.fixture
 def injected_client_with_dummy_database(
     client, client_injection_bindings, dummy_database_injection_bindings, injection_binder
 ):


### PR DESCRIPTION
# Description

Allows specifying a tag when running `renku dataset ls-files` that limits the results to those files that are in the given tag.

Fixes #2918
