### PR TITLE
feat(dataset): make dataset providers plugins

### DIFF
--- a/docs/reference/models/dataset_provider.rst
+++ b/docs/reference/models/dataset_provider.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 
@@ -15,22 +15,9 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 
-.. _models:
+Dataset Provider
+----------------
 
-Models
-======
-
-.. automodule:: renku.domain_model
-
-.. toctree::
-   :maxdepth: 1
-
-   projects
-   entity
-   datasets
-   provenance
-   workflow
-   session
-   template
-   refs
-   dataset_provider
+.. automodule:: renku.domain_model.dataset_provider
+   :members:
+   :show-inheritance:

--- a/renku/core/dataset/providers/dataverse.py
+++ b/renku/core/dataset/providers/dataverse.py
@@ -74,7 +74,7 @@ DATAVERSE_SUBJECTS = [
 ]
 
 
-class DataverseProvider(ProviderApi):
+class DataverseProvider(ProviderApi, IDatasetProviderPlugin):
     """Dataverse API provider."""
 
     priority = ProviderPriority.HIGH
@@ -184,6 +184,12 @@ class DataverseProvider(ProviderApi):
 
         set_export_parameters()
         return DataverseExporter(dataset=dataset, server_url=self._server_url, dataverse_name=self._dataverse_name)
+
+    @classmethod
+    @hookimpl
+    def dataset_provider(cls) -> "Type[DataverseProvider]":
+        """The defintion of the provider."""
+        return cls
 
 
 class DataverseImporter(RepositoryImporter):
@@ -582,12 +588,3 @@ def make_file_url(file_id, base_url):
     args_dict = {"persistentId": file_id}
     url_parts[4] = urllib.parse.urlencode(args_dict)
     return urllib.parse.urlunparse(url_parts)
-
-
-class DataverseProviderPlugin(IDatasetProviderPlugin):
-    """Dataverse provider plugin."""
-
-    @hookimpl
-    def dataset_provider(self) -> "Type[ProviderApi]":
-        """The defintion of the provider."""
-        return DataverseProvider

--- a/renku/core/dataset/providers/dataverse.py
+++ b/renku/core/dataset/providers/dataverse.py
@@ -188,7 +188,7 @@ class DataverseProvider(ProviderApi, IDatasetProviderPlugin):
     @classmethod
     @hookimpl
     def dataset_provider(cls) -> "Type[DataverseProvider]":
-        """The defintion of the provider."""
+        """The definition of the provider."""
         return cls
 
 

--- a/renku/core/dataset/providers/dataverse.py
+++ b/renku/core/dataset/providers/dataverse.py
@@ -23,7 +23,7 @@ import re
 import urllib
 from pathlib import Path
 from string import Template
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 from urllib import parse as urlparse
 
 from renku.command.command_builder import inject
