### PR TITLE
feat(dataset): support for azure blob storage

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -754,6 +754,9 @@ jobs:
           ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
           OLOS_ACCESS_TOKEN: ${{ secrets.OLOS_ACCESS_TOKEN }}
           RENKU_REQUESTS_TIMEOUT_SECONDS: 120
+          CLOUD_STORAGE_AZURE_KEY: ${{ secrets.CLOUD_STORAGE_AZURE_KEY }}
+          CLOUD_STORAGE_S3_ACCESS_KEY_ID: ${{ secrets.CLOUD_STORAGE_S3_ACCESS_KEY_ID }}
+          CLOUD_STORAGE_S3_SECRET_ACCESS_KEY: ${{ secrets.CLOUD_STORAGE_S3_SECRET_ACCESS_KEY }}
         run: pytest -m "integration and not service and not serial" -v --timeout=600 -n auto
       - name: Start Redis
         uses: supercharge/redis-github-action@1.4.0
@@ -912,6 +915,9 @@ jobs:
           ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
           OLOS_ACCESS_TOKEN: ${{ secrets.OLOS_ACCESS_TOKEN }}
           RENKU_REQUESTS_TIMEOUT_SECONDS: 120
+          CLOUD_STORAGE_AZURE_KEY: ${{ secrets.CLOUD_STORAGE_AZURE_KEY }}
+          CLOUD_STORAGE_S3_ACCESS_KEY_ID: ${{ secrets.CLOUD_STORAGE_S3_ACCESS_KEY_ID }}
+          CLOUD_STORAGE_S3_SECRET_ACCESS_KEY: ${{ secrets.CLOUD_STORAGE_S3_SECRET_ACCESS_KEY }}
         run: pytest -m "integration and not serial" -v
       - name: Start Redis
         uses: supercharge/redis-github-action@1.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,9 @@ responses = ">=0.22.0,<0.23.0"
 [tool.poetry.group.docs]
 optional = true
 
+[tool.flakehell]
+extended_default_ignore=[]
+
 [tool.poetry.group.docs.dependencies]
 plantweb = ">=1.2.1,<1.3.0"
 renku-sphinx-theme = ">=0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,9 +167,6 @@ responses = ">=0.22.0,<0.23.0"
 [tool.poetry.group.docs]
 optional = true
 
-[tool.flakehell]
-extended_default_ignore=[]
-
 [tool.poetry.group.docs.dependencies]
 plantweb = ">=1.2.1,<1.3.0"
 renku-sphinx-theme = ">=0.2.0"

--- a/renku/command/dataset.py
+++ b/renku/command/dataset.py
@@ -138,3 +138,8 @@ def mount_external_storage_command(unmount: bool):
     """Command for mounting an external storage."""
     command = unmount_external_storage if unmount else mount_external_storage
     return Command().command(command).lock_dataset().with_database(write=False).require_migration()
+
+
+def unmount_external_storage_command():
+    """Command for unmounting an external storage."""
+    return Command().command(unmount_external_storage).lock_dataset().with_database(write=False).require_migration()

--- a/renku/core/dataset/dataset.py
+++ b/renku/core/dataset/dataset.py
@@ -34,7 +34,6 @@ from renku.core.dataset.datasets_provenance import DatasetsProvenance
 from renku.core.dataset.pointer_file import create_external_file, is_external_file_updated, update_external_file
 from renku.core.dataset.providers.factory import ProviderFactory
 from renku.core.dataset.providers.models import ProviderDataset
-from renku.core.dataset.providers.s3 import S3Credentials
 from renku.core.dataset.request_model import ImageRequestModel
 from renku.core.dataset.tag import get_dataset_by_tag, prompt_access_token, prompt_tag_selection
 from renku.core.interface.dataset_gateway import IDatasetGateway
