### PR TITLE
feat(cli): add SSH support for `renku session`

### DIFF
--- a/renku/command/format/session.py
+++ b/renku/command/format/session.py
@@ -25,6 +25,9 @@ def tabular(sessions, *, columns=None):
     if not columns:
         columns = "id,status,url"
 
+        if any(s.ssh_enabled for s in sessions):
+            columns += ",ssh"
+
     return tabulate(collection=sessions, columns=columns, columns_mapping=SESSION_COLUMNS)
 
 
@@ -35,4 +38,5 @@ SESSION_COLUMNS = {
     "id": ("id", "id"),
     "status": ("status", "status"),
     "url": ("url", "url"),
+    "ssh": ("ssh_connection", "SSH connection"),
 }

--- a/renku/command/session.py
+++ b/renku/command/session.py
@@ -29,7 +29,7 @@ def session_list_command():
 
 def session_start_command():
     """Start an interactive session."""
-    return Command().command(session_start)
+    return Command().command(session_start).with_database()
 
 
 def session_stop_command():

--- a/renku/command/session.py
+++ b/renku/command/session.py
@@ -19,7 +19,7 @@
 
 
 from renku.command.command_builder.command import Command
-from renku.core.session.session import session_list, session_open, session_start, session_stop
+from renku.core.session.session import session_list, session_open, session_start, session_stop, ssh_setup
 
 
 def session_list_command():
@@ -40,3 +40,8 @@ def session_stop_command():
 def session_open_command():
     """Open a running interactive session."""
     return Command().command(session_open)
+
+
+def setup_ssh_command():
+    """Setup SSH keys for SSH connections to sessions."""
+    return Command().command(ssh_setup)

--- a/renku/command/session.py
+++ b/renku/command/session.py
@@ -42,6 +42,6 @@ def session_open_command():
     return Command().command(session_open)
 
 
-def setup_ssh_command():
+def ssh_setup_command():
     """Setup SSH keys for SSH connections to sessions."""
     return Command().command(ssh_setup)

--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -110,6 +110,10 @@ class AuthenticationError(RenkuException):
     """Raise when there is a problem with authentication."""
 
 
+class KeyNotFoundError(RenkuException):
+    """Raise when an SSH private or public key couldn't be found."""
+
+
 class DirtyRepository(RenkuException):
     """Raise when trying to work with dirty repository."""
 
@@ -524,6 +528,15 @@ class NodeNotFoundError(RenkuException):
             "Please install it, for details see https://nodejs.org/en/download/package-manager/"
         )
         super(NodeNotFoundError, self).__init__(msg)
+
+
+class SSHNotFoundError(RenkuException):
+    """Raised when SSH client is not installed on the system."""
+
+    def __init__(self):
+        """Build a custom message."""
+        msg = "SSH client (ssh) could not be found on this system"
+        super(SSHNotFoundError, self).__init__(msg)
 
 
 class ObjectNotFoundError(RenkuException):

--- a/renku/core/session/docker.py
+++ b/renku/core/session/docker.py
@@ -274,7 +274,7 @@ class DockerSessionProvider(ISessionProvider):
             raise errors.DockerError(error.msg)
 
     def session_open(self, project_name: str, session_name: str, **kwargs) -> bool:
-        """Opena given interactive session.
+        """Open a given interactive session.
 
         Args:
             project_name(str): Renku project name.

--- a/renku/core/session/docker.py
+++ b/renku/core/session/docker.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """Docker based interactive session provider."""
 
+import webbrowser
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, cast
 from uuid import uuid4
@@ -113,12 +114,16 @@ class DockerSessionProvider(ISessionProvider):
         """Supported session provider.
 
         Returns:
-            a reference to ``self``.
+            A reference to ``self``.
         """
         return self
 
     def get_start_parameters(self) -> List["ProviderParameter"]:
         """Returns parameters that can be set for session start."""
+        return []
+
+    def get_open_parameters(self) -> List["ProviderParameter"]:
+        """Returns parameters that can be set for session open."""
         return []
 
     def session_list(self, project_name: str, config: Optional[Dict[str, Any]]) -> List[Session]:
@@ -267,6 +272,21 @@ class DockerSessionProvider(ISessionProvider):
             return True
         except docker.errors.APIError as error:
             raise errors.DockerError(error.msg)
+
+    def session_open(self, project_name: str, session_name: str, **kwargs) -> bool:
+        """Opena given interactive session.
+
+        Args:
+            project_name(str): Renku project name.
+            session_name(str): The unique id of the interactive session.
+        """
+        url = self.session_url(session_name)
+
+        if not url:
+            return False
+
+        webbrowser.open(url)
+        return True
 
     def session_url(self, session_name: str) -> Optional[str]:
         """Get the URL of the interactive session."""

--- a/renku/core/session/docker.py
+++ b/renku/core/session/docker.py
@@ -18,7 +18,7 @@
 """Docker based interactive session provider."""
 
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, cast
 from uuid import uuid4
 
 import docker
