### PR TITLE
tests: fix test repo urls to match new gitlab cloudnative form

### DIFF
--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -148,12 +148,12 @@ def test_init_initial_branch(isolated_runner, project_init):
     "remote",
     [
         (
-            "https://user:password@dev.renku.ch/gitlab/group/subgroup/project.git",
+            "https://user:password@gitlab.dev.renku.ch/group/subgroup/project.git",
             "https://dev.renku.ch/projects/group/subgroup/project",
         ),
         ("ssh://@dev.renku.ch:group/subgroup/project.git", "https://dev.renku.ch/projects/group/subgroup/project"),
         (
-            "https://user:password@dev.renku.ch/gitlab/group/subgroup/sub-subgroup/project.git",
+            "https://user:password@gitlab.dev.renku.ch/group/subgroup/sub-subgroup/project.git",
             "https://dev.renku.ch/projects/group/subgroup/sub-subgroup/project",
         ),
         (

--- a/tests/cli/test_integration_cli.py
+++ b/tests/cli/test_integration_cli.py
@@ -28,7 +28,7 @@ from tests.utils import format_result_exception, retry_failed
 
 @pytest.mark.integration
 @retry_failed
-@pytest.mark.parametrize("url", ["https://dev.renku.ch/gitlab/renku-testing/project-9"])
+@pytest.mark.parametrize("url", ["https://gitlab.dev.renku.ch/renku-testing/project-9"])
 def test_renku_clone(runner, monkeypatch, url):
     """Test cloning of a Renku repo and existence of required settings."""
     import renku.core.storage
@@ -59,7 +59,7 @@ def test_renku_clone(runner, monkeypatch, url):
 
 @pytest.mark.integration
 @retry_failed
-@pytest.mark.parametrize("url", ["https://dev.renku.ch/gitlab/renku-testing/project-9"])
+@pytest.mark.parametrize("url", ["https://gitlab.dev.renku.ch/renku-testing/project-9"])
 def test_renku_clone_with_config(tmp_path, url):
     """Test cloning of a Renku repo and existence of required settings."""
     with chdir(tmp_path):
@@ -75,7 +75,7 @@ def test_renku_clone_with_config(tmp_path, url):
 
 @pytest.mark.integration
 @retry_failed
-@pytest.mark.parametrize("url", ["https://dev.renku.ch/gitlab/renku-testing/project-9"])
+@pytest.mark.parametrize("url", ["https://gitlab.dev.renku.ch/renku-testing/project-9"])
 def test_renku_clone_checkout_rev(tmp_path, url):
     """Test cloning of a repo checking out a rev with static config."""
     with chdir(tmp_path):
@@ -102,7 +102,7 @@ def test_renku_clone_checkout_revs(tmp_path, rev, detached):
         repository, _ = (
             project_clone_command()
             .build()
-            .execute("https://dev.renku.ch/gitlab/renku-python-integration-tests/no-renku.git", checkout_revision=rev)
+            .execute("https://gitlab.dev.renku.ch/renku-python-integration-tests/no-renku.git", checkout_revision=rev)
         ).output
 
         if detached:
@@ -117,7 +117,7 @@ def test_renku_clone_checkout_revs(tmp_path, rev, detached):
 @retry_failed
 def test_renku_clone_uses_project_name(runner, path, expected_path):
     """Test renku clone uses project name as target-path by default."""
-    remote = "https://dev.renku.ch/gitlab/renku-testing/project-9"
+    remote = "https://gitlab.dev.renku.ch/renku-testing/project-9"
 
     with runner.isolated_filesystem() as project_path:
         result = runner.invoke(cli, ["clone", remote, path])

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -666,7 +666,7 @@ def test_dataset_export_upload_tag(
 @pytest.mark.integration
 def test_dataset_export_to_local(runner, tmp_path):
     """Test exporting a version of dataset to a local directory."""
-    url = "https://dev.renku.ch/gitlab/renku-python-integration-tests/lego-datasets.git"
+    url = "https://gitlab.dev.renku.ch/renku-python-integration-tests/lego-datasets.git"
     repository = Repository.clone_from(url=url, path=tmp_path / "repo")
     # NOTE: Install LFS and disable LFS smudge filter to make sure that we can get valid content in that case
     repository.lfs.install(skip_smudge=True)
@@ -1440,7 +1440,7 @@ def test_import_from_renku_project(tmpdir, project, runner):
     """Check metadata for an imported dataset from other renkulab repo."""
     from renku.domain_model.project_context import project_context
 
-    url = "https://dev.renku.ch/gitlab/renku-testing/project-9.git"
+    url = "https://gitlab.dev.renku.ch/renku-testing/project-9.git"
 
     def get_remote_file():
         repo_path = tmpdir.mkdir("remote_repo")
@@ -1734,7 +1734,7 @@ def test_migration_submodule_datasets(isolated_runner, old_repository_with_submo
         assert not path.is_symlink()
         assert file.based_on is not None
         assert Path(file.entity.path).name == Path(file.based_on.path).name
-        assert "https://dev.renku.ch/gitlab/mohammad.alisafaee/remote-renku-project.git" == file.based_on.url
+        assert "https://gitlab.dev.renku.ch/mohammad.alisafaee/remote-renku-project.git" == file.based_on.url
 
 
 @pytest.mark.integration
@@ -1948,7 +1948,7 @@ def test_dataset_update_removes_deleted_files(project, runner, with_injection):
 @pytest.mark.integration
 def test_dataset_ls_with_tag(runner, tmp_path):
     """Test listing dataset files from a given tag."""
-    url = "https://dev.renku.ch/gitlab/renku-python-integration-tests/lego-datasets.git"
+    url = "https://gitlab.dev.renku.ch/renku-python-integration-tests/lego-datasets.git"
     repository = Repository.clone_from(url=url, path=tmp_path / "repo")
 
     os.chdir(repository.path)

--- a/tests/cli/test_template.py
+++ b/tests/cli/test_template.py
@@ -203,7 +203,7 @@ def test_template_set_uses_renku_version_when_non_existing(tmpdir, runner):
     from renku.domain_model.project_context import project_context
     from renku.version import __version__
 
-    url = "https://dev.renku.ch/gitlab/renku-testing/project-9.git"
+    url = "https://gitlab.dev.renku.ch/renku-testing/project-9.git"
     repo_path = tmpdir.mkdir("repo")
     Repository.clone_from(url=url, path=repo_path, env={"GIT_LFS_SKIP_SMUDGE": "1"})
 

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -249,7 +249,7 @@ def test_uppercase_dataset_name_is_valid():
 @pytest.mark.integration
 def test_get_dataset_by_tag(with_injection, tmp_path):
     """Test getting datasets by a given tag."""
-    url = "https://dev.renku.ch/gitlab/renku-python-integration-tests/lego-datasets.git"
+    url = "https://gitlab.dev.renku.ch/renku-python-integration-tests/lego-datasets.git"
     repository = Repository.clone_from(url=url, path=tmp_path / "repo")
 
     with project_context.with_path(repository.path), with_injection():

--- a/tests/core/metadata/test_repository.py
+++ b/tests/core/metadata/test_repository.py
@@ -261,7 +261,7 @@ def test_contains_untracked_file(git_repository):
 @pytest.mark.integration
 def test_get_content_from_lfs(tmp_path):
     """Test can get file content from LFS."""
-    url = "https://dev.renku.ch/gitlab/renku-python-integration-tests/lego-datasets.git"
+    url = "https://gitlab.dev.renku.ch/renku-python-integration-tests/lego-datasets.git"
     repository = Repository.clone_from(url=url, path=tmp_path / "repo", env={"GIT_LFS_SKIP_SMUDGE": "1"})
     # NOTE: Install LFS and disable LFS smudge filter to make sure that we can get valid content in that case
     repository.lfs.install(skip_smudge=True)

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -23,19 +23,19 @@ from pathlib import Path
 import pytest
 
 IT_REMOTE_REPO_URL = os.getenv(
-    "IT_REMOTE_REPOSITORY", "https://dev.renku.ch/gitlab/renku-python-integration-tests/core-integration-test"
+    "IT_REMOTE_REPOSITORY", "https://gitlab.dev.renku.ch/renku-python-integration-tests/core-integration-test"
 )
 IT_PROTECTED_REMOTE_REPO_URL = os.getenv(
-    "IT_PROTECTED_REMOTE_REPO", "https://dev.renku.ch/gitlab/renku-python-integration-tests/core-it-protected.git"
+    "IT_PROTECTED_REMOTE_REPO", "https://gitlab.dev.renku.ch/renku-python-integration-tests/core-it-protected.git"
 )
 IT_PUBLIC_REMOTE_REPO_URL = os.getenv(
-    "IT_PUBLIC_REMOTE_REPO", "https://dev.renku.ch/gitlab/renku-python-integration-tests/core-it-public"
+    "IT_PUBLIC_REMOTE_REPO", "https://gitlab.dev.renku.ch/renku-python-integration-tests/core-it-public"
 )
 IT_REMOTE_NON_RENKU_REPO_URL = os.getenv(
-    "IT_REMOTE_NON_RENKU_REPO_URL", "https://dev.renku.ch/gitlab/renku-python-integration-tests/core-it-non-renku"
+    "IT_REMOTE_NON_RENKU_REPO_URL", "https://gitlab.dev.renku.ch/renku-python-integration-tests/core-it-non-renku"
 )
 IT_REMOTE_NO_COMMITS_REPO_URL = os.getenv(
-    "IT_REMOTE_NO_COMMITS_REPO_URL", "https://dev.renku.ch/gitlab/renku-python-integration-tests/core-it-no-commits"
+    "IT_REMOTE_NO_COMMITS_REPO_URL", "https://gitlab.dev.renku.ch/renku-python-integration-tests/core-it-no-commits"
 )
 IT_GIT_ACCESS_TOKEN = os.getenv("IT_OAUTH_GIT_TOKEN")
 

--- a/tests/fixtures/templates.py
+++ b/tests/fixtures/templates.py
@@ -82,7 +82,7 @@ def project_init(template):
             data["test_project"],
         ],
         "init_custom_template": (
-            "https://dev.renku.ch/gitlab/renku-python-integration-tests/core-it-template-variable-test-project"
+            "https://gitlab.dev.renku.ch/renku-python-integration-tests/core-it-template-variable-test-project"
         ),
         "remote": ["--template-source", template["url"], "--template-ref", template["ref"]],
         "id": ["--template-id", template["id"]],

--- a/tests/service/controllers/utils/test_remote_project.py
+++ b/tests/service/controllers/utils/test_remote_project.py
@@ -33,14 +33,14 @@ def test_project_metadata_remote():
         "email": "testing@user.com",
         "token": "123",
     }
-    request_data = {"git_url": "https://dev.renku.ch/gitlab/renku-python-integration-tests/import-me"}
+    request_data = {"git_url": "https://gitlab.dev.renku.ch/renku-python-integration-tests/import-me"}
     ctrl = RemoteProject(user_data, request_data)
     path = ctrl.remote_url
 
     assert path
     assert "https" == path.scheme
-    assert "oauth2:123@dev.renku.ch" == path.netloc
-    assert "/gitlab/renku-python-integration-tests/import-me" == path.path
+    assert "oauth2:123@gitlab.dev.renku.ch" == path.netloc
+    assert "/renku-python-integration-tests/import-me" == path.path
     assert "" == path.params
     assert "" == path.query
     assert "" == path.fragment
@@ -55,7 +55,7 @@ def test_project_metadata_custom_remote():
     }
 
     request_data = {
-        "git_url": "https://dev.renku.ch/gitlab/renku-python-integration-tests/import-me",
+        "git_url": "https://gitlab.dev.renku.ch/renku-python-integration-tests/import-me",
         "ref": "my-branch",
     }
 
@@ -72,12 +72,12 @@ def test_project_metadata_remote_err():
         "email": "testing@user.com",
         "token": "123",
     }