@@ -882,10 +881,8 @@ def update_dataset_custom_metadata(
     if custom_metadata is not None and custom_metadata_source is not None:
         if isinstance(custom_metadata, dict):
             custom_metadata = [custom_metadata]
-        for icustom_metadata in custom_metadata:
-            existing_metadata.append(
-                Annotation(id=Annotation.generate_id(), body=icustom_metadata, source=custom_metadata_source)
-            )
+        for cm in custom_metadata:
+            existing_metadata.append(Annotation(id=Annotation.generate_id(), body=cm, source=custom_metadata_source))
 
     dataset.annotations = existing_metadata
 
@@ -1346,7 +1343,7 @@ def mount_external_storage(name: str, existing: Optional[Path], yes: bool) -> No
     datadir.mkdir(parents=True, exist_ok=True)
 
     provider = ProviderFactory.get_mount_provider(uri=dataset.storage)
-    credentials = S3Credentials(provider)
+    credentials = provider.get_credentials()
     prompt_for_credentials(credentials)
     storage = provider.get_storage(credentials=credentials)
 

--- a/renku/core/dataset/dataset_add.py
+++ b/renku/core/dataset/dataset_add.py
@@ -322,23 +322,33 @@ def move_files_to_dataset(dataset: Dataset, files: List[DatasetAddMetadata]):
             else:
                 file.action = DatasetAddAction.DOWNLOAD
 
-        if file.action == DatasetAddAction.COPY:
-            shutil.copy(file.source, file.destination)
-        elif file.action == DatasetAddAction.MOVE:
-            shutil.move(file.source, file.destination, copy_function=shutil.copy)  # type: ignore
-        elif file.action == DatasetAddAction.SYMLINK:
-            create_external_file(target=file.source, path=file.destination)
-            # NOTE: Don't track symlinks to external files in LFS
-            track_in_lfs = False
-        elif file.action == DatasetAddAction.DOWNLOAD:
-            assert file.provider, f"Storage provider isn't set for {file} with DOWNLOAD action"
-            storage = file.provider.get_storage()
-            storage.download(file.url, file.destination)
-        elif file.metadata_only:
-            # NOTE: Nothing to do when adding file to a dataset with a parent remote storage
-            pass
-        else:
-            raise errors.OperationError(f"Invalid action {file.action}")
+        file_to_upload = file.source.resolve()
+
+        try:
+            if file.action == DatasetAddAction.COPY:
+                shutil.copy(file.source, file.destination)
+            elif file.action == DatasetAddAction.MOVE:
+                shutil.move(file.source, file.destination, copy_function=shutil.copy)  # type: ignore
+            elif file.action == DatasetAddAction.SYMLINK:
+                create_external_file(target=file.source, path=file.destination)
+                # NOTE: Don't track symlinks to external files in LFS
+                track_in_lfs = False
+            elif file.action == DatasetAddAction.DOWNLOAD:
+                assert file.provider, f"Storage provider isn't set for {file} with DOWNLOAD action"
+                download_storage = file.provider.get_storage()
+                download_storage.download(file.url, file.destination)
+                file_to_upload = file.destination
+            elif file.metadata_only:
+                # NOTE: Nothing to do when adding file to a dataset with a parent remote storage
+                pass
+            else:
+                raise errors.OperationError(f"Invalid action {file.action}")
+        except OSError as e:
+            # NOTE: It's ok if copying data to a read-only mounted cloud storage fails
+            if "Read-only file system" in str(e) and storage:
+                pass
+            else:
+                raise
 
         if track_in_lfs and not dataset.storage:
             track_paths_in_storage(file.destination)
@@ -352,8 +362,11 @@ def move_files_to_dataset(dataset: Dataset, files: List[DatasetAddMetadata]):
                 md5_hash = file.based_on.checksum
             else:
                 file_uri = get_upload_uri(dataset=dataset, entity_path=file.entity_path)
-                storage.upload(source=file.destination, uri=file_uri)
-                md5_hash = hash_file(file.destination, hash_type="md5") or ""
+                print("FILE")
+                print(file_to_upload)
+                print(file.destination)
+                storage.upload(source=file_to_upload, uri=file_uri)
+                md5_hash = hash_file(file_to_upload, hash_type="md5") or ""
 
             file.based_on = RemoteEntity(url=file_uri, path=file.entity_path, checksum=md5_hash)
 

--- a/renku/core/dataset/dataset_add.py
+++ b/renku/core/dataset/dataset_add.py
@@ -362,9 +362,6 @@ def move_files_to_dataset(dataset: Dataset, files: List[DatasetAddMetadata]):
                 md5_hash = file.based_on.checksum
             else:
                 file_uri = get_upload_uri(dataset=dataset, entity_path=file.entity_path)
-                print("FILE")
-                print(file_to_upload)
-                print(file.destination)
                 storage.upload(source=file_to_upload, uri=file_uri)
                 md5_hash = hash_file(file_to_upload, hash_type="md5") or ""
 

--- a/renku/core/dataset/providers/azure.py
+++ b/renku/core/dataset/providers/azure.py
@@ -15,7 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""S3 dataset provider."""
+"""Azure dataset provider."""
 
 import re
 import urllib
@@ -33,7 +33,7 @@ from renku.core.dataset.providers.api import (
 )
 from renku.core.dataset.providers.models import DatasetAddAction, DatasetAddMetadata, ProviderParameter
 from renku.core.interface.storage import IStorage, IStorageFactory
-from renku.core.util.metadata import prompt_for_credentials
+from renku.core.util.metadata import get_canonical_key, prompt_for_credentials
 from renku.core.util.urls import get_scheme
 from renku.domain_model.dataset import RemoteEntity
 from renku.domain_model.project_context import project_context
@@ -42,24 +42,25 @@ if TYPE_CHECKING:
     from renku.domain_model.dataset import Dataset
 
 
-class S3Provider(ProviderApi, AddProviderInterface, StorageProviderInterface):
-    """S3 provider."""
+class AzureProvider(ProviderApi, AddProviderInterface, StorageProviderInterface):
+    """Azure provider."""
 
     priority = ProviderPriority.HIGHEST
-    name = "S3"
+    name = "Azure"
 
     def __init__(self, uri: Optional[str]):
         super().__init__(uri=uri)
 
-        endpoint, bucket, _ = parse_s3_uri(uri=self.uri)
+        account, endpoint, container, _ = parse_azure_uri(uri=self.uri)
 
-        self._bucket: str = bucket
+        self._account: str = account
         self._endpoint: str = endpoint
+        self._container = container
 
     @staticmethod
     def supports(uri: str) -> bool:
         """Whether or not this provider supports a given URI."""
-        return get_scheme(uri) == "s3"
+        return get_scheme(uri) == "azure"
 
     @staticmethod
     def get_add_parameters() -> List["ProviderParameter"]:
@@ -71,49 +72,48 @@ class S3Provider(ProviderApi, AddProviderInterface, StorageProviderInterface):
                 "storage",
                 flags=["storage"],
                 default=None,
-                help="Uri for the S3 bucket when creating the dataset at the same time when running 'add'",
+                help="Uri for the Azure container when creating the dataset at the same time when running 'add'",
                 multiple=False,
                 type=str,
             ),
         ]
 
-    def get_credentials(self) -> "S3Credentials":
+    def get_credentials(self) -> "AzureCredentials":
         """Return an instance of provider's credential class."""
-        return S3Credentials(provider=self)
+        return AzureCredentials(provider=self)
 
     @inject.autoparams("storage_factory")
     def get_storage(
         self, storage_factory: "IStorageFactory", credentials: Optional["ProviderCredentials"] = None
     ) -> "IStorage":
         """Return the storage manager for the provider."""
-        s3_configuration = {
-            "type": "s3",
-            "provider": "AWS",
+        azure_configuration = {
+            "type": "azureblob",
             "endpoint": self.endpoint,
         }
 
-        def create_renku_storage_s3_uri(uri: str) -> str:
-            """Create a S3 URI to work with the Renku storage handler."""
-            _, bucket, path = parse_s3_uri(uri=uri)
+        def create_renku_storage_azure_uri(uri: str) -> str:
+            """Create an Azure URI to work with the Renku storage handler."""
+            _, _, container, path = parse_azure_uri(uri=uri)
 
-            return f"s3://{bucket}/{path}"
+            return f"azure://{container}/{path}"
 
         if not credentials:
             credentials = self.get_credentials()
             prompt_for_credentials(credentials)
 
         return storage_factory.get_storage(
-            storage_scheme="s3",
+            storage_scheme="azure",
             provider=self,
             credentials=credentials,
-            configuration=s3_configuration,
-            uri_convertor=create_renku_storage_s3_uri,
+            configuration=azure_configuration,
+            uri_convertor=create_renku_storage_azure_uri,
         )
 
     def add(self, uri: str, destination: Path, **kwargs) -> List["DatasetAddMetadata"]:
         """Add files from a URI to a dataset."""
         if re.search(r"[*?]", uri):
-            raise errors.ParameterError("Wildcards like '*' or '?' are not supported for S3 URIs.")
+            raise errors.ParameterError("Wildcards like '*' or '?' are not supported for Azure URIs.")
 
         storage = self.get_storage()
 
@@ -134,14 +134,19 @@ class S3Provider(ProviderApi, AddProviderInterface, StorageProviderInterface):
         ]
 
     @property
-    def bucket(self) -> str:
-        """Return S3 bucket name."""
-        return self._bucket
+    def account(self) -> str:
+        """Azure account name."""
+        return self._account
 
     @property
     def endpoint(self) -> str:
-        """Return S3 bucket endpoint."""
+        """Return Azure container endpoint."""
         return self._endpoint
+
+    @property
+    def container(self) -> str:
+        """Return Azure container name."""
+        return self._container
 
     def on_create(self, dataset: "Dataset") -> None:
         """Hook to perform provider-specific actions on a newly-created dataset."""
@@ -149,50 +154,59 @@ class S3Provider(ProviderApi, AddProviderInterface, StorageProviderInterface):
         prompt_for_credentials(credentials)
         storage = self.get_storage(credentials=credentials)
 
-        # NOTE: The underlying rclone tool cannot tell if a directory within a S3 bucket exists or not
+        # NOTE: The underlying rclone tool cannot tell if a directory within an Azure container exists or not
         if not storage.exists(self.uri):
-            raise errors.ParameterError(f"S3 bucket '{self.bucket}' doesn't exists.")
+            raise errors.ParameterError(f"Azure container '{self.container}' doesn't exists.")
 
         project_context.repository.add_ignored_pattern(pattern=str(dataset.get_datadir()))
 
 
-class S3Credentials(ProviderCredentials):
-    """S3-specific credentials."""
+class AzureCredentials(ProviderCredentials):
+    """Azure-specific credentials."""
 
-    def __init__(self, provider: S3Provider):
+    def __init__(self, provider: AzureProvider):
         super().__init__(provider=provider)
+
+        # NOTE: Set account name so that users don't need to re-enter it
+        self.data[get_canonical_key("Account")] = self.provider.account
 
     @staticmethod
     def get_credentials_names() -> Tuple[str, ...]:
         """Return a tuple of the required credentials for a provider."""
-        return "Access Key ID", "Secret Access Key"
+        return "Account", "Key"
 
     @property
-    def provider(self) -> S3Provider:
+    def provider(self) -> AzureProvider:
         """Return the associated provider instance."""
-        return cast(S3Provider, self._provider)
+        return cast(AzureProvider, self._provider)
 
     def get_credentials_section_name(self) -> str:
         """Get section name for storing credentials.
 
         NOTE: This methods should be overridden by subclasses to allow multiple credentials per providers if needed.
         """
-        return self.provider.endpoint.lower()
+        return f"{self.provider.account}.{self.provider.endpoint}"
 
 
-def parse_s3_uri(uri: str) -> Tuple[str, str, str]:
-    """Extract endpoint, bucket name, and path within the bucket from a given URI.
+def parse_azure_uri(uri: str) -> Tuple[str, str, str, str]:
+    """Extract account, endpoint, container, and path within the container from a given URI.
 
-    NOTE: We only support s3://<endpoint>/<bucket-name>/<path> at the moment.
+    NOTE: We support azure://<account-name>.<endpoint>/<container-name>/<path> or
+    azure://<account-name>/<container-name>/<path>.
     """
     parsed_uri = urllib.parse.urlparse(uri)
 
-    endpoint = parsed_uri.netloc
+    account, _, endpoint = parsed_uri.netloc.partition(".")
+
+    if parsed_uri.scheme.lower() != "azure" or not account:
+        raise errors.ParameterError(
+            f"Invalid Azure URI: {uri}. Valid format is 'azure://<account-name>.<endpoint>/<container-name>/<path>' or "
+            "azure://<account-name>/<container-name>/<path>"
+        )
+
+    endpoint = endpoint.lower() or "blob.core.windows.net"
+
     path = parsed_uri.path.strip("/")
+    container, _, path = path.partition("/")
 
-    if parsed_uri.scheme.lower() != "s3" or not endpoint:
-        raise errors.ParameterError(f"Invalid S3 URI: {uri}. Valid format is 's3://<endpoint>/<bucket-name>/<path>'")
-
-    bucket, _, path = path.partition("/")
-
-    return endpoint, bucket, path.strip("/")
+    return account, endpoint, container, path.strip("/")

--- a/renku/core/dataset/providers/cloud.py
+++ b/renku/core/dataset/providers/cloud.py
@@ -45,7 +45,6 @@ class CloudStorageAddProvider(AddProviderInterface, StorageProviderInterface):
                 entity_path=destination_path_in_repo / hash.path,
                 url=hash.base_uri,
                 action=DatasetAddAction.REMOTE_STORAGE,
-                # TODO: Store the original URI for use as source; based_on is not needed
                 based_on=RemoteEntity(checksum=hash.hash if hash.hash else "", url=hash.base_uri, path=hash.path),
                 source=Path(hash.base_uri),
                 destination=destination_path_in_repo,

--- a/renku/core/dataset/providers/cloud.py
+++ b/renku/core/dataset/providers/cloud.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Common functionality for cloud storage providers."""
+
+import re
+from pathlib import Path
+from typing import List
+
+from renku.core import errors
+from renku.core.dataset.providers.api import AddProviderInterface, StorageProviderInterface
+from renku.core.dataset.providers.models import DatasetAddAction, DatasetAddMetadata
+from renku.domain_model.dataset import RemoteEntity
+from renku.domain_model.project_context import project_context
+
+
+class CloudStorageAddProvider(AddProviderInterface, StorageProviderInterface):
+    """Common AddProviderInterface for cloud providers."""
+
+    def add(self, uri: str, destination: Path, **kwargs) -> List["DatasetAddMetadata"]:
+        """Add files from a URI to a dataset."""
+        if re.search(r"[*?]", uri):
+            raise errors.ParameterError("Wildcards like '*' or '?' are not supported for cloud storage URIs.")
+
+        storage = self.get_storage()
+
+        destination_path_in_repo = Path(destination).relative_to(project_context.repository.path)
+        hashes = storage.get_hashes(uri=uri)
+        return [
+            DatasetAddMetadata(
+                entity_path=destination_path_in_repo / hash.path,
+                url=hash.base_uri,
+                action=DatasetAddAction.REMOTE_STORAGE,
+                # TODO: Store the original URI for use as source; based_on is not needed
+                based_on=RemoteEntity(checksum=hash.hash if hash.hash else "", url=hash.base_uri, path=hash.path),
+                source=Path(hash.base_uri),
+                destination=destination_path_in_repo,
+                provider=self,
+            )
+            for hash in hashes
+        ]

--- a/renku/core/dataset/providers/s3.py
+++ b/renku/core/dataset/providers/s3.py
@@ -17,32 +17,24 @@
 # limitations under the License.
 """S3 dataset provider."""
 
-import re
 import urllib
-from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple, cast
 
 from renku.command.command_builder import inject
 from renku.core import errors
-from renku.core.dataset.providers.api import (
-    AddProviderInterface,
-    ProviderApi,
-    ProviderCredentials,
-    ProviderPriority,
-    StorageProviderInterface,
-)
-from renku.core.dataset.providers.models import DatasetAddAction, DatasetAddMetadata, ProviderParameter
+from renku.core.dataset.providers.api import ProviderApi, ProviderCredentials, ProviderPriority
+from renku.core.dataset.providers.cloud import CloudStorageAddProvider
+from renku.core.dataset.providers.models import ProviderParameter
 from renku.core.interface.storage import IStorage, IStorageFactory
 from renku.core.util.metadata import prompt_for_credentials
 from renku.core.util.urls import get_scheme
-from renku.domain_model.dataset import RemoteEntity
 from renku.domain_model.project_context import project_context
 
 if TYPE_CHECKING:
     from renku.domain_model.dataset import Dataset
 
 
-class S3Provider(ProviderApi, AddProviderInterface, StorageProviderInterface):
+class S3Provider(ProviderApi, CloudStorageAddProvider):
     """S3 provider."""
 
     priority = ProviderPriority.HIGHEST
@@ -109,29 +101,6 @@ class S3Provider(ProviderApi, AddProviderInterface, StorageProviderInterface):
             configuration=s3_configuration,
             uri_convertor=create_renku_storage_s3_uri,
         )
