### PR TITLE
feat: add RDFGraph to API

### DIFF
--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -58,6 +58,6 @@ The following sections describe the Renku Python API. If you work with the R pro
 .. _api-rdfgraph:
 
 ``RDF Graph``
-------------
+-------------
 
 .. automodule:: renku.ui.api.graph.rdf

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -20,12 +20,12 @@ Renku Python API
 
 The following sections describe the Renku Python API. If you work with the R programming language, you can also use this API through the reticulate package. For more information, visit `our dedicated tutorial <https://renkulab.io/projects/learn-renku/renku-api-from-r>`_.
 
-.. _api-project:
+.. _api-activity:
 
-``Project``
------------
+``Activity``
+------------
 
-.. automodule:: renku.ui.api.models.project
+.. automodule:: renku.ui.api.models.activity
 
 .. _api-dataset:
 
@@ -34,6 +34,13 @@ The following sections describe the Renku Python API. If you work with the R pro
 
 .. automodule:: renku.ui.api.models.dataset
 
+.. _api-parameter:
+
+``Inputs, Outputs, and Parameters``
+-----------------------------------
+
+.. automodule:: renku.ui.api.models.parameter
+
 .. _api-plan:
 
 ``Plan, CompositePlan``
@@ -41,16 +48,16 @@ The following sections describe the Renku Python API. If you work with the R pro
 
 .. automodule:: renku.ui.api.models.plan
 
-.. _api-activity:
+.. _api-project:
 
-``Activity``
+``Project``
+-----------
+
+.. automodule:: renku.ui.api.models.project
+
+.. _api-rdfgraph:
+
+``RDF Graph``
 ------------
 
-.. automodule:: renku.ui.api.models.activity
-
-.. _api-parameter:
-
-``Inputs, Outputs, and Parameters``
------------------------------------
-
-.. automodule:: renku.ui.api.models.parameter
+.. automodule:: renku.ui.api.graph.rdf

--- a/renku/ui/api/__init__.py
+++ b/renku/ui/api/__init__.py
@@ -24,7 +24,6 @@ from renku.ui.api.models.parameter import Input, Link, Mapping, Output, Paramete
 from renku.ui.api.models.plan import CompositePlan, Plan
 from renku.ui.api.models.project import Project
 
-
 __all__ = (
     "Activity",
     "CompositePlan",

--- a/renku/ui/api/graph/__init__.py
+++ b/renku/ui/api/graph/__init__.py
@@ -15,26 +15,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Renku API."""
-
-from renku.ui.api.graph.rdf import RDFGraph
-from renku.ui.api.models.activity import Activity
-from renku.ui.api.models.dataset import Dataset
-from renku.ui.api.models.parameter import Input, Link, Mapping, Output, Parameter
-from renku.ui.api.models.plan import CompositePlan, Plan
-from renku.ui.api.models.project import Project
-
-
-__all__ = (
-    "Activity",
-    "CompositePlan",
-    "Dataset",
-    "Input",
-    "Link",
-    "Mapping",
-    "Output",
-    "Parameter",
-    "Plan",
-    "Project",
-    "RDFGraph",
-)
+"""Renku Graph API."""

--- a/renku/ui/api/graph/rdf.py
+++ b/renku/ui/api/graph/rdf.py
@@ -15,11 +15,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Renku RDF Graph API."""
+"""Renku RDF Graph API.
+
+The ``RDFGraph`` class allows for the quick creation of a searchable graph object
+based on the project's metadata.
+
+To create the graph and query it:
+
+.. code-block:: python
+
+    from renku.ui.api import RDFGraph
+
+    g = RDFGraph()
+    # get a list of contributors to the project
+    list(g.subjects(object=URIRef("http://schema.org/Person")))
+
+For more information on querying the graph, see the `RDFLib
+documentation <https://rdflib.readthedocs.io/en/stable/intro_to_graphs.html>`_.
+
+"""
 
 import json
-import pyld
 
+import pyld
 from rdflib import Graph
 
 from renku.command.graph import export_graph_command
@@ -29,6 +47,12 @@ class RDFGraph(Graph):
     """RDF Graph of the project's metadata."""
 
     def __init__(self, revision_or_range=None):
+        """Instantiate the RDFGraph class.
+
+        Args:
+            revision_or_range(None): Revision or range to generate the graph from. Defaults to ``None``
+
+        """
         super().__init__()
         self.revision_or_range = revision_or_range
         self._build()

--- a/renku/ui/api/graph/rdf.py
+++ b/renku/ui/api/graph/rdf.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Renku RDF Graph API."""
+
+import json
+import pyld
+
+from rdflib import Graph
+
+from renku.command.graph import export_graph_command
+
+
+class RDFGraph(Graph):
+    """RDF Graph of the project's metadata."""
+
+    def __init__(self, revision_or_range=None):
+        super().__init__()
+        self.revision_or_range = revision_or_range
+        self._build()
+        self._bind()
+
+    def _build(self):
+        """Construct the RDF graph representing this Renku project."""
+        data = json.dumps(
+            pyld.jsonld.expand(
+                export_graph_command().build().execute(revision_or_range=self.revision_or_range).output._graph
+            )
+        )
+        self.parse(data=data, format="json-ld")
+
+    def _bind(self):
+        """Bind all the usual URIs."""
+        self.bind("prov", "http://www.w3.org/ns/prov#")
+        self.bind("oa", "http://www.w3.org/ns/oa#")
+        self.bind("schema", "http://schema.org/")
+        self.bind("renku", "https://swissdatasciencecenter.github.io/renku-ontology#")
+        self.bind("foaf", "http://xmlns.com/foaf/0.1/")

--- a/renku/ui/api/graph/rdf.py
+++ b/renku/ui/api/graph/rdf.py
@@ -56,7 +56,7 @@ class RDFGraph(Graph):
         super().__init__()
         self.revision_or_range = revision_or_range
         self._build()
-        self._bind()
+        self.bind_(self)
 
     def _build(self):
         """Construct the RDF graph representing this Renku project."""
@@ -67,10 +67,11 @@ class RDFGraph(Graph):
         )
         self.parse(data=data, format="json-ld")
 
