### PR TITLE
chore: replace deprecated set-output in GH actions

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -23,9 +23,9 @@ jobs:
         run: |
           if [ "$REF" == "refs/heads/$DEFAULT_BRANCH" ] || [[ "$REF" =~ ^refs/tags/.* ]]
           then
-              echo "::set-output name=matrix::{\"python-version\": [\"3.7\", \"3.10\"]}"
+              echo "matrix={\"python-version\": [\"3.7\", \"3.10\"]}" >> $GITHUB_OUTPUT
           else
-              echo "::set-output name=matrix::{\"python-version\": [\"3.9\"]}"
+              echo "matrix={\"python-version\": [\"3.9\"]}" >> $GITHUB_OUTPUT
           fi
 
   cleanup-runs:
@@ -42,7 +42,7 @@ jobs:
       date: ${{ steps.year-week.outputs.date }}
     steps:
       - id: year-week
-        run: echo "::set-output name=date::$(date '+%Y-%V')"
+        run: echo "date=$(date '+%Y-%V')" >> $GITHUB_OUTPUT
 
   style-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #3255 

## Note
This should be merged after https://github.com/SwissDataScienceCenter/renku-python/pull/3292 that fixes tests due to template renaming.