@@ -31,6 +31,9 @@ from renku.core.plugin import hookimpl
 from renku.core.util import communication
 from renku.domain_model.project_context import project_context
 from renku.domain_model.session import ISessionProvider, Session
+
+if TYPE_CHECKING:
+    from renku.core.dataset.providers.models import ProviderParameter
 
 
 class DockerSessionProvider(ISessionProvider):
@@ -71,7 +74,8 @@ class DockerSessionProvider(ISessionProvider):
     def _get_docker_containers(self, project_name: str) -> List[docker.models.containers.Container]:
         return self.docker_client().containers.list(filters={"label": f"renku_project={project_name}"})
 
-    def get_name(self) -> str:
+    @property
+    def name(self) -> str:
         """Return session provider's name."""
         return "docker"
 
@@ -113,6 +117,10 @@ class DockerSessionProvider(ISessionProvider):
         """
         return self
 
+    def get_start_parameters(self) -> List["ProviderParameter"]:
+        """Returns parameters that can be set for session start."""
+        return []
+
     def session_list(self, project_name: str, config: Optional[Dict[str, Any]]) -> List[Session]:
         """Lists all the sessions currently running by the given session provider.
 
@@ -140,6 +148,7 @@ class DockerSessionProvider(ISessionProvider):
         mem_request: Optional[str] = None,
         disk_request: Optional[str] = None,
         gpu_request: Optional[str] = None,
+        **kwargs,
     ) -> Tuple[str, str]:
         """Creates an interactive session.
 

--- a/renku/core/session/renkulab.py
+++ b/renku/core/session/renkulab.py
@@ -296,11 +296,18 @@ class RenkulabSessionProvider(ISessionProvider):
             params=self._get_renku_project_name_parts(),
         )
         if sessions_res.status_code == 200:
+            system_config = SystemSSHConfig()
+            name = self._project_name_from_full_project_name(project_name)
+
             return [
                 Session(
                     session["name"],
                     session.get("status", {}).get("state", "unknown"),
                     self.session_url(session["name"]),
+                    ssh_enabled=system_config.session_config_path(name, session["name"]).exists(),
+                    ssh_connection=system_config.connection_name(name, session["name"])
+                    if system_config.session_config_path(name, session["name"]).exists()
+                    else None,
                 )
                 for session in sessions_res.json().get("servers", {}).values()
             ]

--- a/renku/core/session/renkulab.py
+++ b/renku/core/session/renkulab.py
@@ -167,11 +167,11 @@ class RenkulabSessionProvider(ISessionProvider):
                 else:
                     raise errors.RenkulabSessionError(
                         "Can't run ssh session without setting up Renku SSH support. Run without '--ssh' or "
-                        "run 'renku session setup-ssh'."
+                        "run 'renku session ssh-setup'."
                     )
 
             project_context.ssh_authorized_keys_path.parent.mkdir(parents=True, exist_ok=True)
-            project_context.ssh_authorized_keys_path.touch(mode=0o644, exist_ok=True)
+            project_context.ssh_authorized_keys_path.touch(mode=0o600, exist_ok=True)
 
             key = system_config.public_keyfile.read_text()
             key = f"\n{key} {project_context.repository.get_user().name}"
@@ -420,7 +420,7 @@ class RenkulabSessionProvider(ISessionProvider):
             if not system_config.is_configured or not system_config.session_config_path(name, session_name).exists():
                 raise errors.RenkulabSessionError(
                     "SSH not set up for session. Run without '--ssh' or "
-                    "run 'renku session setup-ssh' and start the session again."
+                    "run 'renku session ssh-setup' and start the session again."
                 )
             pty.spawn(["ssh", system_config.connection_name(name, session_name)])
         else:

--- a/renku/core/session/session.py
+++ b/renku/core/session/session.py
@@ -20,7 +20,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, NamedTuple, Optional
 
 from pydantic import validate_arguments
 
@@ -41,13 +41,20 @@ def _safe_get_provider(provider: str) -> ISessionProvider:
         raise errors.ParameterError(f"Session provider '{provider}' is not available!")
 
 
+SessionList = NamedTuple(
+    "SessionList", [("sessions", List[Session]), ("all_local", bool), ("warning_messages", List[str])]
+)
+
+
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
-def session_list(config_path: Optional[str], provider: Optional[str] = None) -> Tuple[List[Session], bool, List[str]]:
+def session_list(config_path: Optional[str], provider: Optional[str] = None) -> SessionList:
     """List interactive sessions.
 
     Args:
         config_path(str, optional): Path to config YAML.
         provider(str, optional): Name of the session provider to use.