-    def _bind(self):
-        """Bind all the usual URIs."""
-        self.bind("prov", "http://www.w3.org/ns/prov#")
-        self.bind("oa", "http://www.w3.org/ns/oa#")
-        self.bind("schema", "http://schema.org/")
-        self.bind("renku", "https://swissdatasciencecenter.github.io/renku-ontology#")
-        self.bind("foaf", "http://xmlns.com/foaf/0.1/")
+    @staticmethod
+    def bind_(graph):
+        """Bind all the usual namespaces."""
+        graph.bind("prov", "http://www.w3.org/ns/prov#")
+        graph.bind("oa", "http://www.w3.org/ns/oa#")
+        graph.bind("schema", "http://schema.org/")
+        graph.bind("renku", "https://swissdatasciencecenter.github.io/renku-ontology#")
+        graph.bind("foaf", "http://xmlns.com/foaf/0.1/")

--- a/tests/api/test_rdfgraph.py
+++ b/tests/api/test_rdfgraph.py
@@ -15,26 +15,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Renku API."""
+"""Tests for RDFGraph API."""
 
-from renku.ui.api.graph.rdf import RDFGraph
-from renku.ui.api.models.activity import Activity
-from renku.ui.api.models.dataset import Dataset
-from renku.ui.api.models.parameter import Input, Link, Mapping, Output, Parameter
-from renku.ui.api.models.plan import CompositePlan, Plan
-from renku.ui.api.models.project import Project
+from rdflib import URIRef
+
+from renku.ui.api import RDFGraph
 
 
-__all__ = (
-    "Activity",
-    "CompositePlan",
-    "Dataset",
-    "Input",
-    "Link",
-    "Mapping",
-    "Output",
-    "Parameter",
-    "Plan",
-    "Project",
-    "RDFGraph",
-)
+def test_get_graph(project):
+    """Test generating an RDFGraph."""
+    g = RDFGraph()
+    assert URIRef("mailto:renku@datascience.ch") in g.subjects(object=URIRef("http://schema.org/Person"))


### PR DESCRIPTION
Adds an `RDFGraph` object to the API

Usage:

```
from renku.ui.api import RDFGraph

g = RDFGraph()
# get a list of contributors to the project
list(g.subjects(object=URIRef("http://schema.org/Person")))
```