-    request_data = {"git_url": "/dev.renku.ch/gitlab/renku-python-integration-tests/import-me"}
+    request_data = {"git_url": "/gitlab.dev.renku.ch/renku-python-integration-tests/import-me"}
 
     with pytest.raises(ValidationError):
         RemoteProject(user_data, request_data)
 
-    request_data["git_url"] = "httpz://dev.renku.ch/gitlab/renku-python-integration-tests/import-me"
+    request_data["git_url"] = "httpz://gitlab.dev.renku.ch/renku-python-integration-tests/import-me"
 
     with pytest.raises(ValidationError):
         RemoteProject(user_data, request_data)
@@ -93,7 +93,7 @@ def test_remote_project_context():
         "email": "testing@user.com",
         "token": "123",
     }
-    request_data = {"git_url": "https://dev.renku.ch/gitlab/renku-python-integration-tests/import-me"}
+    request_data = {"git_url": "https://gitlab.dev.renku.ch/renku-python-integration-tests/import-me"}
     ctrl = RemoteProject(user_data, request_data)
 
     with ctrl.remote() as project_path:

--- a/tests/service/fixtures/service_client.py
+++ b/tests/service/fixtures/service_client.py
@@ -220,7 +220,7 @@ def svc_client_templates_creation(svc_client_with_templates):
         "parameters": parameters,
         "project_name": f"Test renku-core {uuid.uuid4().hex[:12]}",
         "project_namespace": "renku-python-integration-tests",
