### PR TITLE
fix(cli): bump minimum version so old project properly fail

### DIFF
--- a/renku/version.py
+++ b/renku/version.py
@@ -26,7 +26,7 @@ except ImportError:
 
 __version__ = version("renku")
 __template_version__ = "0.4.1"
-__minimum_project_version__ = "1.7.0"
+__minimum_project_version__ = "2.1.0"
 
 
 def is_release():


### PR DESCRIPTION
I forgot to bump this when changing the template metadata version. Bumping it should properly cause old client to say that the user needs to update when accessing a new project.