-
-    def add(self, uri: str, destination: Path, **kwargs) -> List["DatasetAddMetadata"]:
-        """Add files from a URI to a dataset."""
-        if re.search(r"[*?]", uri):
-            raise errors.ParameterError("Wildcards like '*' or '?' are not supported for S3 URIs.")
-
-        storage = self.get_storage()
-
-        destination_path_in_repo = Path(destination).relative_to(project_context.repository.path)
-        hashes = storage.get_hashes(uri=uri)
-        return [
-            DatasetAddMetadata(
-                entity_path=destination_path_in_repo / hash.path,
-                url=hash.base_uri,
-                action=DatasetAddAction.REMOTE_STORAGE,
-                # TODO: Store the original URI for use as source; based_on is not needed
-                based_on=RemoteEntity(checksum=hash.hash if hash.hash else "", url=hash.base_uri, path=hash.path),
-                source=Path(hash.base_uri),
-                destination=destination_path_in_repo,
-                provider=self,
-            )
-            for hash in hashes
-        ]
 
     @property
     def bucket(self) -> str:

--- a/renku/core/plugin/implementations/__init__.py
+++ b/renku/core/plugin/implementations/__init__.py
@@ -19,6 +19,7 @@
 
 from typing import TYPE_CHECKING, List, Type
 