+    Returns:
+        The list of sessions, whether they're all local sessions and potential warnings raised.
     """
 
     def list_sessions(session_provider: ISessionProvider) -> List[Session]:
@@ -76,7 +83,7 @@ def session_list(config_path: Optional[str], provider: Optional[str] = None) -> 
                 all_local = False
             all_sessions.extend(sessions)
 
-    return all_sessions, all_local, warning_messages
+    return SessionList(all_sessions, all_local, warning_messages)
 
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))

--- a/renku/core/session/utils.py
+++ b/renku/core/session/utils.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utility functions used for sessions."""
+import os
 import urllib
 from typing import Optional
 
@@ -48,6 +49,10 @@ def get_renku_url() -> Optional[str]:
 
 def get_image_repository_host() -> Optional[str]:
     """Derive the hostname for the gitlab container registry."""
+    # NOTE: Used to circumvent cases where the registry URL is not guessed correctly
+    # remove once #3301 is done
+    if "RENKU_IMAGE_REGISTRY" in os.environ:
+        return os.environ["RENKU_IMAGE_REGISTRY"]
     renku_url = get_renku_url()
     if not renku_url:
         return None

--- a/renku/core/util/ssh.py
+++ b/renku/core/util/ssh.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Eidgenössische Technische Hochschule Zürich (ETHZ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SSH utility functions."""
+
+from typing import NamedTuple
+
+from cryptography.hazmat.backends import default_backend as crypto_default_backend
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+SSHKeyPair = NamedTuple("SSHKeyPair", [("private_key", str), ("public_key", str)])
+
+
+def generate_ssh_keys() -> SSHKeyPair:
+    """Generate an SSH keypair.
+
+    Returns:
+        Private Public key pair.
+    """
+    key = rsa.generate_private_key(backend=crypto_default_backend(), public_exponent=65537, key_size=2048)
+
+    private_key = key.private_bytes(
+        crypto_serialization.Encoding.PEM, crypto_serialization.PrivateFormat.PKCS8, crypto_serialization.NoEncryption()
+    )
+
+    public_key = key.public_key().public_bytes(
+        crypto_serialization.Encoding.OpenSSH, crypto_serialization.PublicFormat.OpenSSH
+    )
+
+    return SSHKeyPair(private_key.decode("utf-8"), public_key.decode("utf-8"))

--- a/renku/core/util/ssh.py
+++ b/renku/core/util/ssh.py
@@ -20,7 +20,7 @@
 import textwrap
 import urllib.parse
 from pathlib import Path
-from typing import NamedTuple, cast
+from typing import NamedTuple, Optional, cast
 
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
 from cryptography.hazmat.primitives import serialization as crypto_serialization
@@ -63,7 +63,7 @@ class SystemSSHConfig:
         self.renku_ssh_root.mkdir(mode=0o700, exist_ok=True, parents=True)
         self.ssh_config.touch(mode=0o600, exist_ok=True)
 
-        self.renku_host: str = cast(str, urllib.parse.urlparse(get_renku_url()).hostname)
+        self.renku_host: Optional[str] = cast(Optional[str], urllib.parse.urlparse(get_renku_url()).hostname)
 
         if not self.renku_host:
             raise errors.AuthenticationError(

--- a/renku/domain_model/project_context.py
+++ b/renku/domain_model/project_context.py
@@ -95,9 +95,14 @@ class ProjectContext(threading.local):
         return self.path / RENKU_HOME / DATASET_IMAGES
 
     @property
-    def docker_path(self):
+    def docker_path(self) -> Path:
         """Path to the Dockerfile."""
         return self.path / DOCKERFILE
+
+    @property
+    def ssh_authorized_keys_path(self) -> Path:
+        """Path to SSH authorized keys."""
+        return self.path / ".ssh" / "authorized_keys"
 
     @property
     def global_config_dir(self) -> str:
@@ -255,6 +260,7 @@ class ProjectContext(threading.local):
 
         Arguments:
             path(Union[Path, str]): The path to push.
+            save_changes(bool): Whether to save changes to the database or not.
         """
         path = Path(path).resolve()
         self._context_stack.append(ProjectProperties(path=path, save_changes=save_changes))
@@ -280,6 +286,7 @@ class ProjectContext(threading.local):
 
         Arguments:
             path(Union[Path, str]): The path to push.
+            save_changes(bool): Whether to save changes to the database or not.
         """
         with self.with_rollback():
             self.push_path(path=path, save_changes=save_changes)

--- a/renku/domain_model/session.py
+++ b/renku/domain_model/session.py
@@ -155,7 +155,7 @@ class ISessionProvider(metaclass=ABCMeta):
 
     @abstractmethod
     def session_open(self, project_name: str, session_name: str, **kwargs) -> bool:
-        """Opena given interactive session.
+        """Open a given interactive session.
 
         Args:
             project_name(str): Renku project name.

--- a/renku/domain_model/session.py
+++ b/renku/domain_model/session.py
@@ -32,10 +32,12 @@ if TYPE_CHECKING:
 class Session:
     """Interactive session."""
 
-    def __init__(self, id: str, status: str, url: str):
+    def __init__(self, id: str, status: str, url: str, ssh_enabled: bool = False, ssh_connection: Optional[str] = None):
         self.id = id
         self.status = status
         self.url = url
+        self.ssh_enabled = ssh_enabled
+        self.ssh_connection = ssh_connection
 
 
 class ISessionProvider(metaclass=ABCMeta):

--- a/renku/domain_model/session.py
+++ b/renku/domain_model/session.py
@@ -21,9 +21,12 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from renku.core.constant import ProviderPriority
+
+if TYPE_CHECKING:
+    from renku.core.dataset.providers.models import ProviderParameter
 
 
 class Session:
@@ -40,8 +43,9 @@ class ISessionProvider(metaclass=ABCMeta):
 
     priority: ProviderPriority = ProviderPriority.NORMAL
 
+    @property
     @abstractmethod
-    def get_name(self) -> str:
+    def name(self) -> str:
         """Return session provider's name."""
         pass
 
@@ -84,6 +88,11 @@ class ISessionProvider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def get_start_parameters(self) -> List["ProviderParameter"]:
+        """Returns parameters that can be set for session start."""
+        pass
+
+    @abstractmethod
     def session_list(self, project_name: str, config: Optional[Dict[str, Any]]) -> List[Session]:
         """Lists all the sessions currently running by the given session provider.
 
@@ -106,6 +115,7 @@ class ISessionProvider(metaclass=ABCMeta):
         mem_request: Optional[str] = None,
         disk_request: Optional[str] = None,
         gpu_request: Optional[str] = None,
+        **kwargs,
     ) -> Tuple[str, str]:
         """Creates an interactive session.
 
@@ -150,7 +160,7 @@ class ISessionProvider(metaclass=ABCMeta):
         """
         pass
 
-    def pre_start_checks(self):
+    def pre_start_checks(self, **kwargs):
         """Perform any required checks on the state of the repository prior to starting a session.
 
         The expectation is that this method will abort the

--- a/renku/domain_model/session.py
+++ b/renku/domain_model/session.py
@@ -70,7 +70,7 @@ class ISessionProvider(metaclass=ABCMeta):
         """Search for the given container image.
 
         Args:
-            image_name: Container image name.
+            image_name(str): Container image name.
             config: Path to the session provider specific configuration YAML.
 
         Returns:
@@ -93,12 +93,17 @@ class ISessionProvider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def get_open_parameters(self) -> List["ProviderParameter"]:
+        """Returns parameters that can be set for session open."""
+        pass
+
+    @abstractmethod
     def session_list(self, project_name: str, config: Optional[Dict[str, Any]]) -> List[Session]:
         """Lists all the sessions currently running by the given session provider.
 
         Args:
-            project_name: Renku project name.
-            config: Path to the session provider specific configuration YAML.
+            project_name(str): Renku project name.
+            config(Dict[str, Any], optional): Path to the session provider specific configuration YAML.
 
         Returns:
             a list of sessions.
@@ -138,9 +143,9 @@ class ISessionProvider(metaclass=ABCMeta):
         """Stops all or a given interactive session.
 
         Args:
-            project_name: Project's name.
-            session_name: The unique id of the interactive session.
-            stop_all: Specifies whether or not to stop all the running interactive sessions.
+            project_name(str): Project's name.
+            session_name(str, optional): The unique id of the interactive session.
+            stop_all(bool): Specifies whether or not to stop all the running interactive sessions.
 
 
         Returns:
@@ -149,11 +154,21 @@ class ISessionProvider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def session_open(self, project_name: str, session_name: str, **kwargs) -> bool:
+        """Opena given interactive session.
+
+        Args:
+            project_name(str): Renku project name.
+            session_name(str): The unique id of the interactive session.
+        """
+        pass
+
+    @abstractmethod
     def session_url(self, session_name: str) -> Optional[str]:
         """Get the given session's URL.
 
         Args:
-            session_name: The unique id of the interactive session.
+            session_name(str): The unique id of the interactive session.
 
         Returns:
             URL of the interactive session.

--- a/renku/ui/cli/session.py
+++ b/renku/ui/cli/session.py
@@ -200,6 +200,15 @@ def list_sessions(provider, config, format):
             click.echo(WARNING + message)
 
 
+def session_start_provider_options(*param_decls, **attrs):
+    """Sets dataset export provider option groups on the dataset export command."""
+    from renku.core.plugin.session import get_supported_session_providers
+    from renku.ui.cli.utils.click import create_options
+
+    providers = [p for p in get_supported_session_providers() if p.get_start_parameters()]  # type: ignore
+    return create_options(providers=providers, parameter_function="get_start_parameters")
+
+
 @session.command("start")
 @click.option(
     "provider",
@@ -223,7 +232,8 @@ def list_sessions(provider, config, format):
 @click.option("--disk", type=click.STRING, metavar="<disk size>", help="Amount of disk space required for the session.")
 @click.option("--gpu", type=click.STRING, metavar="<GPU quota>", help="GPU quota for the session.")
 @click.option("--memory", type=click.STRING, metavar="<memory size>", help="Amount of memory required for the session.")
-def start(provider, config, image, cpu, disk, gpu, memory):
+@session_start_provider_options()
+def start(provider, config, image, cpu, disk, gpu, memory, **kwargs):
     """Start an interactive session."""
     from renku.command.session import session_start_command
 
@@ -236,6 +246,7 @@ def start(provider, config, image, cpu, disk, gpu, memory):
         mem_request=memory,
         disk_request=disk,
         gpu_request=gpu,
+        **kwargs,
     )
 
 
@@ -295,9 +306,9 @@ def open(session_name, provider):
     metavar="<private key file>",
     help="Existing private key to use.",
 )
