### PR TITLE
chore: pin poetry in github actions

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install coveralls poetry wheel twine poetry-dynamic-versioning==0.17.1
+          python -m pip install coveralls poetry==1.1.15 wheel twine poetry-dynamic-versioning==0.17.1
           poetry-dynamic-versioning
           make download-templates
           python -m pip install .[all]
@@ -113,7 +113,7 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install coveralls poetry wheel twine poetry-dynamic-versioning==0.17.1
+          python -m pip install coveralls poetry==1.1.15 wheel twine poetry-dynamic-versioning==0.17.1
           poetry-dynamic-versioning
           make download-templates
           python -m pip install .[all]
@@ -152,7 +152,7 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install coveralls poetry wheel twine poetry-dynamic-versioning==0.17.1
+          python -m pip install coveralls poetry==1.1.15 wheel twine poetry-dynamic-versioning==0.17.1
           poetry-dynamic-versioning
           make download-templates
           python -m pip install .[all]
@@ -192,7 +192,7 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install coveralls poetry wheel twine poetry-dynamic-versioning==0.17.1
+          python -m pip install coveralls poetry==1.1.15 wheel twine poetry-dynamic-versioning==0.17.1
           poetry-dynamic-versioning
           make download-templates
           pip install .[all]
@@ -238,7 +238,7 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install coveralls poetry wheel twine poetry-dynamic-versioning==0.17.1
+          python -m pip install coveralls poetry==1.1.15 wheel twine poetry-dynamic-versioning==0.17.1
           poetry-dynamic-versioning
           make download-templates
           python -m pip install .[all]
@@ -306,7 +306,7 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install coveralls poetry wheel twine poetry-dynamic-versioning==0.17.1
+          python -m pip install coveralls poetry==1.1.15 wheel twine poetry-dynamic-versioning==0.17.1
           poetry-dynamic-versioning
           make download-templates
           python -m pip install .[all]
@@ -380,7 +380,7 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install coveralls poetry wheel twine poetry-dynamic-versioning==0.17.1
+          python -m pip install coveralls poetry==1.1.15 wheel twine poetry-dynamic-versioning==0.17.1
           poetry-dynamic-versioning
           make download-templates
           python -m pip install .[all]
@@ -454,7 +454,7 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install coveralls poetry wheel twine poetry-dynamic-versioning==0.17.1
+          python -m pip install coveralls poetry==1.1.15 wheel twine poetry-dynamic-versioning==0.17.1
           poetry-dynamic-versioning
           make download-templates
           python -m pip install .[all]
@@ -678,7 +678,7 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install coveralls poetry wheel twine poetry-dynamic-versioning==0.17.1
+          python -m pip install coveralls poetry==1.1.15 wheel twine poetry-dynamic-versioning==0.17.1
           poetry-dynamic-versioning
           make download-templates
           python -m pip install .[all]
@@ -769,7 +769,7 @@ jobs:
         if: steps.dependency-cache.outputs.cache-hit != 'true' || 'refs/heads/master' == github.ref || 'refs/heads/develop' == github.ref || startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip
-          python -m pip install coveralls poetry wheel twine poetry-dynamic-versioning==0.17.1
+          python -m pip install coveralls poetry==1.1.15 wheel twine poetry-dynamic-versioning==0.17.1
           poetry-dynamic-versioning
           make download-templates
           python -m pip install .[all]
@@ -897,7 +897,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry poetry-dynamic-versioning==0.17.1 poetry-lock-package twine
+          python -m pip install poetry==1.1.15 poetry-dynamic-versioning==0.17.1 poetry-lock-package twine
           python -m pip install .[all]
           git config --global --add user.name "Renku Bot"
           git config --global --add user.email "renku@datascience.ch"


### PR DESCRIPTION
the action to publish the `renku_lock` package didn't work properly with poetry 1.2.x. Other actions seem to work, but just in case, it's probably safer to pin it everywhere until we switch.