-        "project_repository": "https://dev.renku.ch/gitlab",
+        "project_repository": "https://gitlab.dev.renku.ch",
         "project_description": "new service project",
         "project_custom_metadata": {
             "@id": "http://example.com/metadata12",

--- a/tests/service/fixtures/service_projects.py
+++ b/tests/service/fixtures/service_projects.py
@@ -76,7 +76,7 @@ def it_remote_public_renku_repo_url():
 @pytest.fixture(scope="module")
 def it_remote_public_repo_url():
     """Returns a remote path to a public integration test repository."""
-    return "https://dev.renku.ch/gitlab/renku-python-integration-tests/no-renku"
+    return "https://gitlab.dev.renku.ch/renku-python-integration-tests/no-renku"
 
 
 @pytest.fixture(scope="function")

--- a/tests/service/views/test_dataset_views.py
+++ b/tests/service/views/test_dataset_views.py
@@ -658,7 +658,7 @@ def test_list_datasets_anonymous(svc_client_with_repo, it_remote_repo_url):
     assert UserRepoNoAccessError.code == response.json["error"]["code"]
 
     params = {
-        "git_url": "https://dev.renku.ch/gitlab/renku-python-integration-tests/no-renku",
+        "git_url": "https://gitlab.dev.renku.ch/renku-python-integration-tests/no-renku",
     }
 
     response = svc_client.get("/datasets.list", query_string=params, headers={})
@@ -733,7 +733,7 @@ def test_list_dataset_files_anonymous(svc_client_with_repo, it_remote_repo_url):
     assert_rpc_response(response, "error")
     assert UserRepoNoAccessError.code == response.json["error"]["code"]
 
-    params = {"git_url": "https://dev.renku.ch/gitlab/renku-python-integration-tests/no-renku", "name": "mydata"}
+    params = {"git_url": "https://gitlab.dev.renku.ch/renku-python-integration-tests/no-renku", "name": "mydata"}
 
     response = svc_client.get("/datasets.files_list", query_string=params, headers={})
     assert_rpc_response(response, "error")


### PR DESCRIPTION
With the cloud-native chart, urls are now `gitlab.dev.renku.ch` instead of `dev.renku.ch/gitlab`