### PR TITLE
chore: change CI test versions of python from 3.7,[3.8,3.9] to 3.9,[3.7,3.10]

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -23,9 +23,9 @@ jobs:
         run: |
           if [ "$REF" == "refs/heads/$DEFAULT_BRANCH" ] || [[ "$REF" =~ ^refs/tags/.* ]]
           then
-              echo "::set-output name=matrix::{\"python-version\": [\"3.8\", \"3.9\"]}"
+              echo "::set-output name=matrix::{\"python-version\": [\"3.7\", \"3.10\"]}"
           else
-              echo "::set-output name=matrix::{\"python-version\": [\"3.7\"]}"
+              echo "::set-output name=matrix::{\"python-version\": [\"3.9\"]}"
           fi
 
   cleanup-runs:


### PR DESCRIPTION
Since 3.9 is the most common version and we should test with 3.10 as well.