@@ -37,10 +37,12 @@ from renku.core.dataset.providers.dataverse_metadata_templates import (
 from renku.core.dataset.providers.doi import DOIProvider
 from renku.core.dataset.providers.repository import RepositoryImporter, make_request
 from renku.core.interface.client_dispatcher import IClientDispatcher
+from renku.core.plugin import hookimpl
 from renku.core.util import communication
 from renku.core.util.doi import extract_doi, get_doi_url, is_doi
 from renku.core.util.file_size import bytes_to_unit
 from renku.core.util.urls import remove_credentials
+from renku.domain_model.dataset_provider import IDatasetProviderPlugin
 
 if TYPE_CHECKING:
     from renku.core.dataset.providers.models import ProviderDataset, ProviderParameter
@@ -580,3 +582,12 @@ def make_file_url(file_id, base_url):
     args_dict = {"persistentId": file_id}
     url_parts[4] = urllib.parse.urlencode(args_dict)
     return urllib.parse.urlunparse(url_parts)
+
+
+class DataverseProviderPlugin(IDatasetProviderPlugin):
+    """Dataverse provider plugin."""
+
+    @hookimpl
+    def dataset_provider(self) -> "Type[ProviderApi]":
+        """The defintion of the provider."""
+        return DataverseProvider

--- a/renku/core/dataset/providers/doi.py
+++ b/renku/core/dataset/providers/doi.py
@@ -19,10 +19,13 @@
 
 import urllib
 from pathlib import Path
+from typing import Type
 
 from renku.core import errors
 from renku.core.dataset.providers.api import ImporterApi, ProviderApi, ProviderPriority
+from renku.core.plugin import hookimpl
 from renku.core.util.doi import extract_doi, is_doi
+from renku.domain_model.dataset_provider import IDatasetProviderPlugin
 
 DOI_BASE_URL = "https://dx.doi.org"
 
@@ -148,3 +151,12 @@ def make_doi_url(doi):
         parsed_url = parsed_url._replace(scheme="")
         doi = parsed_url.geturl()
     return urllib.parse.urljoin(DOI_BASE_URL, doi)
+
+
+class DOIProviderPlugin(IDatasetProviderPlugin):
+    """DOI provider plugin."""
+
+    @hookimpl
+    def dataset_provider(self) -> "Type[ProviderApi]":
+        """The defintion of the provider."""
+        return DOIProvider

--- a/renku/core/dataset/providers/doi.py
+++ b/renku/core/dataset/providers/doi.py
@@ -76,7 +76,7 @@ class DOIProvider(ProviderApi, IDatasetProviderPlugin):
     @classmethod
     @hookimpl
     def dataset_provider(cls) -> "Type[DOIProvider]":
-        """The defintion of the provider."""
+        """The definition of the provider."""
         return cls
 
 

--- a/renku/core/dataset/providers/doi.py
+++ b/renku/core/dataset/providers/doi.py
@@ -30,7 +30,7 @@ from renku.domain_model.dataset_provider import IDatasetProviderPlugin
 DOI_BASE_URL = "https://dx.doi.org"
 
 
-class DOIProvider(ProviderApi):
+class DOIProvider(ProviderApi, IDatasetProviderPlugin):
     """`doi.org <http://doi.org>`_ registry API provider."""
 
     priority = ProviderPriority.HIGHER
@@ -72,6 +72,12 @@ class DOIProvider(ProviderApi):
 
         query_response = query(uri)
         return serialize(query_response)
+
+    @classmethod
+    @hookimpl
+    def dataset_provider(cls) -> "Type[DOIProvider]":
+        """The defintion of the provider."""
+        return cls
 
 
 class DOIImporter(ImporterApi):
@@ -151,12 +157,3 @@ def make_doi_url(doi):
         parsed_url = parsed_url._replace(scheme="")
         doi = parsed_url.geturl()
     return urllib.parse.urljoin(DOI_BASE_URL, doi)
-
-
-class DOIProviderPlugin(IDatasetProviderPlugin):
-    """DOI provider plugin."""
-
-    @hookimpl
-    def dataset_provider(self) -> "Type[ProviderApi]":
-        """The defintion of the provider."""
-        return DOIProvider

--- a/renku/core/dataset/providers/factory.py
+++ b/renku/core/dataset/providers/factory.py
@@ -17,13 +17,13 @@
 # limitations under the License.
 """A factory to get various data providers."""
 
-from typing import TYPE_CHECKING, Type, List
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from renku.core import errors
+from renku.core.plugin.dataset_provider import get_supported_dataset_providers
 from renku.core.util import communication
 from renku.core.util.doi import is_doi
-from renku.core.plugin.dataset_provider import get_supported_dataset_providers
 
 if TYPE_CHECKING:
     from renku.core.dataset.providers.api import ProviderApi
@@ -33,7 +33,7 @@ class ProviderFactory:
     """Create a provider type from URI."""
 
     @staticmethod
-    def get_providers() -> "List[Type[ProviderApi]]":
+    def get_providers():
         """Return a list of providers sorted based on their priorities (higher priority providers come first)."""
         providers = get_supported_dataset_providers()
         return sorted(providers, key=lambda p: p.priority)

--- a/renku/core/dataset/providers/factory.py
+++ b/renku/core/dataset/providers/factory.py
@@ -17,12 +17,13 @@
 # limitations under the License.
 """A factory to get various data providers."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Type, List
 from urllib.parse import urlparse
 
 from renku.core import errors
 from renku.core.util import communication
 from renku.core.util.doi import is_doi
+from renku.core.plugin.dataset_provider import get_supported_dataset_providers
 
 if TYPE_CHECKING:
     from renku.core.dataset.providers.api import ProviderApi
@@ -32,26 +33,9 @@ class ProviderFactory:
     """Create a provider type from URI."""
 
     @staticmethod
-    def get_providers():
+    def get_providers() -> "List[Type[ProviderApi]]":
         """Return a list of providers sorted based on their priorities (higher priority providers come first)."""
-        from renku.core.dataset.providers.dataverse import DataverseProvider
-        from renku.core.dataset.providers.git import GitProvider
-        from renku.core.dataset.providers.local import FilesystemProvider
-        from renku.core.dataset.providers.olos import OLOSProvider
-        from renku.core.dataset.providers.renku import RenkuProvider
-        from renku.core.dataset.providers.web import WebProvider
-        from renku.core.dataset.providers.zenodo import ZenodoProvider
-
-        providers = [
-            DataverseProvider,
-            GitProvider,
-            FilesystemProvider,
-            OLOSProvider,
-            RenkuProvider,
-            WebProvider,
-            ZenodoProvider,
-        ]
-
+        providers = get_supported_dataset_providers()
         return sorted(providers, key=lambda p: p.priority)
 
     @staticmethod

--- a/renku/core/dataset/providers/git.py
+++ b/renku/core/dataset/providers/git.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from renku.core.management.client import LocalClient
 
 
-class GitProvider(ProviderApi):
+class GitProvider(ProviderApi, IDatasetProviderPlugin):
     """Git provider."""
 
     priority = ProviderPriority.NORMAL
@@ -189,11 +189,8 @@ class GitProvider(ProviderApi):
 
         return results
 
-
-class GitProviderPlugin(IDatasetProviderPlugin):
-    """Git provider plugin."""
-
+    @classmethod
     @hookimpl
-    def dataset_provider(self) -> "Type[ProviderApi]":
+    def dataset_provider(cls) -> "Type[GitProvider]":
         """The defintion of the provider."""
-        return GitProvider
+        return cls

--- a/renku/core/dataset/providers/git.py
+++ b/renku/core/dataset/providers/git.py
@@ -192,5 +192,5 @@ class GitProvider(ProviderApi, IDatasetProviderPlugin):
     @classmethod
     @hookimpl
     def dataset_provider(cls) -> "Type[GitProvider]":
-        """The defintion of the provider."""
+        """The definition of the provider."""
         return cls

--- a/renku/core/dataset/providers/git.py
+++ b/renku/core/dataset/providers/git.py
@@ -21,16 +21,18 @@ import glob
 import os
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Type, Union
 
 from renku.core import errors
 from renku.core.dataset.providers.api import ProviderApi, ProviderPriority
+from renku.core.plugin import hookimpl
 from renku.core.util import communication
 from renku.core.util.dataset import check_url
 from renku.core.util.git import clone_repository, get_cache_directory_for_repository
 from renku.core.util.os import get_files, is_subpath
 from renku.core.util.urls import remove_credentials
 from renku.domain_model.dataset import RemoteEntity
+from renku.domain_model.dataset_provider import IDatasetProviderPlugin
 
 if TYPE_CHECKING:
     from renku.core.dataset.providers.models import DatasetAddMetadata, ProviderParameter
@@ -186,3 +188,12 @@ class GitProvider(ProviderApi):
             communication.warn(f"The following files overwrite each other in the destination project:/n/t{files_str}")
 
         return results
+
+
+class GitProviderPlugin(IDatasetProviderPlugin):
+    """Git provider plugin."""
+
+    @hookimpl
+    def dataset_provider(self) -> "Type[ProviderApi]":
+        """The defintion of the provider."""
+        return GitProvider

--- a/renku/core/dataset/providers/local.py
+++ b/renku/core/dataset/providers/local.py
@@ -21,13 +21,15 @@ import os
 import urllib
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Type
 
 from renku.core import errors
 from renku.core.dataset.providers.api import ExporterApi, ProviderApi, ProviderPriority
+from renku.core.plugin import hookimpl
 from renku.core.util import communication
 from renku.core.util.dataset import check_url
 from renku.core.util.os import get_absolute_path, is_path_empty, is_subpath
+from renku.domain_model.dataset_provider import IDatasetProviderPlugin
 
 if TYPE_CHECKING:
     from renku.core.dataset.providers.models import DatasetAddMetadata, ProviderParameter
@@ -245,3 +247,12 @@ class LocalExporter(ExporterApi):
 
         communication.echo(f"Dataset metadata was copied to {metadata_path}")
         return str(dst_root)
+
+
+class FilesystemProviderPlugin(IDatasetProviderPlugin):
+    """Filesystem provider plugin."""
+
+    @hookimpl
+    def dataset_provider(self) -> "Type[ProviderApi]":
+        """The defintion of the provider."""
+        return FilesystemProvider

--- a/renku/core/dataset/providers/local.py
+++ b/renku/core/dataset/providers/local.py
@@ -186,7 +186,7 @@ class FilesystemProvider(ProviderApi, IDatasetProviderPlugin):
     @classmethod
     @hookimpl
     def dataset_provider(cls) -> "Type[FilesystemProvider]":
-        """The defintion of the provider."""
+        """The definition of the provider."""
         return cls
 
 

--- a/renku/core/dataset/providers/local.py
+++ b/renku/core/dataset/providers/local.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from renku.domain_model.dataset import Dataset, DatasetTag
 
 
-class FilesystemProvider(ProviderApi):
+class FilesystemProvider(ProviderApi, IDatasetProviderPlugin):
     """Local filesystem provider."""
 
     priority = ProviderPriority.LOW
@@ -103,7 +103,7 @@ class FilesystemProvider(ProviderApi):
         absolute_dataset_data_dir = (client.path / get_dataset_data_dir(client, dataset_name)).resolve()
         source_root = Path(get_absolute_path(path))
         is_within_repo = is_subpath(path=source_root, base=client.path)
-        warnings = []
+        warnings: List[str] = []
 
         def check_recursive_addition(src: Path):
             if src.resolve() == absolute_dataset_data_dir:
@@ -183,6 +183,12 @@ class FilesystemProvider(ProviderApi):
         """Get import manager."""
         raise NotImplementedError
 
+    @classmethod
+    @hookimpl
+    def dataset_provider(cls) -> "Type[FilesystemProvider]":
+        """The defintion of the provider."""
+        return cls
+
 
 class LocalExporter(ExporterApi):
     """Local export manager."""
@@ -247,12 +253,3 @@ class LocalExporter(ExporterApi):
 
         communication.echo(f"Dataset metadata was copied to {metadata_path}")
         return str(dst_root)
-
-
-class FilesystemProviderPlugin(IDatasetProviderPlugin):
-    """Filesystem provider plugin."""
-
-    @hookimpl
-    def dataset_provider(self) -> "Type[ProviderApi]":
-        """The defintion of the provider."""
-        return FilesystemProvider

--- a/renku/core/dataset/providers/olos.py
+++ b/renku/core/dataset/providers/olos.py
@@ -92,7 +92,7 @@ class OLOSProvider(ProviderApi, IDatasetProviderPlugin):
     @classmethod
     @hookimpl
     def dataset_provider(cls) -> "Type[OLOSProvider]":
-        """The defintion of the provider."""
+        """The definition of the provider."""
         return cls
 
 

--- a/renku/core/dataset/providers/olos.py
+++ b/renku/core/dataset/providers/olos.py
@@ -20,7 +20,7 @@
 import datetime
 import urllib
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Type
 from urllib import parse as urlparse
 from uuid import UUID, uuid4
 
@@ -28,7 +28,9 @@ from renku.command.command_builder import inject
 from renku.core import errors
 from renku.core.dataset.providers.api import ExporterApi, ProviderApi, ProviderPriority
 from renku.core.interface.client_dispatcher import IClientDispatcher
+from renku.core.plugin import hookimpl
 from renku.core.util import communication
+from renku.domain_model.dataset_provider import IDatasetProviderPlugin
 
 if TYPE_CHECKING:
     from renku.core.dataset.providers.models import ProviderParameter
@@ -282,3 +284,12 @@ class _OLOSDeposition:
                     response.status_code, json_res["message"] if "message" in json_res else json_res["status"]
                 )
             )
+
+
+class OLOSProviderPlugin(IDatasetProviderPlugin):
+    """OLOS provider plugin."""
+
+    @hookimpl
+    def dataset_provider(self) -> "Type[ProviderApi]":
+        """The defintion of the provider."""
+        return OLOSProvider

--- a/renku/core/dataset/providers/olos.py
+++ b/renku/core/dataset/providers/olos.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from renku.domain_model.dataset import Dataset, DatasetTag
 
 
-class OLOSProvider(ProviderApi):
+class OLOSProvider(ProviderApi, IDatasetProviderPlugin):
     """Provider for OLOS integration."""
 
     priority = ProviderPriority.HIGH
@@ -88,6 +88,12 @@ class OLOSProvider(ProviderApi):
 
         set_export_parameters()
         return OLOSExporter(dataset=dataset, server_url=self._server_url)
+
+    @classmethod
+    @hookimpl
+    def dataset_provider(cls) -> "Type[OLOSProvider]":
+        """The defintion of the provider."""
+        return cls
 
 
 class OLOSExporter(ExporterApi):
@@ -284,12 +290,3 @@ class _OLOSDeposition:
                     response.status_code, json_res["message"] if "message" in json_res else json_res["status"]
                 )
             )
-
-
-class OLOSProviderPlugin(IDatasetProviderPlugin):
-    """OLOS provider plugin."""
-
-    @hookimpl
-    def dataset_provider(self) -> "Type[ProviderApi]":
-        """The defintion of the provider."""
-        return OLOSProvider

--- a/renku/core/dataset/providers/renku.py
+++ b/renku/core/dataset/providers/renku.py
@@ -22,7 +22,7 @@ import shutil
 import urllib
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Type
 
 from renku.command.command_builder.command import inject
 from renku.command.login import read_renku_token
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from renku.domain_model.dataset import Dataset
 
 
-class RenkuProvider(ProviderApi):
+class RenkuProvider(ProviderApi, IDatasetProviderPlugin):
     """Renku API provider."""
 
     priority = ProviderPriority.HIGH
@@ -225,6 +225,12 @@ class RenkuProvider(ProviderApi):
             token = self._renku_token
 
         self._authorization_header = {"Authorization": f"Bearer {token}"} if token else {}
+
+    @classmethod
+    @hookimpl
+    def dataset_provider(cls) -> "Type[RenkuProvider]":
+        """The defintion of the provider."""
+        return cls
 
 
 class RenkuImporter(ImporterApi):
@@ -550,12 +556,3 @@ class RenkuImporter(ImporterApi):
             )
         finally:
             communication.enable()
-
-
-class RenkuProviderPlugin(IDatasetProviderPlugin):
-    """Renku provider plugin."""
-
-    @hookimpl
-    def dataset_provider(self) -> "Type[ProviderApi]":
-        """The defintion of the provider."""
-        return RenkuProvider

--- a/renku/core/dataset/providers/renku.py
+++ b/renku/core/dataset/providers/renku.py
@@ -229,7 +229,7 @@ class RenkuProvider(ProviderApi, IDatasetProviderPlugin):
     @classmethod
     @hookimpl
     def dataset_provider(cls) -> "Type[RenkuProvider]":
-        """The defintion of the provider."""
+        """The definition of the provider."""
         return cls
 
 

--- a/renku/core/dataset/providers/renku.py
+++ b/renku/core/dataset/providers/renku.py
@@ -22,7 +22,7 @@ import shutil
 import urllib
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
 from renku.command.command_builder.command import inject
 from renku.command.login import read_renku_token
@@ -31,11 +31,13 @@ from renku.core.dataset.datasets_provenance import DatasetsProvenance
 from renku.core.dataset.providers.api import ImporterApi, ProviderApi, ProviderPriority
 from renku.core.interface.client_dispatcher import IClientDispatcher
 from renku.core.interface.database_dispatcher import IDatabaseDispatcher
+from renku.core.plugin import hookimpl
 from renku.core.util import communication
 from renku.core.util.file_size import bytes_to_unit
 from renku.core.util.git import clone_renku_repository, get_cache_directory_for_repository, get_file_size
 from renku.core.util.metadata import is_external_file, make_project_temp_dir
 from renku.core.util.urls import remove_credentials
+from renku.domain_model.dataset_provider import IDatasetProviderPlugin
 
 if TYPE_CHECKING:
     from renku.core.dataset.providers.models import DatasetAddMetadata, ProviderDataset, ProviderParameter
@@ -548,3 +550,12 @@ class RenkuImporter(ImporterApi):
             )
         finally:
             communication.enable()
+
+
+class RenkuProviderPlugin(IDatasetProviderPlugin):
+    """Renku provider plugin."""
+
+    @hookimpl
+    def dataset_provider(self) -> "Type[ProviderApi]":
+        """The defintion of the provider."""
+        return RenkuProvider

--- a/renku/core/dataset/providers/web.py
+++ b/renku/core/dataset/providers/web.py
@@ -74,7 +74,7 @@ class WebProvider(ProviderApi, IDatasetProviderPlugin):
     @classmethod
     @hookimpl
     def dataset_provider(cls) -> "Type[WebProvider]":
-        """The defintion of the provider."""
+        """The definition of the provider."""
         return cls
 
 

--- a/renku/core/dataset/providers/web.py
+++ b/renku/core/dataset/providers/web.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from renku.core.management.client import LocalClient
 
 
-class WebProvider(ProviderApi):
+class WebProvider(ProviderApi, IDatasetProviderPlugin):
     """A provider for downloading data from web URLs."""
 
     priority = ProviderPriority.LOWEST
@@ -70,6 +70,12 @@ class WebProvider(ProviderApi):
         return download_file(
             client=client, uri=uri, destination=destination, extract=extract, filename=filename, multiple=multiple
         )
+
+    @classmethod
+    @hookimpl
+    def dataset_provider(cls) -> "Type[WebProvider]":
+        """The defintion of the provider."""
+        return cls
 
 
 def _ensure_dropbox(url):
@@ -193,12 +199,3 @@ def download_files(
             files.extend(future.result())
 
     return files
-
-
-class WebProviderPlugin(IDatasetProviderPlugin):
-    """Web provider plugin."""
-
-    @hookimpl
-    def dataset_provider(self) -> "Type[ProviderApi]":
-        """The defintion of the provider."""
-        return WebProvider

--- a/renku/core/dataset/providers/web.py
+++ b/renku/core/dataset/providers/web.py
@@ -21,15 +21,17 @@ import concurrent.futures
 import os
 import urllib
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, List, Tuple, Type
 
 from renku.core import errors
 from renku.core.constant import CACHE
 from renku.core.dataset.context import wait_for
 from renku.core.dataset.providers.api import ProviderApi, ProviderPriority
+from renku.core.plugin import hookimpl
 from renku.core.util import communication
 from renku.core.util.dataset import check_url
 from renku.core.util.urls import remove_credentials
+from renku.domain_model.dataset_provider import IDatasetProviderPlugin
 
 if TYPE_CHECKING:
     from renku.core.dataset.providers.models import DatasetAddMetadata
@@ -191,3 +193,12 @@ def download_files(
             files.extend(future.result())
 
     return files
+
+
+class WebProviderPlugin(IDatasetProviderPlugin):
+    """Web provider plugin."""
+
+    @hookimpl
+    def dataset_provider(self) -> "Type[ProviderApi]":
+        """The defintion of the provider."""
+        return WebProvider

--- a/renku/core/dataset/providers/zenodo.py
+++ b/renku/core/dataset/providers/zenodo.py
@@ -54,7 +54,7 @@ ZENODO_FILES_URL = "depositions/{0}/files"
 ZENODO_NEW_DEPOSIT_URL = "depositions"
 
 
-class ZenodoProvider(ProviderApi):
+class ZenodoProvider(ProviderApi, IDatasetProviderPlugin):
     """Zenodo registry API provider."""
 
     priority = ProviderPriority.HIGH
@@ -121,6 +121,12 @@ class ZenodoProvider(ProviderApi):
         """Create export manager for given dataset."""
         self._publish = publish
         return ZenodoExporter(dataset=dataset, publish=self._publish, tag=tag)
+
+    @classmethod
+    @hookimpl
+    def dataset_provider(cls) -> "Type[ZenodoProvider]":
+        """The defintion of the provider."""
+        return cls
 
 
 class ZenodoImporter(RepositoryImporter):
@@ -559,12 +565,3 @@ def make_records_url(record_id):
         str: Full URL for the record.
     """
     return urllib.parse.urljoin(ZENODO_BASE_URL, pathlib.posixpath.join(ZENODO_API_PATH, "records", record_id))
-
-
-class ZenodoProviderPlugin(IDatasetProviderPlugin):
-    """Zenodo provider plugin."""
-
-    @hookimpl
-    def dataset_provider(self) -> "Type[ProviderApi]":
-        """The defintion of the provider."""
-        return ZenodoProvider

--- a/renku/core/dataset/providers/zenodo.py
+++ b/renku/core/dataset/providers/zenodo.py
@@ -125,7 +125,7 @@ class ZenodoProvider(ProviderApi, IDatasetProviderPlugin):
     @classmethod
     @hookimpl
     def dataset_provider(cls) -> "Type[ZenodoProvider]":
-        """The defintion of the provider."""
+        """The definition of the provider."""
         return cls
 
 

--- a/renku/core/dataset/providers/zenodo.py
+++ b/renku/core/dataset/providers/zenodo.py
@@ -22,16 +22,18 @@ import os
 import pathlib
 import urllib
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 from urllib.parse import urlparse
 
 from renku.core import errors
 from renku.core.dataset.providers.api import ExporterApi, ProviderApi, ProviderPriority
 from renku.core.dataset.providers.repository import RepositoryImporter, make_request
+from renku.core.plugin import hookimpl
 from renku.core.util import communication
 from renku.core.util.doi import is_doi
 from renku.core.util.file_size import bytes_to_unit
 from renku.core.util.urls import remove_credentials
+from renku.domain_model.dataset_provider import IDatasetProviderPlugin
 
 if TYPE_CHECKING:
     from renku.core.dataset.providers.models import ProviderDataset, ProviderParameter
@@ -557,3 +559,12 @@ def make_records_url(record_id):
         str: Full URL for the record.
     """
     return urllib.parse.urljoin(ZENODO_BASE_URL, pathlib.posixpath.join(ZENODO_API_PATH, "records", record_id))
+
+
+class ZenodoProviderPlugin(IDatasetProviderPlugin):
+    """Zenodo provider plugin."""
+
+    @hookimpl
+    def dataset_provider(self) -> "Type[ProviderApi]":
+        """The defintion of the provider."""
+        return ZenodoProvider

--- a/renku/core/plugin/dataset_provider.py
+++ b/renku/core/plugin/dataset_provider.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Plugin hooks for renku workflow customization."""
+from typing import List, Type
+
+import pluggy
+
+from renku.core.dataset.providers.api import ProviderApi
+
+hookspec = pluggy.HookspecMarker("renku")
+
+
+@hookspec
+def dataset_provider() -> "Type[ProviderApi]":
+    """Plugin Hook for different dataset providers.
+
+    Returns:
+        A reference to the provider itself
+    """
+    pass
+
+
+def get_supported_dataset_providers() -> "List[Type[ProviderApi]]":
+    """Returns the currently available interactive session providers."""
+    from renku.core.plugin.pluginmanager import get_plugin_manager
+
+    pm = get_plugin_manager()
+    return pm.hook.dataset_provider()

--- a/renku/core/plugin/dataset_provider.py
+++ b/renku/core/plugin/dataset_provider.py
@@ -16,11 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Plugin hooks for renku workflow customization."""
-from typing import List, Type
+from typing import TYPE_CHECKING, List, Type
 
 import pluggy
 
-from renku.core.dataset.providers.api import ProviderApi
+if TYPE_CHECKING:
+    from renku.core.dataset.providers.api import ProviderApi
 
 hookspec = pluggy.HookspecMarker("renku")
 

--- a/renku/core/plugin/implementations/__init__.py
+++ b/renku/core/plugin/implementations/__init__.py
@@ -19,23 +19,23 @@
 
 from typing import TYPE_CHECKING, List, Type
 
+from renku.core.dataset.providers.dataverse import DataverseProvider
+from renku.core.dataset.providers.git import GitProvider
+from renku.core.dataset.providers.local import FilesystemProvider
+from renku.core.dataset.providers.olos import OLOSProvider
+from renku.core.dataset.providers.renku import RenkuProvider
+from renku.core.dataset.providers.web import WebProvider
+from renku.core.dataset.providers.zenodo import ZenodoProvider
 from renku.core.session.docker import DockerSessionProvider
 from renku.core.session.renkulab import RenkulabSessionProvider
 from renku.core.workflow.converters.cwl import CWLExporter
 from renku.core.workflow.providers.cwltool import CWLToolProvider
-from renku.core.dataset.providers.dataverse import DataverseProviderPlugin
-from renku.core.dataset.providers.git import GitProviderPlugin
-from renku.core.dataset.providers.local import FilesystemProviderPlugin
-from renku.core.dataset.providers.olos import OLOSProviderPlugin
-from renku.core.dataset.providers.renku import RenkuProviderPlugin
-from renku.core.dataset.providers.web import WebProviderPlugin
-from renku.core.dataset.providers.zenodo import ZenodoProviderPlugin
 
 if TYPE_CHECKING:
+    from renku.core.dataset.providers.api import ProviderApi
     from renku.domain_model.session import ISessionProvider
     from renku.domain_model.workflow.converters import IWorkflowConverter
     from renku.domain_model.workflow.provider import IWorkflowProvider
-    from renku.core.dataset.providers.api import ProviderApi
 
 __all__: List[str] = []
 
@@ -43,13 +43,13 @@ session_providers: "List[Type[ISessionProvider]]" = [DockerSessionProvider, Renk
 workflow_exporters: "List[Type[IWorkflowConverter]]" = [CWLExporter]
 workflow_providers: "List[Type[IWorkflowProvider]]" = [CWLToolProvider]
 dataset_providers: "List[Type[ProviderApi]]" = [
-    DataverseProviderPlugin,
-    GitProviderPlugin,
-    FilesystemProviderPlugin,
-    OLOSProviderPlugin,
-    RenkuProviderPlugin,
-    WebProviderPlugin,
-    ZenodoProviderPlugin,
+    DataverseProvider,
+    GitProvider,
+    FilesystemProvider,
+    OLOSProvider,
+    RenkuProvider,
+    WebProvider,
+    ZenodoProvider,
 ]
 
 try:

--- a/renku/core/plugin/implementations/__init__.py
+++ b/renku/core/plugin/implementations/__init__.py
@@ -23,17 +23,34 @@ from renku.core.session.docker import DockerSessionProvider
 from renku.core.session.renkulab import RenkulabSessionProvider
 from renku.core.workflow.converters.cwl import CWLExporter
 from renku.core.workflow.providers.cwltool import CWLToolProvider
+from renku.core.dataset.providers.dataverse import DataverseProviderPlugin
+from renku.core.dataset.providers.git import GitProviderPlugin
+from renku.core.dataset.providers.local import FilesystemProviderPlugin
+from renku.core.dataset.providers.olos import OLOSProviderPlugin
+from renku.core.dataset.providers.renku import RenkuProviderPlugin
+from renku.core.dataset.providers.web import WebProviderPlugin
+from renku.core.dataset.providers.zenodo import ZenodoProviderPlugin
 
 if TYPE_CHECKING:
     from renku.domain_model.session import ISessionProvider
     from renku.domain_model.workflow.converters import IWorkflowConverter
     from renku.domain_model.workflow.provider import IWorkflowProvider
+    from renku.core.dataset.providers.api import ProviderApi
 
 __all__: List[str] = []
 
 session_providers: "List[Type[ISessionProvider]]" = [DockerSessionProvider, RenkulabSessionProvider]
 workflow_exporters: "List[Type[IWorkflowConverter]]" = [CWLExporter]
 workflow_providers: "List[Type[IWorkflowProvider]]" = [CWLToolProvider]
+dataset_providers: "List[Type[ProviderApi]]" = [
+    DataverseProviderPlugin,
+    GitProviderPlugin,
+    FilesystemProviderPlugin,
+    OLOSProviderPlugin,
+    RenkuProviderPlugin,
+    WebProviderPlugin,
+    ZenodoProviderPlugin,
+]
 
 try:
     from renku.core.workflow.providers.toil import ToilProvider

--- a/renku/core/plugin/pluginmanager.py
+++ b/renku/core/plugin/pluginmanager.py
@@ -24,11 +24,11 @@ import pluggy
 @lru_cache(None)
 def get_plugin_manager():
     """The ``pluggy`` plugin manager."""
+    from renku.core.plugin import dataset_provider
     from renku.core.plugin import implementations as default_implementations
     from renku.core.plugin import provider as provider_hook_specs
     from renku.core.plugin import run as run_hook_specs
     from renku.core.plugin import workflow as workflow_hook_specs
-    from renku.core.plugin import dataset_provider
 
     pm = pluggy.PluginManager("renku")
     pm.add_hookspecs(provider_hook_specs)
@@ -40,5 +40,8 @@ def get_plugin_manager():
     for cls in default_implementations.__dict__.values():
         if not isinstance(cls, type):
             continue
-        pm.register(cls())
+        try:
+            pm.register(cls())
+        except TypeError:
+            pm.register(cls)
     return pm

--- a/renku/core/plugin/pluginmanager.py
+++ b/renku/core/plugin/pluginmanager.py
@@ -28,11 +28,13 @@ def get_plugin_manager():
     from renku.core.plugin import provider as provider_hook_specs
     from renku.core.plugin import run as run_hook_specs
     from renku.core.plugin import workflow as workflow_hook_specs
+    from renku.core.plugin import dataset_provider
 
     pm = pluggy.PluginManager("renku")
     pm.add_hookspecs(provider_hook_specs)
     pm.add_hookspecs(run_hook_specs)
     pm.add_hookspecs(workflow_hook_specs)
+    pm.add_hookspecs(dataset_provider)
     pm.load_setuptools_entrypoints("renku")
 
     for cls in default_implementations.__dict__.values():

--- a/renku/domain_model/dataset_provider.py
+++ b/renku/domain_model/dataset_provider.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Interactive session engine."""
+from abc import ABCMeta, abstractmethod
+from typing import Type
+
+from renku.core.dataset.providers.api import ProviderApi
+
+
+class IDatasetProviderPlugin(metaclass=ABCMeta):
+    """Abstract class for a dataset provider plugin."""
+
+    @abstractmethod
+    def dataset_provider(self) -> "Type[ProviderApi]":
+        """Supported dataset provider plugin.
+
+        Returns:
+            a ProviderApi class definition (not instance) from a specific plugin
+        """
+        pass

--- a/renku/domain_model/dataset_provider.py
+++ b/renku/domain_model/dataset_provider.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Interactive session engine."""
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta, abstractclassmethod
 from typing import Type
 
 from renku.core.dataset.providers.api import ProviderApi
@@ -25,8 +25,8 @@ from renku.core.dataset.providers.api import ProviderApi
 class IDatasetProviderPlugin(metaclass=ABCMeta):
     """Abstract class for a dataset provider plugin."""
 
-    @abstractmethod
-    def dataset_provider(self) -> "Type[ProviderApi]":
+    @abstractclassmethod
+    def dataset_provider(cls) -> "Type[ProviderApi]":
         """Supported dataset provider plugin.
 
         Returns:

--- a/renku/domain_model/dataset_provider.py
+++ b/renku/domain_model/dataset_provider.py
@@ -15,7 +15,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Interactive session engine."""
+"""Dataset providers."""
+
 from abc import ABCMeta, abstractclassmethod
 from typing import Type
 


### PR DESCRIPTION
As I am working through #2971 one of the subtasks is to make the dataset providers plugins.

I isolated the changes for this and thought it would be a good idea to submit this PR separately from the rest.

Also wanted to get a feeling of whether my way of going about this is acceptable. I decided to not try to separate `ProviderApi` and the similar importer and exporter abstract classes and try to move some portion of them in the domain_model. But if you think this is necessary then I am happy to do it. 

For now the plugins simply provide the defintion of a specific ProviderApi. And the provider factory is now using pluggy to list all the providers rather than importing what is only locally available.