### PR TITLE
fix(core): fix git url regex matching taking too long

### DIFF
--- a/renku/domain_model/git.py
+++ b/renku/domain_model/git.py
@@ -44,7 +44,7 @@ _RE_HOSTNAME = (
 
 _RE_PORT = r":(?P<port>\d+)"
 
-_RE_PATHNAME = r"(?P<path>(([\w\-\~\.]+)/)*?(((?P<owner>([\w\-\.]+/?)+)/)?(?P<name>[\w\-\.]+)(\.git)?)?)/*"
+_RE_PATHNAME = r"(?P<path>((\~[\w\-\.]+)/)*?(((?P<owner>[\w\-\./]+?)/)?(?P<name>[\w\-\.]+)(\.git)?)?)/*"
 
 _RE_PATHNAME_WITH_GITLAB = (
     r"(?P<path>((((gitlab/){0,1}|([\w\-\~\.]+/)*?)(?P<owner>([\w\-\.]+/)*[\w\-\.]+)/)?"

--- a/tests/core/models/test_git.py
+++ b/tests/core/models/test_git.py
@@ -18,6 +18,7 @@
 """Git regex tests."""
 
 import os
+import time
 
 import pytest
 
@@ -287,6 +288,15 @@ from renku.domain_model.git import GitURL
             "port": "1234",
             "env": "https://gitlab.example.com:1234/",
         },
+        {
+            "href": "https://gitlab.example.com/renku-test/test-2022-11-11-17-01-46.git",
+            "scheme": "https",
+            "hostname": "gitlab.example.com",
+            "name": "test-2022-11-11-17-01-46",
+            "path": "renku-test/test-2022-11-11-17-01-46.git",
+            "owner": "renku-test",
+            "env": "https://gitlab.example.com",
+        },
     ],
 )
 def test_valid_href(fields):
@@ -296,4 +306,8 @@ def test_valid_href(fields):
     if gitlab_env:
         os.environ["GITLAB_BASE_URL"] = gitlab_env
 
+    start = time.monotonic()
     assert GitURL(**fields) == GitURL.parse(fields["href"])
+    duration = time.monotonic() - start
+
+    assert duration < 1.0, "Something wrong with the GitUrl regexes, probably catastrophic backtracking"


### PR DESCRIPTION
The `gitlab_re` that we build has an issue with [catastropic backtracking](https://www.regular-expressions.info/catastrophic.html).

essentially, we matched a path like `/~something/owner/repo` and the part that matches `~something`, the part that matches `owner` and the part that matches `repo` were greedy matches for a variable number of path fragments separated by `/` so there's a ton of valid match combinations which regex searches exhaustively.

with this change, it only matches a single part with `~` in front, `owner` matches a variable path like `a/b/c/d` and repo only matches the last part. so the only variable-length thing is `owner` (in the case of subgroups in gitlab). This makes it run fast again.

I also added a test case that, with the old regex, takes 14 seconds and the duration check fails, with the new regex takes 2.3 seconds (for 14 tests) and passes.