### PR TITLE
chore: add vscode settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ __pycache__/
 *.py[cod]
 
 # VSCode
-.vscode/
+.vscode/*
+!.vscode/settings.json
 
 # Idea software family
 .idea/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  "python.linting.flake8Path": "flake8helled",
+  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Args": [
+    "--config",
+    "pyproject.toml",
+  ],
+  "python.formatting.provider": "black",
+  "python.formatting.blackArgs": [
+    "-l",
+    "120",
+    "-t",
+    "py36",
+    "-t",
+    "py37",
+    "-t",
+    "py38",
+    "--include",
+    "\\.pyi?$",
+    "--exclude",
+    "\\.eggs | \\.git | \\.hg | \\.mypy_cache | \\.tox | \\.venv | _build | buck-out | build | dist | docs/conf.py",
+  ],
+}


### PR DESCRIPTION
I am ok if people would like this to not be checked in. 

But if we do want it I replicated the stuff from pyproject.toml in the settings.json file.

The most important thing tbh is that vscode properly uses 120 as the line length after using this file.