### PR TITLE
docs: fix RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,6 @@ build:
       - poetry install --with docs --with tests
 
 python:
-  version: 3.9
   install:
     - method: pip
       path: .


### PR DESCRIPTION
`python.version` is deprecated and we set `build.tools.python` already