### PR TITLE
chore: make poetry lockfile check not required

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -41,7 +41,7 @@ check_styles(){
     isort -c --df .
     flakehell lint renku/ tests/ conftest.py
     find . -path ./.eggs -prune -o -iname \*.sh -print0 | xargs -0 shellcheck
-    poetry lock --no-update && (git diff --exit-code -- poetry.lock > /dev/null || (echo "Poetry lock file out of date! Run 'poetry lock'" && exit 1))
+    poetry lock --no-update && (git diff --exit-code -- poetry.lock > /dev/null || (echo "Poetry lock file out of date! Run 'poetry lock'"))
 }
 
 build_docs(){


### PR DESCRIPTION
Because poetry lockfile sort order is non-deterministic at the moment