+from renku.core.dataset.providers.azure import AzureProvider
 from renku.core.dataset.providers.dataverse import DataverseProvider
 from renku.core.dataset.providers.git import GitProvider
 from renku.core.dataset.providers.local import FilesystemProvider
@@ -48,6 +49,7 @@ session_providers: "List[Type[ISessionProvider]]" = [DockerSessionProvider, Renk
 workflow_exporters: "List[Type[IWorkflowConverter]]" = [CWLExporter, RenkuWorkflowFileExporter]
 workflow_providers: "List[Type[IWorkflowProvider]]" = [CWLToolProvider, LocalWorkflowProvider]
 dataset_providers: "List[Type[ProviderApi]]" = [
+    AzureProvider,
     DataverseProvider,
     GitProvider,
     FilesystemProvider,

--- a/renku/infrastructure/storage/rclone.py
+++ b/renku/infrastructure/storage/rclone.py
@@ -138,8 +138,12 @@ def run_rclone_command(command: str, *args: Any, env=None, **kwargs) -> str:
     all_outputs = result.stdout + result.stderr
     if result.returncode in (3, 4):
         raise errors.StorageObjectNotFound(all_outputs)
-    elif "AccessDenied" in all_outputs:
-        raise errors.AuthenticationError(f"Authentication failed when accessing the remote storage: {all_outputs}")
+    elif (
+        "AccessDenied" in all_outputs
+        or "no authentication method configured" in all_outputs
+        or "Need account+key" in all_outputs
+    ):
+        raise errors.AuthenticationError(f"Authentication failed when accessing the cloud storage: {all_outputs}")
     else:
         raise errors.RCloneException(f"Remote storage operation failed: {all_outputs}")
 

--- a/renku/ui/cli/dataset.py
+++ b/renku/ui/cli/dataset.py
@@ -595,7 +595,7 @@ def list_dataset(format, columns):
     help="Custom metadata to be associated with the dataset.",
 )
 @click.option("-k", "--keyword", default=None, multiple=True, type=click.STRING, help="List of keywords.")
-@click.option("-s", "--storage", default=None, type=click.STRING, help="URI of the storage backend.")
+@click.option("-s", "--storage", default=None, type=click.STRING, help="URI of the cloud storage backend.")
 @click.option(
     "--datadir",
     default=None,
@@ -1193,7 +1193,7 @@ def update(
     help="A directory to copy data to, instead of the dataset's data directory.",
 )
 def pull(name, location):
-    """Pull data from an external storage."""
+    """Pull data from a cloud storage."""
     from renku.command.dataset import pull_external_data_command
     from renku.ui.cli.utils.callback import ClickCallback
 
@@ -1213,7 +1213,7 @@ def pull(name, location):
 @click.option("-u", "--unmount", is_flag=True, help="Unmount dataset's external storage.")
 @click.option("-y", "--yes", is_flag=True, help="No prompt when removing non-empty dataset's data directory.")
 def mount(name, existing, unmount, yes):
-    """Mount an external storage in the dataset's data directory."""
+    """Mount a cloud storage in the dataset's data directory."""
     from renku.command.dataset import mount_external_storage_command
     from renku.ui.cli.utils.callback import ClickCallback
 
@@ -1223,3 +1223,13 @@ def mount(name, existing, unmount, yes):
         command.execute(name=name)
     else:
         command.execute(name=name, existing=existing, yes=yes)
+
+
+@dataset.command(hidden=True)
+@click.argument("name", shell_complete=_complete_datasets)
+def unmount(name):
+    """Unmount an external storage in the dataset's data directory."""
+    from renku.command.dataset import unmount_external_storage_command
+    from renku.ui.cli.utils.callback import ClickCallback
+
+    unmount_external_storage_command().with_communicator(ClickCallback()).build().execute(name=name)

--- a/renku/version.py
+++ b/renku/version.py
@@ -38,10 +38,11 @@ def is_release():
 
 def _get_distribution_url():
     try:
-        d = distribution("renku")
-        return d.metadata["Home-page"]
+        url = distribution("renku").metadata["Home-page"]
     except Exception:
-        return "https://github.com/swissdatasciencecenter/renku-python"
+        url = None
+
+    return "https://github.com/swissdatasciencecenter/renku-python" if not url else url
 
 
 version_url = f"{_get_distribution_url()}/tree/v{__version__}"

--- a/tests/cli/fixtures/cli_integration_datasets.py
+++ b/tests/cli/fixtures/cli_integration_datasets.py
@@ -23,11 +23,11 @@ from renku.ui.cli import cli
 
 
 @pytest.fixture()
-def create_s3_dataset(runner):
+def create_cloud_storage_dataset(runner):
     """Fixture that creates a dataset given its name and uri."""
 
-    def _create_s3_dataset(name, uri):
+    def _create_cloud_storage_dataset(name, uri):
         res = runner.invoke(cli, ["dataset", "create", name, "--storage", uri])
         return res
 
-    yield _create_s3_dataset
+    yield _create_cloud_storage_dataset

--- a/tests/cli/fixtures/cli_providers.py
+++ b/tests/cli/fixtures/cli_providers.py
@@ -97,6 +97,24 @@ def dataverse_demo(project, dataverse_demo_cleanup):
 
 
 @pytest.fixture
+def cloud_storage_credentials(project):
+    """Set credentials for all cloud storages."""
+    # S3
+    s3_access_key_id = os.getenv("CLOUD_STORAGE_S3_ACCESS_KEY_ID", "")
+    s3_secret_access_key = os.getenv("CLOUD_STORAGE_S3_SECRET_ACCESS_KEY", "")
+    s3_section = "os.zhdk.cloud.switch.ch"
+    set_value(section=s3_section, key="access-key-id", value=s3_access_key_id, global_only=True)
+    set_value(section=s3_section, key="secret-access-key", value=s3_secret_access_key, global_only=True)
+
+    # Azure
+    azure_account = "renkupythontest1"
+    azure_key = os.getenv("CLOUD_STORAGE_AZURE_KEY", "")
+    azure_section = f"{azure_account}.blob.core.windows.net"
+    set_value(section=azure_section, key="account", value=azure_account, global_only=True)
+    set_value(section=azure_section, key="key", value=azure_key, global_only=True)
+
+
+@pytest.fixture
 def doi_responses():
     """Responses for doi.org requests."""
     import responses

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -18,6 +18,7 @@
 """Integration tests for dataset command."""
 
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -1972,20 +1973,26 @@ def test_dataset_ls_with_tag(runner, tmp_path):
 @retry_failed
 @pytest.mark.vcr
 @pytest.mark.parametrize(
-    "storage", ["s3://s3.amazonaws.com/giab/", "s3://os.zhdk.cloud.switch.ch/renku-python-test-public/"]
+    "storage",
+    [
+        "s3://s3.amazonaws.com/giab/",
+        "s3://os.zhdk.cloud.switch.ch/renku-python-test-public/",
+        "azure://renkupythontest1.blob.core.windows.net/test-private-1/path",
+        "azure://renkupythontest1/test-private-1/path",
+    ],
 )
-def test_create_with_s3_backend(runner, project, storage):
-    """Test creating a dataset with a valid S3 backend storage."""
-    result = runner.invoke(cli, ["dataset", "create", "s3-data", "--storage", storage], input="\n\n\n")
+def test_create_with_could_storage(runner, project, cloud_storage_credentials, storage):
+    """Test creating a dataset with a valid backend cloud storage."""
+    result = runner.invoke(cli, ["dataset", "create", "cloud-data", "--storage", storage], input="\n\n\n")
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
-    dataset = get_dataset_with_injection("s3-data")
+    dataset = get_dataset_with_injection("cloud-data")
 
     assert storage == dataset.storage
 
     # NOTE: Dataset's data dir is git-ignored
-    dataset_datadir = os.path.join(DATA_DIR, "s3-data")
+    dataset_datadir = os.path.join(DATA_DIR, "cloud-data")
     assert {dataset_datadir} == set(project.repository.get_ignored_paths(dataset_datadir))
 
 
@@ -2005,105 +2012,155 @@ def test_create_with_non_existing_s3_backend(runner, project):
 @pytest.mark.integration
 @retry_failed
 @pytest.mark.vcr
-def test_create_with_unauthorized_s3_backend(runner, project):
-    """Test creating a dataset with an invalid credentials."""
+def test_create_with_non_existing_azure_backend(runner, project, cloud_storage_credentials):
+    """Test creating a dataset with an invalid Azure cloud storage."""
     result = runner.invoke(
-        cli, ["dataset", "create", "s3-data", "--storage", "s3://s3.amazonaws.com/amazon/"], input="\n\n\n"
+        cli, ["dataset", "create", "cloud-data", "--storage", "azure://renkupythontest1/non-existing/"], input="\n\n\n"
     )
+
+    assert 2 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
+    assert "Azure container 'non-existing' doesn't exists" in result.output
+
+
+@pytest.mark.integration
+@retry_failed
+@pytest.mark.vcr
+@pytest.mark.parametrize(
+    "storage",
+    [
+        "s3://s3.amazonaws.com/amazon/",
+        "azure://renkupythontest1/test-private-1",
+    ],
+)
+def test_create_with_unauthorized_cloud_storage(runner, project, storage):
+    """Test creating a dataset with an invalid credentials."""
+    result = runner.invoke(cli, ["dataset", "create", "cloud-data", "--storage", storage], input="\n\n\n")
 
     assert 1 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
-    assert "Authentication failed when accessing the remote storage" in result.output
+    assert "Authentication failed when accessing the cloud storage" in result.output
 
 
 @pytest.mark.integration
 @retry_failed
 @pytest.mark.vcr
-def test_pull_data_from_s3_backend(runner, project):
-    """Test pulling data for a dataset with an S3 backend."""
-    result = runner.invoke(
-        cli, ["dataset", "create", "s3-data", "--storage", "s3://s3.amazonaws.com/giab/"], input="\n\n\n"
-    )
-
-    assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
-
-    result = runner.invoke(
-        cli,
+@pytest.mark.parametrize(
+    "storage, files",
+    [
         [
-            "dataset",
-            "add",
-            "s3-data",
-            "s3://s3.amazonaws.com/giab/Aspera_download_from_ftp.README",
-            "s3://s3.amazonaws.com/giab/technical/unimask/02structural.bed.gz",
+            "s3://s3.amazonaws.com/giab/",
+            [
+                ("s3://s3.amazonaws.com/giab/Aspera_download_from_ftp.README", "e8530c02585aaaecba2d5bd6c4cea6ae"),
+                (
+                    "s3://s3.amazonaws.com/giab/technical/unimask/02structural.bed.gz",
+                    "0ddc10ab9f9f0dd0fea4d66d9a55ba99",
+                ),
+            ],
         ],
-    )
+        [
+            "azure://renkupythontest1/test-private-1",
+            [
+                ("azure://renkupythontest1/test-private-1/file-1", "ba240f743099afb725adcc0e267b2987"),
+                ("azure://renkupythontest1/test-private-1/directory-1/file-2", "e984bdba4a20181ef40f1bdc9ca82865"),
+            ],
+        ],
+    ],
+)
+def test_pull_data_from_cloud_storage(runner, project, cloud_storage_credentials, storage, files):
+    """Test pulling data for a dataset with cloud storage backend."""
+    result = runner.invoke(cli, ["dataset", "create", "cloud-data", "--storage", storage], input="\n\n\n")
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
-    result = runner.invoke(cli, ["dataset", "pull", "s3-data"])
+    file_1, hash_1 = files[0]
+    file_2, hash_2 = files[1]
+
+    result = runner.invoke(cli, ["dataset", "add", "cloud-data", file_1, file_2])
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
-    dataset = get_dataset_with_injection("s3-data")
-    file = next(f for f in dataset.files if f.entity.path.endswith("Aspera_download_from_ftp.README"))
+    result = runner.invoke(cli, ["dataset", "pull", "cloud-data"])
+
+    assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
+
+    dataset = get_dataset_with_injection("cloud-data")
+    file = next(f for f in dataset.files if f.entity.path.endswith(Path(file_1).name))
+    assert hash_1 == file.based_on.checksum
 
     assert (project.path / file.entity.path).exists()
     assert not (project.path / file.entity.path).is_symlink()
 
-    file = next(f for f in dataset.files if f.entity.path.endswith("02structural.bed.gz"))
+    file = next(f for f in dataset.files if f.entity.path.endswith(Path(file_2).name))
 
     assert (project.path / file.entity.path).exists()
     assert not (project.path / file.entity.path).is_symlink()
-    assert "0ddc10ab9f9f0dd0fea4d66d9a55ba99" == file.based_on.checksum
+    assert hash_2 == file.based_on.checksum
 
 
 @pytest.mark.integration
 @retry_failed
 @pytest.mark.vcr
-def test_pull_data_from_s3_backend_to_a_location(runner, project, tmp_path):
-    """Test pulling data for a dataset with an S3 backend to a location other than dataset's data directory."""
-    result = runner.invoke(
-        cli, ["dataset", "create", "s3-data", "--storage", "s3://s3.amazonaws.com/giab/"], input="\n\n\n"
-    )
-
-    assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
-
-    result = runner.invoke(
-        cli,
+@pytest.mark.parametrize(
+    "storage, files",
+    [
         [
-            "dataset",
-            "add",
-            "s3-data",
-            "s3://s3.amazonaws.com/giab/Aspera_download_from_ftp.README",
-            "s3://s3.amazonaws.com/giab/technical/unimask/02structural.bed.gz",
+            "s3://s3.amazonaws.com/giab/",
+            [
+                ("s3://s3.amazonaws.com/giab/Aspera_download_from_ftp.README", "e8530c02585aaaecba2d5bd6c4cea6ae"),
+                (
+                    "s3://s3.amazonaws.com/giab/technical/unimask/02structural.bed.gz",
+                    "0ddc10ab9f9f0dd0fea4d66d9a55ba99",
+                ),
+            ],
         ],
-    )
+        [
+            "azure://renkupythontest1/test-private-1",
+            [
+                ("azure://renkupythontest1/test-private-1/file-1", "ba240f743099afb725adcc0e267b2987"),
+                ("azure://renkupythontest1/test-private-1/directory-1/file-2", "e984bdba4a20181ef40f1bdc9ca82865"),
+            ],
+        ],
+    ],
+)
+def test_pull_data_from_cloud_storage_to_a_location(
+    runner, project, cloud_storage_credentials, tmp_path, storage, files
+):
+    """Test pulling data for a dataset with cloud storage to a location other than dataset's data directory."""
+    result = runner.invoke(cli, ["dataset", "create", "cloud-data", "--storage", storage], input="\n\n\n")
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
-    location = tmp_path / "s3-data"
+    file_1, hash_1 = files[0]
+    file_2, hash_2 = files[1]
 
-    result = runner.invoke(cli, ["dataset", "pull", "s3-data", "--location", str(location)])
+    result = runner.invoke(cli, ["dataset", "add", "cloud-data", file_1, file_2])
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
-    dataset = get_dataset_with_injection("s3-data")
-    file = next(f for f in dataset.files if f.entity.path.endswith("Aspera_download_from_ftp.README"))
+    location = tmp_path / "cloud-data"
+
+    result = runner.invoke(cli, ["dataset", "pull", "cloud-data", "--location", str(location)])
+
+    assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
+
+    dataset = get_dataset_with_injection("cloud-data")
+    file = next(f for f in dataset.files if f.entity.path.endswith(Path(file_1).name))
 
     assert (project.path / file.entity.path).is_symlink()
     assert (location / file.entity.path).resolve() == (project.path / file.entity.path).resolve()
+    assert hash_1 == file.based_on.checksum
 
-    file = next(f for f in dataset.files if f.entity.path.endswith("02structural.bed.gz"))
+    file = next(f for f in dataset.files if f.entity.path.endswith(Path(file_2).name))
 
     assert (project.path / file.entity.path).is_symlink()
     assert (location / file.entity.path).resolve() == (project.path / file.entity.path).resolve()
-    assert "0ddc10ab9f9f0dd0fea4d66d9a55ba99" == file.based_on.checksum
+    assert hash_2 == file.based_on.checksum
 
     assert str(location) in (project.path / ".renku" / "renku.ini").read_text()
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "args,uris,storage_uri",
+    "args, uris, storage_uri",
     [
         (["--create", "--storage", "s3://s3.amazonaws.com/giab"], ["s3://s3.amazonaws.com/giab"], None),
         (
@@ -2117,146 +2174,270 @@ def test_pull_data_from_s3_backend_to_a_location(runner, project, tmp_path):
             ["s3://s3.amazonaws.com/giab/tools", "s3://s3.amazonaws.com/giab/changelog_details"],
             "s3://s3.amazonaws.com/giab",
         ),
+        (
+            ["--create", "--storage", "azure://renkupythontest1/test-private-1"],
+            ["azure://renkupythontest1/test-private-1"],
+            None,
+        ),
+        (
+            [],
+            ["azure://renkupythontest1/test-private-1/file-1", "azure://renkupythontest1/test-private-1/use_cases"],
+            "azure://renkupythontest1/test-private-1",
+        ),
+        ([], ["azure://renkupythontest1/test-private-1"], "azure://renkupythontest1/test-private-1"),
+        (
+            [],
+            [
+                "azure://renkupythontest1/test-private-1/file-1",
+                "azure://renkupythontest1/test-private-1/changelog_details",
+            ],
+            "azure://renkupythontest1/test-private-1",
+        ),
     ],
 )
-def test_adding_data_from_s3(runner, project, create_s3_dataset, mocker, args, uris, storage_uri):
+def test_adding_data_from_cloud_storage(runner, project, create_cloud_storage_dataset, mocker, args, uris, storage_uri):
     """Ensure metadata from a bucket can be added."""
-    mock_s3_storage = mocker.patch("renku.infrastructure.storage.factory.StorageFactory.get_storage", autospec=True)
-    instance_s3_storage = mock_s3_storage.return_value
+    mock_cloud_storage = mocker.patch("renku.infrastructure.storage.factory.StorageFactory.get_storage", autospec=True)
+    instance_cloud_storage = mock_cloud_storage.return_value
     dataset_name = "test-s3-dataset"
-    instance_s3_storage.get_hashes.return_value = [
-        FileHash(base_uri=uri, path=uri[5:], hash=uri, hash_type="md5")  # uri[5:] removes s3:// from beginning
+    instance_cloud_storage.get_hashes.return_value = [
+        FileHash(base_uri=uri, path=re.sub(r".*://", "", uri), hash=uri, hash_type="md5")  # remove scheme from URI
         for uri in uris
     ]
     if storage_uri:
-        res = create_s3_dataset(dataset_name, storage_uri)
+        res = create_cloud_storage_dataset(dataset_name, storage_uri)
         assert res.exit_code == 0
     res = runner.invoke(cli, ["dataset", "add", dataset_name, *args, *uris], input="\n\nn\n")
     assert res.exit_code == 0
-    assert instance_s3_storage.get_hashes.call_count == len(uris)
+    assert instance_cloud_storage.get_hashes.call_count == len(uris)
     res = runner.invoke(cli, ["dataset", "ls-files"])
     assert res.exit_code == 0
-    assert all([uri[5:] in res.stdout for uri in uris])
+    assert all([re.sub(r".*://", "", uri) in res.stdout for uri in uris])
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "cmd_args,expected_error_msg",
+    "storage, cmd_args, expected_error_msg",
     [
         (
+            "s3://s3.amazonaws.com/giab",
             ["s3://s3.amazonaws.com/giab", "--storage", "s3://s3.amazonaws.com/giab"],
             "Storage can be set only when creating a dataset",
         ),
         (
+            "s3://s3.amazonaws.com/giab",
             ["https://github.com/SwissDataScienceCenter/renku-python/raw/develop/README.rst"],
             "does not match the defined storage url",
         ),
         (
+            "s3://s3.amazonaws.com/giab",
             ["s3://s3.amazonaws.com/giab/*"],
             "Wildcards like '*' or '?' are not supported for S3 URIs",
         ),
         (
+            "s3://s3.amazonaws.com/giab",
             ["s3://s3.amazonaws.com/giab/test?.txt"],
             "Wildcards like '*' or '?' are not supported for S3 URIs",
         ),
         (
+            "s3://s3.amazonaws.com/giab",
             ["s3://s3.amazonaws.com/giab", "--source", "tools"],
+            "Cannot use '-s/--src/--source' with URLs or local files",
+        ),
+        (
+            "azure://renkupythontest1/test-private-1",
+            ["azure://renkupythontest1/test-private-1", "--storage", "azure://renkupythontest1/test-private-1"],
+            "Storage can be set only when creating a dataset",
+        ),
+        (
+            "azure://renkupythontest1/test-private-1",
+            ["https://github.com/SwissDataScienceCenter/renku-python/raw/develop/README.rst"],
+            "does not match the defined storage url",
+        ),
+        (
+            "azure://renkupythontest1/test-private-1",
+            ["azure://renkupythontest1/test-private-1/*"],
+            "Wildcards like '*' or '?' are not supported for Azure URIs",
+        ),
+        (
+            "azure://renkupythontest1/test-private-1",
+            ["azure://renkupythontest1/test-private-1/test?.txt"],
+            "Wildcards like '*' or '?' are not supported for Azure URIs",
+        ),
+        (
+            "azure://renkupythontest1/test-private-1",
+            ["azure://renkupythontest1/test-private-1", "--source", "tools"],
             "Cannot use '-s/--src/--source' with URLs or local files",
         ),
     ],
 )
-def test_invalid_s3_args(runner, project, create_s3_dataset, cmd_args, expected_error_msg, mocker):
+def test_invalid_cloud_storage_args(
+    runner, project, create_cloud_storage_dataset, storage, cmd_args, expected_error_msg, mocker
+):
     """Test invalid arguments for adding data to S3 dataset."""
-    mock_s3_storage = mocker.patch("renku.infrastructure.storage.factory.StorageFactory.get_storage", autospec=True)
-    storage_uri = "s3://s3.amazonaws.com/giab"
-    dataset_name = "test-s3-dataset"
+    mock_cloud_storage_storage = mocker.patch(
+        "renku.infrastructure.storage.factory.StorageFactory.get_storage", autospec=True
+    )
+    dataset_name = "test-cloud-dataset"
     if "--create" not in cmd_args:
-        instance_s3_storage = mock_s3_storage.return_value
-        res = create_s3_dataset(dataset_name, storage_uri)
+        instance_cloud_storage_storage = mock_cloud_storage_storage.return_value
+        res = create_cloud_storage_dataset(dataset_name, storage)
         assert res.exit_code == 0
-        instance_s3_storage.exists.assert_called_with(storage_uri)
+        instance_cloud_storage_storage.exists.assert_called_with(storage)
+
     res = runner.invoke(cli, ["dataset", "add", dataset_name, *cmd_args])
+
     assert res.exit_code != 0
     assert expected_error_msg in res.stderr
 
 
 @pytest.mark.integration
 @retry_failed
-def test_mount_unmount_data_from_s3_backend(runner, project):
-    """Test mounting/unmounting data for a dataset with an S3 backend."""
-    result = runner.invoke(
-        cli, ["dataset", "create", "s3-data", "--storage", "s3://s3.amazonaws.com/giab/"], input="\n\n\n"
-    )
+@pytest.mark.parametrize(
+    "storage, path",
+    [
+        ("s3://s3.amazonaws.com/giab/", "Aspera_download_from_ftp.README"),
+        ("azure://renkupythontest1/test-private-1", "file-1"),
+    ],
+)
+def test_mount_unmount_data_from_cloud_storage(runner, project, cloud_storage_credentials, storage, path):
+    """Test mounting/unmounting data for a dataset with cloud storage backend."""
+    result = runner.invoke(cli, ["dataset", "create", "cloud-data", "--storage", storage], input="\n\n\n")
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
-    s3_data = project.path / "data" / "s3-data" / "Aspera_download_from_ftp.README"
-    assert not s3_data.exists()
+    cloud_data = project.path / "data" / "cloud-data" / path
+    assert not cloud_data.exists()
 
     # NOTE: Create some dummy files
-    dummy = project.path / "data" / "s3-data" / "dummy"
+    dummy = project.path / "data" / "cloud-data" / "dummy"
     dummy.parent.mkdir(exist_ok=True, parents=True)
     dummy.touch()
 
     try:
-        result = runner.invoke(cli, ["dataset", "mount", "s3-data"], input="y")
+        result = runner.invoke(cli, ["dataset", "mount", "cloud-data"], input="y")
         time.sleep(1)
 
         assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
-        assert "Warning: Dataset's data directory will be removed: data/s3-data." in result.output
-        assert s3_data.exists()
+        assert "Warning: Dataset's data directory will be removed: data/cloud-data." in result.output
+        assert cloud_data.exists()
     finally:
-        result = runner.invoke(cli, ["dataset", "mount", "s3-data", "--unmount"])
+        result = runner.invoke(cli, ["dataset", "mount", "cloud-data", "--unmount"])
 
         assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
-        assert not s3_data.exists()
+        assert not cloud_data.exists()
 
 
 @pytest.mark.integration
 @retry_failed
-def test_mount_data_from_an_existing_mount_point(runner, project, tmp_path):
-    """Test get data for a dataset with an S3 backend from an existing mount-point."""
-    result = runner.invoke(
-        cli, ["dataset", "create", "s3-data", "--storage", "s3://s3.amazonaws.com/giab/"], input="\n\n\n"
-    )
+@pytest.mark.parametrize(
+    "storage, path, rclone_uri, env",
+    [
+        (
+            "s3://s3.amazonaws.com/giab/",
+            "Aspera_download_from_ftp.README",
+            "s3://giab/",
+            {"RCLONE_CONFIG_S3_TYPE": "s3", "RCLONE_CONFIG_S3_PROVIDER": "AWS"},
+        ),
+        (
+            "azure://renkupythontest1/test-private-1",
+            "file-1",
+            "azure://test-private-1/",
+            {
+                "RCLONE_CONFIG_AZURE_TYPE": "azureblob",
+                "RCLONE_CONFIG_AZURE_ACCOUNT": "renkupythontest1",
+                "RCLONE_CONFIG_AZURE_KEY": os.getenv("CLOUD_STORAGE_AZURE_KEY", ""),
+            },
+        ),
+    ],
+)
+def test_mount_data_from_an_existing_mount_point(
+    runner, project, tmp_path, cloud_storage_credentials, storage, path, rclone_uri, env
+):
+    """Test get data for a dataset with cloud storage backend from an existing mount-point."""
+    result = runner.invoke(cli, ["dataset", "create", "cloud-data", "--storage", storage], input="\n\n\n")
 
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
 
-    s3_data = project.path / "data" / "s3-data" / "Aspera_download_from_ftp.README"
-    assert not s3_data.exists()
+    cloud_data = project.path / "data" / "cloud-data" / path
+    assert not cloud_data.exists()
 
     # NOTE: Create some dummy files
-    dummy = project.path / "data" / "s3-data" / "dummy"
+    dummy = project.path / "data" / "cloud-data" / "dummy"
     dummy.parent.mkdir(exist_ok=True, parents=True)
     dummy.touch()
 
-    mount_point = tmp_path / "s3-mount"
+    mount_point = tmp_path / "cloud-mount"
     mount_point.mkdir(exist_ok=True, parents=True)
-    env = os.environ.copy()
-    env["RCLONE_CONFIG_S3_TYPE"] = "s3"
-    env["RCLONE_CONFIG_S3_PROVIDER"] = "AWS"
+    os_env = os.environ.copy()
+    os_env.update(env)
     subprocess.run(
-        ["rclone", "mount", "--read-only", "--no-modtime", "--daemon", "s3://giab/", str(mount_point)], env=env
+        ["rclone", "mount", "--read-only", "--no-modtime", "--daemon", rclone_uri, str(mount_point)], env=os_env
     )
 
     try:
-        result = runner.invoke(cli, ["dataset", "mount", "s3-data", "--yes", "--existing", str(mount_point)])
+        result = runner.invoke(cli, ["dataset", "mount", "cloud-data", "--yes", "--existing", str(mount_point)])
 
         assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
-        assert "Warning: Dataset's data directory will be removed: data/s3-data." not in result.output
-        assert s3_data.exists()
+        assert "Warning: Dataset's data directory will be removed: data/cloud-data." not in result.output
+        assert cloud_data.exists()
 
-        datadir = s3_data.parent
+        datadir = cloud_data.parent
         assert datadir.is_symlink()
         assert datadir.resolve() == mount_point.resolve()
 
-        result = runner.invoke(cli, ["dataset", "mount", "s3-data", "--unmount"])
+        result = runner.invoke(cli, ["dataset", "unmount", "cloud-data"])
 
         assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
-        assert not s3_data.exists()
+        assert not cloud_data.exists()
         assert not datadir.exists()
 
-        s3_data = tmp_path / "s3-mount" / "Aspera_download_from_ftp.README"
-        assert s3_data.exists()
+        cloud_data = tmp_path / "cloud-mount" / path
+        assert cloud_data.exists()
     finally:
         unmount_path(mount_point)
+
+
+@pytest.mark.integration
+@retry_failed
+@pytest.mark.parametrize(
+    "storage",
+    [
+        ("s3://os.zhdk.cloud.switch.ch/renku-python-integration-test"),
+        ("azure://renkupythontest1/test-private-1/renku-python-test"),
+    ],
+)
+def test_add_data_to_mounted_cloud_storage(runner, project, tmp_path, cloud_storage_credentials, storage):
+    """Test add data to datasets with read-only mounted cloud storage."""
+    result = runner.invoke(cli, ["dataset", "create", "cloud-data", "--storage", storage], input="\n\n\n")
+
+    assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
+
+    cloud_data = project.path / "data" / "cloud-data"
+
+    local_data = tmp_path / "local-data"
+    local_data.write_text("some content")
+
+    try:
+        assert not cloud_data.exists()
+
+        result = runner.invoke(cli, ["dataset", "mount", "cloud-data", "--yes"])
+
+        assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
+        assert cloud_data.exists()
+
+        result = runner.invoke(cli, ["dataset", "add", "--copy", "cloud-data", local_data])
+
+        assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
+
+        # NOTE: It takes a while to sync for S3; we unmount/mount to make changes visible
+        if storage.startswith("s3"):
+            runner.invoke(cli, ["dataset", "mount", "cloud-data", "--unmount"])
+            runner.invoke(cli, ["dataset", "mount", "cloud-data", "--yes"])
+
+        copied_data = cloud_data / "local-data"
+        assert copied_data.exists()
+    finally:
+        result = runner.invoke(cli, ["dataset", "mount", "cloud-data", "--unmount"])
+
+        assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -197,7 +197,7 @@ def test_dataset_import_real_doi_warnings(runner, project, sleep_after):
 
     result = runner.invoke(cli, ["dataset", "ls"])
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
-    assert "pyndl_naive_d_v1.1.0" in result.output
+    assert "pyndl_naive_discr_v1.1.1" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/service/jobs/test_datasets.py
+++ b/tests/service/jobs/test_datasets.py
@@ -33,13 +33,7 @@ from renku.ui.service.utils import make_project_path
 from tests.utils import assert_rpc_response, retry_failed
 
 
-@pytest.mark.parametrize(
-    "url",
-    [
-        "https://dev.renku.ch/datasets/428c36261c56463d8753336470cc6917/",
-        "https://dev.renku.ch/datasets/0d4630e56ee542b3bb3ab3222da811ec",
-    ],
-)
+@pytest.mark.parametrize("url", ["https://dev.renku.ch/datasets/428c36261c56463d8753336470cc6917/"])
 @pytest.mark.integration
 @pytest.mark.service
 @retry_failed


### PR DESCRIPTION
# Description

Support for azure cloud storage similar to what we have for s3.
You can use `renkupythontest1` storage account and `test-private-1` container for testing:
```
renku dataset create azure --storage azure://renkupythontest1/test-private-1
```
Ask me for credentials if you don't have it.

# NOTE:
We mount the dataset in `read-only` mode. If we allow writes, then it's really easy to mess up the remote data in the CLI (e.g. deleting, ...). Let's discuss this if we should ever provide a writable mount.

Fixes #3241 