-@click.option("--yes", is_flag=True, help="Do not prompt, overwrite existing keys.")
-def setup_ssh(existing_key, yes):
+@click.option("--force", is_flag=True, help="Overwrite existing keys/config.")
+def setup_ssh(existing_key, force):
     """Setup keys for SSH connections into sessions."""
     from renku.command.session import setup_ssh_command
 
-    setup_ssh_command().build().execute(existing_key=existing_key, yes=yes)
+    setup_ssh_command().build().execute(existing_key=existing_key, force=force)

--- a/renku/ui/cli/session.py
+++ b/renku/ui/cli/session.py
@@ -92,6 +92,41 @@ Please note that there are a few limitations with the ``renkulab`` provider:
 
     $ renku session start -p renkulab
 
+SSH connections to remote sessions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can connect via SSH to remote (Renkulab) sessions, if your project supports it.
+
+To see if your project supports SSH, you can run ``renku project show`` and check the
+``SSH Supported`` flag. If your project doesn't support SSH, update the project template
+or contact the template maintainer to enable SSH support on the template.
+
+On a project that supports SSH, you need to first set up SSH keys for the deployment
+you want to connect to, e.g. for renkulab.io:
+
+.. code-block:: console
+
+    $ renku login renkulab.io
+    $ renku session setup-ssh
+
+Your system is now ready for starting sessions with SSH connections:
+
+.. code-block:: console
+
+    $ renku session start -p renkulab --ssh
+    [...]
+    SSH connection successfully configured, use 'ssh renkulab.io-myproject-sessionid' to connect.
+
+You can then use the SSH connection name (``ssh renkulab.io-myproject-sessionid`` in the example)
+to connect to the session or in tools such as VSCode.
+
+Alternatively, you can use ``renku session open --ssh <session_id>`` to directly open an SSH
+connection to the session.
+
+You can see the SSH connection name using ``renku session ls``.
+
+SSH config for specific sessions is removed when the session is stopped.
+
 Managing active sessions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -188,15 +223,14 @@ def list_sessions(provider, config, format):
     from renku.command.session import session_list_command
 
     result = session_list_command().build().execute(provider=provider, config_path=config)
