### PR TITLE
fix(docs): remove indentation

### DIFF
--- a/renku/domain_model/project.py
+++ b/renku/domain_model/project.py
@@ -111,8 +111,7 @@ class Project(persistent.Persistent):
             namespace(Optional[str]): Namespace of the project (when creating a new one) (Default value = None).
             description(Optional[str]): Project description (when creating a new one) (Default value = None).
             keywords(Optional[List[str]]): Keywords for the project (when creating a new one) (Default value = None).
-            custom_metadata(Optional[Dict]): Custom JSON-LD metadata (when creating a new project)
-                (Default value = None).
+            custom_metadata(Optional[Dict]): Custom JSON-LD metadata (when creating a new project) (Default value = None).
             creator(Optional[Person]): The project creator.
         """
         namespace, name = cls.get_namespace_and_name(


### PR DESCRIPTION
The extra indentation was causing problems for sphinx:

```
reading sources... [100%] renku-python/docs/reference/plugins                                                                                                   
/workspaces/renku/.venv/lib/python3.9/site-packages/renku/domain_model/project.py:docstring of renku.domain_model.project.Project.from_client:11: WARNING: Unexpected indentation.
/workspaces/renku/.venv/lib/python3.9/site-packages/renku/domain_model/project.py:docstring of renku.domain_model.project.Project.from_client:12: WARNING: Block quote ends without a blank line; unexpected unindent.
```

