### PR TITLE
chore: fix coveralls comments

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -3,9 +3,13 @@ name: Test, Integration Tests and Deploy
 on:
   push:
     branches:
-      - "**"
+      - master
+      - develop
     tags:
       - "v*.*.*"
+  pull_request:
+    types: [opened, reopened, synchronize]
+
 env:
   DEPENDENCY_CACHE_PREFIX: "v2"
   NETWORK_CACHE_PREFIX: "v1"


### PR DESCRIPTION
Coveralls should be posting code coverage on the repo, but doesn't I think it's because the actions only run on push, not on PR. So from the POV of coveralls, it's never run on a PR and doesn't comment. This should fix that.