### PR TITLE
fix(workflow): set modification date when deriving a plan

### DIFF
--- a/renku/command/checks/__init__.py
+++ b/renku/command/checks/__init__.py
@@ -30,7 +30,7 @@ from .migration import check_migration
 from .project import check_project_id_group
 from .storage import check_lfs_info
 from .validate_shacl import check_datasets_structure, check_project_structure
-from .workflow import check_activity_catalog
+from .workflow import check_activity_catalog, check_modification_date
 
 # Checks will be executed in the order as they are listed in __all__. They are mostly used in ``doctor`` command to
 # inspect broken things. The order of operations matters when fixing issues, so, don't sort this list.
@@ -48,4 +48,5 @@ __all__ = (
     "check_missing_files",
     "check_project_id_group",
     "check_project_structure",
+    "check_modification_date",
 )

--- a/renku/domain_model/dataset.py
+++ b/renku/domain_model/dataset.py
@@ -213,8 +213,8 @@ class RemoteEntity(Slots):
     def generate_id(checksum: str, path: Union[Path, str], url: str) -> str:
         """Generate an id."""
         parsed_url = urlparse(url)
-        prefix = quote(posixpath.join(parsed_url.netloc, parsed_url.path))
-        path = quote(str(path))
+        prefix = quote(posixpath.join(parsed_url.netloc.strip("/"), parsed_url.path.strip("/")))
+        path = quote(str(path).strip("/"))
         return f"/remote-entities/{prefix}/{checksum}/{path}"
 
     def __eq__(self, other):

--- a/renku/domain_model/workflow/plan.py
+++ b/renku/domain_model/workflow/plan.py
@@ -317,7 +317,7 @@ class Plan(AbstractPlan):
         """Create a new ``Plan`` that is derived from self."""
         derived = copy.copy(self)
         derived.derived_from = self.id
-        derived.date_created = local_now()
+        derived.date_modified = local_now()
         derived.parameters = self.parameters.copy()
         derived.inputs = self.inputs.copy()
         derived.keywords = copy.deepcopy(self.keywords)


### PR DESCRIPTION
# Description

Fixes plan modification dates and their migration. The issue is that deleting and creating a plan with the same name overrides the first plan in the plan tails index and it won't be accessible through that index.

Fixes #3302 
Fixes #3306 