-    sessions, all_local, warning_messages = result.output
 
-    click.echo(SESSION_FORMATS[format](sessions))
+    click.echo(SESSION_FORMATS[format](result.output.sessions))
 
-    if warning_messages:
+    if result.output.warning_messages:
         click.echo()
-        if all_local and sessions:
+        if result.output.all_local and result.output.sessions:
             click.echo(WARNING + "Only showing sessions from local provider")
-        for message in warning_messages:
+        for message in result.output.warning_messages:
             click.echo(WARNING + message)
 
 

--- a/renku/ui/cli/session.py
+++ b/renku/ui/cli/session.py
@@ -107,7 +107,7 @@ you want to connect to, e.g. for renkulab.io:
 .. code-block:: console
 
     $ renku login renkulab.io
-    $ renku session setup-ssh
+    $ renku session ssh-setup
 
 Your system is now ready for starting sessions with SSH connections:
 
@@ -341,7 +341,7 @@ def open(session_name, provider, **kwargs):
     session_open_command().build().execute(session_name=session_name, provider=provider, **kwargs)
 
 
-@session.command("setup-ssh")
+@session.command("ssh-setup")
 @click.option(
     "existing_key",
     "-k",
@@ -351,8 +351,8 @@ def open(session_name, provider, **kwargs):
     help="Existing private key to use.",
 )
 @click.option("--force", is_flag=True, help="Overwrite existing keys/config.")
-def setup_ssh(existing_key, force):
+def ssh_setup(existing_key, force):
     """Setup keys for SSH connections into sessions."""
-    from renku.command.session import setup_ssh_command
+    from renku.command.session import ssh_setup_command
 
-    setup_ssh_command().build().execute(existing_key=existing_key, force=force)
+    ssh_setup_command().build().execute(existing_key=existing_key, force=force)

