### PR TITLE
chore: run ca cert injection as non root

### DIFF
--- a/helm-chart/renku-core/requirements.yaml
+++ b/helm-chart/renku-core/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: certificates
-  version: 0.0.1
+  version: 0.0.3
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"

--- a/helm-chart/renku-core/values.yaml
+++ b/helm-chart/renku-core/values.yaml
@@ -13,7 +13,7 @@ global:
   certificates:
     image:
       repository: renku/certificates
-      tag: '0.0.1'
+      tag: '0.0.2'
     customCAs: []
       # - secret:
 


### PR DESCRIPTION
The latest certificates image and chart can run as non-root.

This is safer than what we had before.

Also the chart and image tags are not tracking each other. This is on purpose.