### PR TITLE
fix(service): correctly use passed namespace in project id generation

### DIFF
--- a/renku/command/checks/__init__.py
+++ b/renku/command/checks/__init__.py
@@ -22,6 +22,7 @@ from .datasets import check_dataset_old_metadata_location, check_invalid_dataset
 from .external import check_missing_external_files
 from .githooks import check_git_hooks_installed
 from .migration import check_migration
+from .project import check_project_id_group
 from .storage import check_lfs_info
 from .validate_shacl import check_datasets_structure, check_project_structure
 
@@ -38,4 +39,5 @@ __all__ = (
     "check_missing_external_files",
     "check_missing_files",
     "check_project_structure",
+    "check_project_id_group",
 )

--- a/renku/command/checks/project.py
+++ b/renku/command/checks/project.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checks needed to determine integrity of the project."""
+
+from renku.command.command_builder import inject
+from renku.command.echo import WARNING
+from renku.core.interface.project_gateway import IProjectGateway
+from renku.core.util import communication
+from renku.domain_model.project import Project
+
+
+@inject.autoparams()
+def check_project_id_group(client, fix, project_gateway: IProjectGateway):
+    """Check that projects in groups have the correct id set.
+
+    Args:
+        client: ``LocalClient``.
+        fix: Whether to fix found issues.
+        project_gateway: Injected project gateway.
+    Returns:
+        Tuple of whether project id is valid.
+    """
+    current_project = client.project
+
+    namespace, name = Project.get_namespace_and_name(client=client)
+
+    if namespace is None or name is None:
+        return True, None
+
+    generated_id = Project.generate_id(namespace=namespace, name=name)
+
+    if generated_id == current_project.id:
+        return True, None
+
+    if fix:
+        communication.info(f"Fixing project id '{current_project.id}' -> '{generated_id}'")
+        current_project.id = generated_id
+        project_gateway.update_project(current_project)
+        return True, None
+
+    return True, (
+        WARNING
+        + "Project id doesn't match id created based on the current Git remote (use 'renku doctor --fix' to fix it):"
+        f"\n\t'{current_project.id}' -> '{generated_id}'"
+    )

--- a/renku/core/management/repository.py
+++ b/renku/core/management/repository.py
@@ -22,7 +22,7 @@ import shutil
 from contextlib import contextmanager
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 import attr
@@ -257,24 +257,42 @@ class RepositoryApiMixin(GitCore):
         return self, commit, path
 
     @contextmanager
-    @inject.autoparams()
+    @inject.autoparams("project_gateway", "database_gateway")
     def with_metadata(
         self,
         project_gateway: IProjectGateway,
         database_gateway: IDatabaseGateway,
-        read_only=False,
-        name=None,
-        description=None,
-        keywords=None,
-        custom_metadata=None,
+        read_only: bool = False,
+        name: Optional[str] = None,
+        namespace: Optional[str] = None,
+        description: Optional[str] = None,
+        keywords: Optional[List[str]] = None,
+        custom_metadata: Optional[Dict] = None,
     ):
-        """Yield an editable metadata object."""
+        """Yield an editable metadata object.
+
+        Args:
+            project_gateway(IProjectGateway): Injected project gateway.
+            database_gateway(IDatabaseGateway): Injected database gateway.
+            read_only(bool): Whether to save changes or not (Default value = False).
+            name(Optional[str]): Name of the project (when creating a new one) (Default value = None).
+            namespace(Optional[str]): Namespace of the project (when creating a new one) (Default value = None).
+            description(Optional[str]): Project description (when creating a new one) (Default value = None).
+            keywords(Optional[List[str]]): Keywords for the project (when creating a new one) (Default value = None).
+            custom_metadata(Optional[Dict]): Custom JSON-LD metadata (when creating a new project)
+                (Default value = None).
+        """
 
         try:
             project = project_gateway.get_project()
         except ValueError:
             project = Project.from_client(
-                name=name, description=description, keywords=keywords, custom_metadata=custom_metadata, client=self
+                name=name,
+                namespace=namespace,
+                description=description,
+                keywords=keywords,
+                custom_metadata=custom_metadata,
+                client=self,  # type: ignore
             )
 
         yield project

--- a/renku/domain_model/project.py
+++ b/renku/domain_model/project.py
@@ -126,13 +126,13 @@ class Project(persistent.Persistent):
             annotations = [Annotation(id=Annotation.generate_id(), body=custom_metadata, source="renku")]
 
         if creator is None:
-            raise ValueError("Project Creator not set")
+            raise errors.ParameterError("Project Creator not set", "creator")
 
         if name is None:
-            raise ValueError("Project 'name' not set and could not be generated")
+            raise errors.ParameterError("Project 'name' not set and could not be generated", "name")
 
         if namespace is None:
-            raise ValueError("Project 'namespace' not set and could not be generated")
+            raise errors.ParameterError("Project 'namespace' not set and could not be generated", "namespace")
 
         id = cls.generate_id(namespace=namespace, name=name)
         return cls(

--- a/renku/domain_model/project.py
+++ b/renku/domain_model/project.py
@@ -18,7 +18,7 @@
 """Project class."""
 
 from datetime import datetime
-from typing import Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, cast
 from urllib.parse import quote
 
 import persistent
@@ -30,6 +30,9 @@ from renku.core.util.os import normalize_to_ascii
 from renku.domain_model.provenance.agent import Person
 from renku.domain_model.provenance.annotation import Annotation
 from renku.version import __minimum_project_version__
+
+if TYPE_CHECKING:
+    from renku.core.management.client import LocalClient
 
 
 class Project(persistent.Persistent):
@@ -94,15 +97,28 @@ class Project(persistent.Persistent):
     @classmethod
     def from_client(
         cls,
-        client,
+        client: "LocalClient",
         name: Optional[str] = None,
+        namespace: Optional[str] = None,
         description: Optional[str] = None,
         keywords: Optional[List[str]] = None,
         custom_metadata: Optional[Dict] = None,
         creator: Optional[Person] = None,
     ) -> "Project":
-        """Create an instance from a LocalClient."""
-        namespace, name = cls.get_namespace_and_name(client=client, name=name, creator=creator)
+        """Create an instance from a LocalClient.
+
+        Args:
+            cls: The class.
+            client(LocalClient): Local client instance.
+            name(Optional[str]): Name of the project (when creating a new one) (Default value = None).
+            namespace(Optional[str]): Namespace of the project (when creating a new one) (Default value = None).
+            description(Optional[str]): Project description (when creating a new one) (Default value = None).
+            keywords(Optional[List[str]]): Keywords for the project (when creating a new one) (Default value = None).
+            custom_metadata(Optional[Dict]): Custom JSON-LD metadata (when creating a new project)
+                (Default value = None).
+            creator(Optional[Person]): The project creator.
+        """
+        namespace, name = cls.get_namespace_and_name(client=client, name=name, namespace=namespace, creator=creator)
         creator = creator or get_git_user(client.repository)
         annotations = None
 
@@ -115,20 +131,24 @@ class Project(persistent.Persistent):
         if name is None:
             raise ValueError("Project 'name' not set and could not be generated")
 
+        if namespace is None:
+            raise ValueError("Project 'namespace' not set and could not be generated")
+
         id = cls.generate_id(namespace=namespace, name=name)
         return cls(
             creator=creator, id=id, name=name, description=description, keywords=keywords, annotations=annotations
         )
 
     @staticmethod
-    def get_namespace_and_name(*, client=None, name: Optional[str] = None, creator: Optional[Person] = None):
+    def get_namespace_and_name(
+        *, client=None, name: Optional[str] = None, namespace: Optional[str] = None, creator: Optional[Person] = None
+    ):
         """Return Project's namespace and name from various objects."""
