### PR TITLE
chore(chart): run nginx as non-root

### DIFF
--- a/helm-chart/renku-core/templates/deployment-nginx.yaml
+++ b/helm-chart/renku-core/templates/deployment-nginx.yaml
@@ -20,13 +20,6 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-              add:
-                - chown
-                - setgid
-                - setuid
             runAsNonRoot: true
           ports:
           - containerPort: 8080


### PR DESCRIPTION
This is messing with the BIT deployment. I don't see why we had to give special capabilities to nginx but @Panaetius  maybe there was a specific reason for this?

I deployed this and everything seems to be fine. The nginx server starts normally.