--- a/renku/ui/cli/session.py
+++ b/renku/ui/cli/session.py
@@ -205,7 +205,7 @@ def session_start_provider_options(*param_decls, **attrs):
     from renku.core.plugin.session import get_supported_session_providers
     from renku.ui.cli.utils.click import create_options
 
-    providers = [p for p in get_supported_session_providers() if p.get_start_parameters()]  # type: ignore
+    providers = [p for p in get_supported_session_providers() if p.get_start_parameters()]
     return create_options(providers=providers, parameter_function="get_start_parameters")
 
 
@@ -280,6 +280,15 @@ def stop(session_name, stop_all, provider):
         click.echo(f"Interactive session '{session_name}' has been successfully stopped.")
 
 
+def session_open_provider_options(*param_decls, **attrs):
+    """Sets dataset export provider option groups on the dataset export command."""
+    from renku.core.plugin.session import get_supported_session_providers
+    from renku.ui.cli.utils.click import create_options
+
+    providers = [p for p in get_supported_session_providers() if p.get_open_parameters()]  # type: ignore
+    return create_options(providers=providers, parameter_function="get_open_parameters")
+
+
 @session.command("open")
 @click.argument("session_name", metavar="<name>", required=True)
 @click.option(
@@ -290,11 +299,12 @@ def stop(session_name, stop_all, provider):
     default=None,
     help="Session provider to use.",
 )
-def open(session_name, provider):
+@session_open_provider_options()
+def open(session_name, provider, **kwargs):
     """Open an interactive session."""
     from renku.command.session import session_open_command
 
-    session_open_command().build().execute(session_name=session_name, provider=provider)
+    session_open_command().build().execute(session_name=session_name, provider=provider, **kwargs)
 
 
 @session.command("setup-ssh")

--- a/renku/ui/cli/session.py
+++ b/renku/ui/cli/session.py
@@ -284,3 +284,20 @@ def open(session_name, provider):
     from renku.command.session import session_open_command
 
     session_open_command().build().execute(session_name=session_name, provider=provider)
+
+
+@session.command("setup-ssh")
+@click.option(
+    "existing_key",
+    "-k",
+    "--existing-key",
+    type=click.Path(exists=True, dir_okay=False),
+    metavar="<private key file>",
+    help="Existing private key to use.",
+)
+@click.option("--yes", is_flag=True, help="Do not prompt, overwrite existing keys.")
+def setup_ssh(existing_key, yes):
+    """Setup keys for SSH connections into sessions."""
+    from renku.command.session import setup_ssh_command
+
+    setup_ssh_command().build().execute(existing_key=existing_key, yes=yes)

--- a/renku/ui/cli/utils/plugins.py
+++ b/renku/ui/cli/utils/plugins.py
@@ -36,4 +36,4 @@ def get_supported_session_providers_names():
     """Deferred import as plugins are slow."""
     from renku.core.plugin.session import get_supported_session_providers
 
-    return [p.get_name() for p in get_supported_session_providers()]
+    return [p.name for p in get_supported_session_providers()]

--- a/tests/cli/test_session.py
+++ b/tests/cli/test_session.py
@@ -26,7 +26,7 @@ from tests.utils import format_result_exception
 
 def test_session_up_down(runner, project, dummy_session_provider, monkeypatch):
     """Test starting a session."""
-    import renku.core.session.session
+    browser = dummy_session_provider
 
     result = runner.invoke(cli, ["session", "ls", "-p", "dummy"])
     assert 0 == result.exit_code, format_result_exception(result)
@@ -43,12 +43,9 @@ def test_session_up_down(runner, project, dummy_session_provider, monkeypatch):
     assert 0 == result.exit_code, format_result_exception(result)
     assert 5 == len(result.output.splitlines())
 
-    with monkeypatch.context() as monkey:
-        browser = MagicMock()
-        monkey.setattr(renku.core.session.session, "webbrowser", browser)
-        result = runner.invoke(cli, ["session", "open", "-p", "dummy", session_id])
-        assert 0 == result.exit_code, format_result_exception(result)
-        browser.open.assert_called_once_with("http://localhost/")
+    result = runner.invoke(cli, ["session", "open", "-p", "dummy", session_id])
+    assert 0 == result.exit_code, format_result_exception(result)
+    browser.open.assert_called_once_with("http://localhost/")
 
     result = runner.invoke(cli, ["session", "stop", "-p", "dummy", session_id])
     assert 0 == result.exit_code, format_result_exception(result)

--- a/tests/core/plugins/test_session.py
+++ b/tests/core/plugins/test_session.py
@@ -94,6 +94,7 @@ def test_session_start(
     with_injection,
     mock_communication,
 ):