-        namespace = None
 
         if client:
             remote = client.remote
-            namespace = remote.get("owner")
-            name = remote.get("name") or name
+            namespace = namespace or remote.get("owner")
+            name = name or remote.get("name")
 
             if not creator:
                 creator = get_git_user(client.repository)

--- a/renku/ui/cli/init.py
+++ b/renku/ui/cli/init.py
@@ -214,13 +214,6 @@ def parse_parameters(ctx, param, value):
     return parameters
 
 
-def validate_name(ctx, param, value):
-    """Validate a project name."""
-    if not value:
-        value = os.path.basename(ctx.params["path"].rstrip(os.path.sep))
-    return value
-
-
 def resolve_data_directory(data_dir, path):
     """Check data directory is within the project path."""
     if not data_dir:
@@ -241,7 +234,7 @@ def resolve_data_directory(data_dir, path):
 
 @click.command()
 @click.argument("path", default=".", type=click.Path(writable=True, file_okay=False, resolve_path=True))
-@click.option("-n", "--name", callback=validate_name, help="Provide a custom project name.")
+@click.option("-n", "--name", default=None, help="Provide a custom project name.")
 @click.option("--description", help="Provide a description for the project.")
 @click.option("-k", "--keyword", default=None, multiple=True, type=click.STRING, help="List of keywords.")
 @click.option(

--- a/renku/ui/service/controllers/templates_create_project.py
+++ b/renku/ui/service/controllers/templates_create_project.py
@@ -18,6 +18,7 @@
 """Renku service template create project controller."""
 import shutil
 from pathlib import Path
+from typing import Dict
 
 from marshmallow import EXCLUDE
 
@@ -79,7 +80,7 @@ class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
         return metadata
 
     @property
-    def git_user(self):
+    def git_user(self) -> Dict[str, str]:
         """Extract git user from the user data."""
         return {
             "email": self.user_data["email"],
@@ -149,7 +150,8 @@ class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
         with click_context(new_project_path, "create_from_template"):
             create_from_template_local_command().build().execute(
                 source_path,
-                self.ctx["project_name"],
+                name=self.ctx["project_name"],
+                namespace=self.ctx["project_namespace"],
                 metadata=provided_parameters,
                 default_metadata=self.default_metadata,
                 custom_metadata=self.ctx["project_custom_metadata"],
@@ -157,9 +159,6 @@ class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
                 immutable_template_files=self.template.get("immutable_template_files", []),
                 automated_template_update=self.template.get("allow_template_update", True),
                 user=self.git_user,
-                source=self.ctx["url"],
-                ref=self.ctx["ref"],
-                invoked_from="service",
                 initial_branch=self.ctx["initial_branch"],
                 commit_message=self.ctx["commit_message"],
                 description=self.ctx["project_description"],

--- a/tests/core/commands/test_status.py
+++ b/tests/core/commands/test_status.py
@@ -294,8 +294,10 @@ def test_status_deleted_inputs(runner, project):
 
     write_and_commit_file(repo, source, "content")
 
-    assert 0 == runner.invoke(cli, ["run", "cp", source, intermediate]).exit_code
-    assert 0 == runner.invoke(cli, ["run", "cp", intermediate, output]).exit_code
+    result = runner.invoke(cli, ["run", "cp", source, intermediate])
+    assert 0 == result.exit_code, format_result_exception(result)
+    result = runner.invoke(cli, ["run", "cp", intermediate, output])
+    assert 0 == result.exit_code, format_result_exception(result)
 
     os.unlink(source)
 

--- a/tests/service/fixtures/service_client.py
+++ b/tests/service/fixtures/service_client.py
@@ -228,7 +228,7 @@ def svc_client_templates_creation(svc_client_with_templates):
         },
     }
 
-    # clenup by invoking the GitLab delete API
+    # cleanup by invoking the GitLab delete API
     # TODO: consider using the project delete endpoint once implemented
     def remove_project():
         project_slug = "{0}/{1}".format(payload["project_namespace"], normalize_to_ascii(payload["project_name"]))


### PR DESCRIPTION
closes #2937 

Fixes id generation for newly created projects.

For existing projects, `renku doctor --fix` will fix the id. Checked with KG and it shouldn't affect them, as they build the ID themselves based on gitlab.