### PR TITLE
chore: fix cleanup of service test branches

### DIFF
--- a/tests/service/fixtures/service_integration.py
+++ b/tests/service/fixtures/service_integration.py
@@ -137,6 +137,7 @@ def svc_client_setup(integration_lifecycle):
             # NOTE: Some tests delete the repo
             repository.checkout("master")
             repository.branches.remove(current, force=True)
+            repository.push(remote="origin", refspec=new_branch, delete=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
the branch was deleted in the fixture but the deletion was not pushed to the remote