+    """Test starting sessions."""
     with patch.multiple(
         session_provider,
         session_start=fake_start,
@@ -141,6 +142,7 @@ def test_session_stop(
     result,
     with_injection,
 ):
+    """Test stopping sessions."""
     with patch.multiple(session_provider, session_stop=fake_stop, **provider_patches):
         provider_implementation = next(
             filter(lambda x: x.name == provider_name, get_supported_session_providers()), None
@@ -172,6 +174,7 @@ def test_session_list(
     result,
     with_injection,
 ):
+    """Test listing sessions."""
     with patch.multiple(session_provider, session_list=fake_session_list, **provider_patches):
         with with_injection():
             provider = provider_name if provider_exists else "no_provider"
@@ -184,7 +187,7 @@ def test_session_list(
                 assert result.sessions == result
 
 
-def test_session_setup_ssh(project, with_injection, fake_home, mock_communication):
+def test_session_ssh_setup(project, with_injection, fake_home, mock_communication):
     """Test setting up SSH config for a deployment."""
     with with_injection():
         ssh_setup()
@@ -214,6 +217,8 @@ def test_session_setup_ssh(project, with_injection, fake_home, mock_communicatio
 
 
 def test_session_start_ssh(project, with_injection, mock_communication, fake_home):
+    """Test starting of a session with SSH support."""
+
     def _fake_send_request(self, req_type: str, *args, **kwargs):
         class _FakeResponse:
             status_code = 200

--- a/tests/core/plugins/test_session.py
+++ b/tests/core/plugins/test_session.py
@@ -180,8 +180,8 @@ def test_session_list(
                 with pytest.raises(result):
                     session_list(provider=provider, config_path=None)
             else:
-                sessions, _, _ = session_list(provider=provider, config_path=None)
-                assert sessions == result
+                result = session_list(provider=provider, config_path=None)
+                assert result.sessions == result
 
 
 def test_session_setup_ssh(project, with_injection, fake_home, mock_communication):

--- a/tests/core/plugins/test_session.py
+++ b/tests/core/plugins/test_session.py
@@ -17,15 +17,17 @@
 # limitations under the License.
 """Test ``session`` commands."""
 
+import re
 from unittest.mock import patch
 
+import click
 import pytest
 
 from renku.core.errors import ParameterError
 from renku.core.plugin.session import get_supported_session_providers
 from renku.core.session.docker import DockerSessionProvider
 from renku.core.session.renkulab import RenkulabSessionProvider
-from renku.core.session.session import session_list, session_start, session_stop
+from renku.core.session.session import session_list, session_start, session_stop, ssh_setup
 
 
 def fake_start(
@@ -37,6 +39,7 @@ def fake_start(
     mem_request,
     disk_request,
     gpu_request,
+    **kwargs,
 ):
     return "0xdeadbeef", ""
 
@@ -61,7 +64,7 @@ def fake_session_list(self, project_name, config):
     return ["0xdeadbeef"]
 
 
-def fake_pre_start_checks(self):
+def fake_pre_start_checks(self, **kwargs):
     pass
 
 
@@ -100,7 +103,7 @@ def test_session_start(
         **provider_patches,
     ):
         provider_implementation = next(
-            filter(lambda x: x.get_name() == provider_name, get_supported_session_providers()), None
+            filter(lambda x: x.name == provider_name, get_supported_session_providers()), None
         )
         assert provider_implementation is not None
 
@@ -140,7 +143,7 @@ def test_session_stop(
 ):
     with patch.multiple(session_provider, session_stop=fake_stop, **provider_patches):
         provider_implementation = next(
-            filter(lambda x: x.get_name() == provider_name, get_supported_session_providers()), None
+            filter(lambda x: x.name == provider_name, get_supported_session_providers()), None
         )
         assert provider_implementation is not None
 
@@ -161,7 +164,6 @@ def test_session_stop(
 )
 @pytest.mark.parametrize("provider_exists,result", [(True, ["0xdeadbeef"]), (False, ParameterError)])
 def test_session_list(
-    run_shell,
     project,
     provider_name,
     session_provider,
@@ -180,3 +182,68 @@ def test_session_list(
             else:
                 sessions, _, _ = session_list(provider=provider, config_path=None)
                 assert sessions == result
+
+
+def test_session_setup_ssh(project, with_injection, fake_home, mock_communication):
+    """Test setting up SSH config for a deployment."""
+    with with_injection():
+        ssh_setup()
+
+    ssh_home = fake_home / ".ssh"
+    renku_ssh_path = ssh_home / "renku"
+    assert renku_ssh_path.exists()
+    assert re.search(r"Include .*/\.ssh/renku/\*\.conf", (ssh_home / "config").read_text())
+    assert (renku_ssh_path / "99-None-jumphost.conf").exists()
+    assert (renku_ssh_path / "None-key").exists()
+    assert (renku_ssh_path / "None-key.pub").exists()
+    assert len(mock_communication.confirm_calls) == 0
+
+    key = (renku_ssh_path / "None-key").read_text()
+
+    with with_injection():
+        with pytest.raises(click.Abort):
+            ssh_setup()
+
+    assert len(mock_communication.confirm_calls) == 1
+    assert key == (renku_ssh_path / "None-key").read_text()
+
+    with with_injection():
+        ssh_setup(force=True)
+
+    assert key != (renku_ssh_path / "None-key").read_text()
+
+
+def test_session_start_ssh(project, with_injection, mock_communication, fake_home):
+    def _fake_send_request(self, req_type: str, *args, **kwargs):
+        class _FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return {"name": "0xdeadbeef"}
+
+        return _FakeResponse()
+
+    with patch.multiple(
+        RenkulabSessionProvider,
+        find_image=fake_find_image,
+        build_image=fake_build_image,
+        _wait_for_session_status=lambda _, __, ___: None,
+        _send_renku_request=_fake_send_request,
+        _remote_head_hexsha=lambda _: project.repository.head.commit.hexsha,
+        _renku_url=lambda _: "example.com",
+        _cleanup_ssh_connection_configs=lambda _, __: None,
+        _auth_header=lambda _: None,
+    ):
+        provider_implementation = next(filter(lambda x: x.name == "renkulab", get_supported_session_providers()), None)
+        assert provider_implementation is not None
+
+        with with_injection():
+            ssh_setup()
+            session_start(provider="renkulab", config_path=None, ssh=True)
+
+        assert any("0xdeadbeef" in line for line in mock_communication.stdout_lines)
+        ssh_home = fake_home / ".ssh"
+        renku_ssh_path = ssh_home / "renku"
+        assert (renku_ssh_path / "99-None-jumphost.conf").exists()
+        assert (project.path / ".ssh" / "authorized_keys").exists()
+        assert len(list(renku_ssh_path.glob("00-*-0xdeadbeef.conf"))) == 1

--- a/tests/fixtures/communication.py
+++ b/tests/fixtures/communication.py
@@ -19,6 +19,7 @@
 
 from typing import Generator, List
 
+import click
 import pytest
 
 from renku.core.util.communication import CommunicationCallback
@@ -31,6 +32,7 @@ class MockCommunication(CommunicationCallback):
         super().__init__()
         self._stdout: List[str] = []
         self._stderr: List[str] = []
+        self.confirm_calls: List[str] = []
 
     @property
     def stdout(self) -> str:
@@ -70,7 +72,14 @@ class MockCommunication(CommunicationCallback):
 
     def confirm(self, msg, abort=False, warning=False, default=False):
         """Get confirmation for an action."""
+        self.confirm_calls.append(msg)
+        if abort:
+            raise click.Abort()
         return False
+
+    def has_prompt(self):
+        """Prompt for user input."""
+        return True
 
     def _write_to(self, message: str, output=None):
         output = output or self._stdout

--- a/tests/fixtures/session.py
+++ b/tests/fixtures/session.py
@@ -35,7 +35,8 @@ def dummy_session_provider():
     class _DummySessionProvider(ISessionProvider):
         sessions = list()
 
-        def get_name(self):
+        @property
+        def name(self):
             return "dummy"
 
         def is_remote_provider(self):
@@ -63,6 +64,7 @@ def dummy_session_provider():
             mem_request: Optional[str] = None,
             disk_request: Optional[str] = None,
             gpu_request: Optional[str] = None,
+            **kwargs,
         ) -> Tuple[str, str]:
             name = f"session-random-{uuid4().hex}-name"
             self.sessions.append(name)
@@ -81,6 +83,9 @@ def dummy_session_provider():
 
         def pre_start_checks(self):
             pass
+
+        def get_start_parameters(self):
+            return []
 
     plugin = _DummySessionProvider()
     pm = plugin_manager.get_plugin_manager()

--- a/tests/fixtures/session.py
+++ b/tests/fixtures/session.py
@@ -18,6 +18,7 @@
 """Renku session fixtures."""
 
 from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -81,16 +82,25 @@ def dummy_session_provider():
         def session_url(self, session_name: str) -> Optional[str]:
             return "http://localhost/"
 
-        def pre_start_checks(self):
+        def pre_start_checks(self, **kwargs):
             pass
 
         def get_start_parameters(self):
             return []
 
+        def get_open_parameters(self):
+            return []
+
+        def session_open(self, project_name: str, session_name: str, **kwargs) -> bool:
+            browser.open(self.session_url(session_name))
+            return True
+
     plugin = _DummySessionProvider()
     pm = plugin_manager.get_plugin_manager()
     pm.register(plugin)
 
-    yield
+    browser = MagicMock()
+
+    yield browser
 
     pm.unregister(plugin)


### PR DESCRIPTION
closes #3289 
closes #3290 

Adds `renku session setup-ssh` command to configure SSH locally for access to a deployment (need to be logged in).
Adds `renku session start --ssh` command that setups of keys in the project for SSH access and configures the local machine for access to a session. Also perfirms `setup-ssh` if not done already.
Adds `renku session open --ssh` command that opens an SSH connection to a session.