### PR TITLE
fix(workflow): set plan creation date to activity start date

### DIFF
--- a/renku/command/run.py
+++ b/renku/command/run.py
@@ -204,7 +204,9 @@ def _run_command(
         if not creators:
             creators = [cast(Person, get_git_user(project_context.repository))]
 
-        plan = tool.to_plan(name=name, description=description, keywords=keyword, creators=creators)
+        plan = tool.to_plan(
+            name=name, description=description, keywords=keyword, creators=creators, date_created=started_at_time
+        )
         activity = Activity.from_plan(
             plan=plan,
             repository=project_context.repository,

--- a/renku/core/workflow/plan_factory.py
+++ b/renku/core/workflow/plan_factory.py
@@ -22,6 +22,7 @@ import re
 import shlex
 import time
 from contextlib import contextmanager
+from datetime import datetime
 from itertools import chain
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
@@ -701,11 +702,13 @@ class PlanFactory:
         description: Optional[str] = None,
         keywords: Optional[List[str]] = None,
         creators: Optional[List[Person]] = None,
+        date_created: Optional[datetime] = None,
     ) -> Plan:
         """Return an instance of ``Plan`` based on this factory."""
         plan = Plan(
             id=self.plan_id,
             name=name,
+            date_created=date_created,
             description=description,
             keywords=keywords,
             command=" ".join(self.base_command),

--- a/tests/cli/test_workflow.py
+++ b/tests/cli/test_workflow.py
@@ -1450,3 +1450,17 @@ def test_rerun_doesnt_update_plan_index(runner, project, with_injection):
     assert 0 == result.exit_code, format_result_exception(result)
     assert new_description in result.output
     assert original_description not in result.output
+
+
+def test_plan_creation_date(runner, project, with_injection):
+    """Test Plan's creation date is before Activity's start date."""
+    result = runner.invoke(cli, ["run", "--name", "r1", "--no-output", "sleep", "2"])
+    assert 0 == result.exit_code, format_result_exception(result)
+
+    with with_injection():
+        plan_gateway = PlanGateway()
+        plan = plan_gateway.get_by_name("r1")
+        activity_gateway = ActivityGateway()
+        activity = activity_gateway.get_all_activities()[0]
+
+    assert plan.date_created <= activity.started_at_time


### PR DESCRIPTION
# Description

Set Plan's creation date to be equal to Activity's start date.

Fixes #3208 
