### PR TITLE
docs: fix readthedocs build not installing docs group

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,11 +3,23 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+  jobs:
+    post_create_environment:
+      # Install poetry
+      - pip install poetry
+      # Tell poetry to not use a virtual environment
+      - poetry config virtualenvs.create false
+    post_install:
+      # Install dependencies
+      - poetry install --with docs --with tests
+
 python:
-  version: 3.7
+  version: 3.9
   install:
     - method: pip
       path: .
-      extra_requirements:
-        - docs
-        - tests


### PR DESCRIPTION
since dev and docs are now groups, not extras, `pip install .[docs]` doesn't work anymore. This fixes that