### PR TITLE
fix(service): snyk xss warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ tmp/
 
 # pytest-recording cache
 cassettes
+
+# snyk
+.dccache

--- a/renku/ui/service/entrypoint.py
+++ b/renku/ui/service/entrypoint.py
@@ -117,7 +117,7 @@ def register_exceptions(app):
 
         # NOTE: craft user messages
         if hasattr(e, "code"):
-            code = e.code
+            code = int(e.code)
 
             # NOTE: return an http error for methods with no body allowed. This prevents undesired exceptions.
             NO_PAYLOAD_METHODS = "HEAD"

--- a/renku/ui/service/views/__init__.py
+++ b/renku/ui/service/views/__init__.py
@@ -16,15 +16,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Renku service views."""
-from flask import current_app
+from flask import jsonify
+from marshmallow import Schema
 
 from renku.ui.service.config import SVC_ERROR_GENERIC
 from renku.ui.service.serializers.rpc import JsonRPCResponse
 
 
-def result_response(serializer, data):
+def result_response(serializer: Schema, data):
     """Construct flask response."""
-    return current_app.response_class(response=serializer.dumps({"result": data}), mimetype="application/json")
+    return jsonify(serializer.dump({"result": data}))
 
 
 def error_response(serviceError):
@@ -40,4 +41,4 @@ def error_response(serviceError):
     if hasattr(serviceError, "sentry"):
         error["sentry"] = serviceError.sentry
 
-    return current_app.response_class(response=JsonRPCResponse().dumps({"error": error}), mimetype="application/json")
+    return jsonify(JsonRPCResponse().dump({"error": error}))


### PR DESCRIPTION
Fixes high severity XSS vulnerabilities reported by snyk. I think these are hard if not impossible to abuse because the parameter in question is looked up in the renku metadata before it is returned. And if the id is not found then the request would fail.

The strange thing is that running snyk locally like `SNYK_CFG_ORG=renku snyk code test` still shows:
```
✗ [High] Cross-site Scripting (XSS) 
   Path: renku/ui/service/views/jobs.py, line 103 
   Info: Unsanitized input from an HTTP parameter flows into the return value of job_details, where it is used to render an HTML page returned to the user. This may result in a Cross-Site Scripting attack (XSS).
```

But if I move the code from `result_response` directly into `renku/ui/service/views/jobs.py` where the error is reported then the error goes away. So I think that simply snyk fails to recognize/track the function that is being used.