### PR TITLE
chore: remove python 3.7 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/.github/workflows/publish_shacl.yml
+++ b/.github/workflows/publish_shacl.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -33,9 +33,9 @@ jobs:
         run: |
           if [ "$REF" == "refs/heads/$DEFAULT_BRANCH" ] || [[ "$REF" =~ ^refs/tags/.* ]]
           then
-              echo "matrix={\"python-version\": [\"3.7\", \"3.10\"]}" >> $GITHUB_OUTPUT
+              echo "matrix={\"python-version\": [\"3.8\", \"3.11\"]}" >> $GITHUB_OUTPUT
           else
-              echo "matrix={\"python-version\": [\"3.9\"]}" >> $GITHUB_OUTPUT
+              echo "matrix={\"python-version\": [\"3.10\"]}" >> $GITHUB_OUTPUT
           fi
 
   cleanup-runs:

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: [3.10]
     steps:
     - uses: actions/checkout@v3.3.0
       with:
@@ -43,7 +43,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: [3.10]
     if: "startsWith(github.ref, 'refs/tags/') || endsWith(github.ref, github.event.repository.default_branch)"
     steps:
     - uses: actions/checkout@v3.3.0

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -188,6 +188,6 @@ Before you submit a pull request, check that it meets these guidelines:
 * Make sure you agree with the license and follow the legal_ matter.
 * The pull request should include tests and must not decrease test coverage.
 * If the pull request adds functionality, the docs should be updated. Put your new functionality into a function with a docstring.
-* The pull request should work for Python 3.7, 3.8 and 3.9. Check GitHub action builds and make sure that the tests pass for all supported Python versions.
+* The pull request should work for Python 3.8, 3.9, 3.10 and 3.11. Check GitHub action builds and make sure that the tests pass for all supported Python versions.
 
 .. _legal: https://github.com/SwissDataScienceCenter/documentation/wiki/Legal-matter

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/QA_PROTOCOL.rst
+++ b/QA_PROTOCOL.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2022 Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/docs/_ext/cheatsheet.py
+++ b/docs/_ext/cheatsheet.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/cheatsheet/conf.py
+++ b/docs/cheatsheet/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #
@@ -86,7 +86,7 @@ master_doc = "cheatsheet"
 
 # General information about the project.
 project = "Renku"
-copyright = "2017-2022, Swiss Data Science Center"
+copyright = "2017-2023, Swiss Data Science Center"
 author = "Swiss Data Science Center"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #
@@ -71,7 +71,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Renku"
-copyright = "2017-2022, Swiss Data Science Center"
+copyright = "2017-2023, Swiss Data Science Center"
 author = "Swiss Data Science Center"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -178,8 +178,8 @@ html_favicon = "_static/icons/favicon.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-html_css_files = ['css/override-theme.css']
+html_static_path = ["_static"]
+html_css_files = ["css/override-theme.css"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 :orphan:
 
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -3,7 +3,7 @@ License
 
 .. code-block:: text
 
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/commands/index.rst
+++ b/docs/reference/commands/index.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/core.rst
+++ b/docs/reference/core.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/database.rst
+++ b/docs/reference/database.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/gateways.rst
+++ b/docs/reference/gateways.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/models/dataset_provider.rst
+++ b/docs/reference/models/dataset_provider.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/models/datasets.rst
+++ b/docs/reference/models/datasets.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/models/entity.rst
+++ b/docs/reference/models/entity.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2019-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/models/index.rst
+++ b/docs/reference/models/index.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2019-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/models/projects.rst
+++ b/docs/reference/models/projects.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/models/provenance.rst
+++ b/docs/reference/models/provenance.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/models/refs.rst
+++ b/docs/reference/models/refs.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2019-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/models/session.rst
+++ b/docs/reference/models/session.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2019-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/models/template.rst
+++ b/docs/reference/models/template.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2019-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/models/workflow.rst
+++ b/docs/reference/models/workflow.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/service.rst
+++ b/docs/reference/service.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/docs/reference/service_errors.rst
+++ b/docs/reference/service_errors.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+    Copyright 2017-2023 - Swiss Data Science Center (SDSC)
     A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
     Eidgenössische Technische Hochschule Zürich (ETHZ).
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -94,18 +94,19 @@ files = [
 
 [[package]]
 name = "argcomplete"
-version = "2.0.0"
+version = "2.0.5"
 description = "Bash tab completion for argparse"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "argcomplete-2.0.0-py2.py3-none-any.whl", hash = "sha256:cffa11ea77999bb0dd27bb25ff6dc142a6796142f68d45b1a26b11f58724561e"},
-    {file = "argcomplete-2.0.0.tar.gz", hash = "sha256:6372ad78c89d662035101418ae253668445b391755cfe94ea52f1b9d22425b20"},
+    {file = "argcomplete-2.0.5-py3-none-any.whl", hash = "sha256:e2a2cdb8ee9634ff2fa368ba6b996b46205341e0cf106be8075fd9bdbc5cf2e7"},
+    {file = "argcomplete-2.0.5.tar.gz", hash = "sha256:1cfd12928d62e41901783e4dc7d7ca03eccd589840face4c020693b13f754312"},
 ]
 
 [package.extras]
-test = ["coverage", "flake8", "pexpect", "wheel"]
+lint = ["flake8", "mypy"]
+test = ["coverage", "flake8", "mypy", "pexpect", "wheel"]
 
 [[package]]
 name = "attrs"
@@ -2234,14 +2235,14 @@ six = "*"
 
 [[package]]
 name = "platformdirs"
-version = "3.0.0"
+version = "3.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.0.0-py3-none-any.whl", hash = "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"},
-    {file = "platformdirs-3.0.0.tar.gz", hash = "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9"},
+    {file = "platformdirs-3.1.0-py3-none-any.whl", hash = "sha256:13b08a53ed71021350c9e300d4ea8668438fb0046ab3937ac9a29913a1a1350a"},
+    {file = "platformdirs-3.1.0.tar.gz", hash = "sha256:accc3665857288317f32c7bebb5a8e482ba717b474f3fc1d18ca7f9214be0cef"},
 ]
 
 [package.extras]
@@ -3498,14 +3499,14 @@ tornado = ["tornado (>=5)"]
 
 [[package]]
 name = "setuptools"
-version = "67.4.0"
+version = "67.5.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.4.0-py3-none-any.whl", hash = "sha256:f106dee1b506dee5102cc3f3e9e68137bbad6d47b616be7991714b0c62204251"},
-    {file = "setuptools-67.4.0.tar.gz", hash = "sha256:e5fd0a713141a4a105412233c63dc4e17ba0090c8e8334594ac790ec97792330"},
+    {file = "setuptools-67.5.0-py3-none-any.whl", hash = "sha256:9f0004c0daa3d41ef4465934a89498da3eef994039f48845d6eb8202aa13b2e9"},
+    {file = "setuptools-67.5.0.tar.gz", hash = "sha256:113ff8d482b826d2f3b99f26adb1fe505e526a94a08e68cdf392d1dff9ce0595"},
 ]
 
 [package.extras]

--- a/poetry.lock
+++ b/poetry.lock
@@ -104,9 +104,6 @@ files = [
     {file = "argcomplete-2.0.0.tar.gz", hash = "sha256:6372ad78c89d662035101418ae253668445b391755cfe94ea52f1b9d22425b20"},
 ]
 
-[package.dependencies]
-importlib-metadata = {version = ">=0.23,<5", markers = "python_version == \"3.7\""}
-
 [package.extras]
 test = ["coverage", "flake8", "pexpect", "wheel"]
 
@@ -130,14 +127,14 @@ tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy 
 
 [[package]]
 name = "babel"
-version = "2.12.0"
+version = "2.12.1"
 description = "Internationalization utilities"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Babel-2.12.0-py3-none-any.whl", hash = "sha256:8f8b752c803e9f9e03ff219b644aceb0dbcf081c55a88ea11f86291e60a7bb68"},
-    {file = "Babel-2.12.0.tar.gz", hash = "sha256:468e6cd1e2b571a1663110fc737e3a7d9069d038e0c9c4a7f158caeeafe4089c"},
+    {file = "Babel-2.12.1-py3-none-any.whl", hash = "sha256:b4246fb7677d3b98f501a39d43396d3cafdc8eadb045f4a31be01863f655c610"},
+    {file = "Babel-2.12.1.tar.gz", hash = "sha256:cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455"},
 ]
 
 [package.dependencies]
@@ -204,7 +201,6 @@ mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
@@ -494,7 +490,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "click-option-group"
@@ -662,35 +657,35 @@ python-dateutil = "*"
 
 [[package]]
 name = "cryptography"
-version = "39.0.1"
+version = "39.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "cryptography-39.0.1-cp36-abi3-macosx_10_12_universal2.whl", hash = "sha256:6687ef6d0a6497e2b58e7c5b852b53f62142cfa7cd1555795758934da363a965"},
-    {file = "cryptography-39.0.1-cp36-abi3-macosx_10_12_x86_64.whl", hash = "sha256:706843b48f9a3f9b9911979761c91541e3d90db1ca905fd63fee540a217698bc"},
-    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:5d2d8b87a490bfcd407ed9d49093793d0f75198a35e6eb1a923ce1ee86c62b41"},
-    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e17b26de248c33f3acffb922748151d71827d6021d98c70e6c1a25ddd78505"},
-    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e124352fd3db36a9d4a21c1aa27fd5d051e621845cb87fb851c08f4f75ce8be6"},
-    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:5aa67414fcdfa22cf052e640cb5ddc461924a045cacf325cd164e65312d99502"},
-    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:35f7c7d015d474f4011e859e93e789c87d21f6f4880ebdc29896a60403328f1f"},
-    {file = "cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f24077a3b5298a5a06a8e0536e3ea9ec60e4c7ac486755e5fb6e6ea9b3500106"},
-    {file = "cryptography-39.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:f0c64d1bd842ca2633e74a1a28033d139368ad959872533b1bab8c80e8240a0c"},
-    {file = "cryptography-39.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:0f8da300b5c8af9f98111ffd512910bc792b4c77392a9523624680f7956a99d4"},
-    {file = "cryptography-39.0.1-cp36-abi3-win32.whl", hash = "sha256:fe913f20024eb2cb2f323e42a64bdf2911bb9738a15dba7d3cce48151034e3a8"},
-    {file = "cryptography-39.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac"},
-    {file = "cryptography-39.0.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:807ce09d4434881ca3a7594733669bd834f5b2c6d5c7e36f8c00f691887042ad"},
-    {file = "cryptography-39.0.1-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c5caeb8188c24888c90b5108a441c106f7faa4c4c075a2bcae438c6e8ca73cef"},
-    {file = "cryptography-39.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4789d1e3e257965e960232345002262ede4d094d1a19f4d3b52e48d4d8f3b885"},
-    {file = "cryptography-39.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388"},
-    {file = "cryptography-39.0.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e422abdec8b5fa8462aa016786680720d78bdce7a30c652b7fadf83a4ba35336"},
-    {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2"},
-    {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:6f8ba7f0328b79f08bdacc3e4e66fb4d7aab0c3584e0bd41328dce5262e26b2e"},
-    {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:ef8b72fa70b348724ff1218267e7f7375b8de4e8194d1636ee60510aae104cd0"},
-    {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:aec5a6c9864be7df2240c382740fcf3b96928c46604eaa7f3091f58b878c0bb6"},
-    {file = "cryptography-39.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:fdd188c8a6ef8769f148f88f859884507b954cc64db6b52f66ef199bb9ad660a"},
-    {file = "cryptography-39.0.1.tar.gz", hash = "sha256:d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695"},
+    {file = "cryptography-39.0.2-cp36-abi3-macosx_10_12_universal2.whl", hash = "sha256:2725672bb53bb92dc7b4150d233cd4b8c59615cd8288d495eaa86db00d4e5c06"},
+    {file = "cryptography-39.0.2-cp36-abi3-macosx_10_12_x86_64.whl", hash = "sha256:23df8ca3f24699167daf3e23e51f7ba7334d504af63a94af468f468b975b7dd7"},
+    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:eb40fe69cfc6f5cdab9a5ebd022131ba21453cf7b8a7fd3631f45bbf52bed612"},
+    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc0521cce2c1d541634b19f3ac661d7a64f9555135e9d8af3980965be717fd4a"},
+    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffd394c7896ed7821a6d13b24657c6a34b6e2650bd84ae063cf11ccffa4f1a97"},
+    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:e8a0772016feeb106efd28d4a328e77dc2edae84dfbac06061319fdb669ff828"},
+    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f35c17bd4faed2bc7797d2a66cbb4f986242ce2e30340ab832e5d99ae60e011"},
+    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b49a88ff802e1993b7f749b1eeb31134f03c8d5c956e3c125c75558955cda536"},
+    {file = "cryptography-39.0.2-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:5f8c682e736513db7d04349b4f6693690170f95aac449c56f97415c6980edef5"},
+    {file = "cryptography-39.0.2-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:d7d84a512a59f4412ca8549b01f94be4161c94efc598bf09d027d67826beddc0"},
+    {file = "cryptography-39.0.2-cp36-abi3-win32.whl", hash = "sha256:c43ac224aabcbf83a947eeb8b17eaf1547bce3767ee2d70093b461f31729a480"},
+    {file = "cryptography-39.0.2-cp36-abi3-win_amd64.whl", hash = "sha256:788b3921d763ee35dfdb04248d0e3de11e3ca8eb22e2e48fef880c42e1f3c8f9"},
+    {file = "cryptography-39.0.2-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:d15809e0dbdad486f4ad0979753518f47980020b7a34e9fc56e8be4f60702fac"},
+    {file = "cryptography-39.0.2-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:50cadb9b2f961757e712a9737ef33d89b8190c3ea34d0fb6675e00edbe35d074"},
+    {file = "cryptography-39.0.2-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:103e8f7155f3ce2ffa0049fe60169878d47a4364b277906386f8de21c9234aa1"},
+    {file = "cryptography-39.0.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:6236a9610c912b129610eb1a274bdc1350b5df834d124fa84729ebeaf7da42c3"},
+    {file = "cryptography-39.0.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e944fe07b6f229f4c1a06a7ef906a19652bdd9fd54c761b0ff87e83ae7a30354"},
+    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:35d658536b0a4117c885728d1a7032bdc9a5974722ae298d6c533755a6ee3915"},
+    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:30b1d1bfd00f6fc80d11300a29f1d8ab2b8d9febb6ed4a38a76880ec564fae84"},
+    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:e029b844c21116564b8b61216befabca4b500e6816fa9f0ba49527653cae2108"},
+    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fa507318e427169ade4e9eccef39e9011cdc19534f55ca2f36ec3f388c1f70f3"},
+    {file = "cryptography-39.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:8bc0008ef798231fac03fe7d26e82d601d15bd16f3afaad1c6113771566570f3"},
+    {file = "cryptography-39.0.2.tar.gz", hash = "sha256:bc5b871e977c8ee5a1bbc42fa8d19bcc08baf0c51cbf1586b0e87a2694dde42f"},
 ]
 
 [package.dependencies]
@@ -723,7 +718,6 @@ files = [
     {version = ">=0.16.0,<0.17.22", markers = "python_version >= \"3.10\""},
     {version = ">=0.15.78,<0.17.22", markers = "python_version >= \"3.8\""},
     {version = ">=0.15.98,<0.17.22", markers = "python_version >= \"3.9\""},
-    {version = ">=0.15.71,<0.17.22", markers = "python_version < \"3.8\""},
 ]
 schema-salad = "*"
 setuptools = "*"
@@ -904,7 +898,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=1.6.0", markers = "python_version < \"3.8\""}
 packaging = ">=20.9"
 
 [[package]]
@@ -979,24 +972,6 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pyt
 
 [[package]]
 name = "flake8"
-version = "4.0.1"
-description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
-    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
-]
-
-[package.dependencies]
-importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
-mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.8.0,<2.9.0"
-pyflakes = ">=2.4.0,<2.5.0"
-
-[[package]]
-name = "flake8"
 version = "6.0.0"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
@@ -1011,24 +986,6 @@ files = [
 mccabe = ">=0.7.0,<0.8.0"
 pycodestyle = ">=2.10.0,<2.11.0"
 pyflakes = ">=3.0.0,<3.1.0"
-
-[[package]]
-name = "flake8-pyproject"
-version = "0.9.1"
-description = "Runs Flake8 with configuration from pyproject.toml."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "flake8_pyproject-0.9.1-py3-none-any.whl", hash = "sha256:e4b6973021ab78aeb2a0ec993a0f990f26e01746728b102db3b212d1e509b43e"},
-]
-
-[package.dependencies]
-Flake8 = "<5"
-TOMLi = "*"
-
-[package.extras]
-test = ["pyTest", "pyTest-cov"]
 
 [[package]]
 name = "flake8-pyproject"
@@ -1149,7 +1106,6 @@ files = [
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
-typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "grandalf"
@@ -1202,7 +1158,6 @@ files = [
 ]
 
 [package.dependencies]
-pyreadline = {version = "*", markers = "sys_platform == \"win32\" and python_version < \"3.8\""}
 pyreadline3 = {version = "*", markers = "sys_platform == \"win32\" and python_version >= \"3.8\""}
 
 [[package]]
@@ -1216,9 +1171,6 @@ files = [
     {file = "humanize-4.0.0-py3-none-any.whl", hash = "sha256:8d86333b8557dacffd4dce1dbe09c81c189e2caf7bb17a970b2212f0f58f10f2"},
     {file = "humanize-4.0.0.tar.gz", hash = "sha256:ee1f872fdfc7d2ef4a28d4f80ddde9f96d36955b5d6b0dac4bdeb99502bddb00"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 tests = ["freezegun", "pytest", "pytest-cov"]
@@ -1264,63 +1216,42 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "4.2.0"
-description = "Read metadata from Python packages"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
-    {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pep517", "pyfakefs", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
-
-[[package]]
-name = "importlib-metadata"
-version = "4.13.0"
+version = "6.0.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_metadata-4.13.0-py3-none-any.whl", hash = "sha256:8a8a81bcf996e74fee46f0d16bd3eaa382a7eb20fd82445c3ad11f4090334116"},
-    {file = "importlib_metadata-4.13.0.tar.gz", hash = "sha256:dd0173e8f150d6815e098fd354f6414b0f079af4644ddfe90c71e2fc6174346d"},
+    {file = "importlib_metadata-6.0.0-py3-none-any.whl", hash = "sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad"},
+    {file = "importlib_metadata-6.0.0.tar.gz", hash = "sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d"},
 ]
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
 testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
 name = "importlib-resources"
-version = "5.9.0"
+version = "5.12.0"
 description = "Read resources from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_resources-5.9.0-py3-none-any.whl", hash = "sha256:f78a8df21a79bcc30cfd400bdc38f314333de7c0fb619763f6b9dabab8268bb7"},
-    {file = "importlib_resources-5.9.0.tar.gz", hash = "sha256:5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681"},
+    {file = "importlib_resources-5.12.0-py3-none-any.whl", hash = "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"},
+    {file = "importlib_resources-5.12.0.tar.gz", hash = "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6"},
 ]
 
 [package.dependencies]
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -1762,18 +1693,6 @@ tests = ["mock", "pytest"]
 
 [[package]]
 name = "mccabe"
-version = "0.6.1"
-description = "McCabe checker, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
-    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
-]
-
-[[package]]
-name = "mccabe"
 version = "0.7.0"
 description = "McCabe checker, plugin for flake8"
 category = "dev"
@@ -1985,7 +1904,6 @@ files = [
 [package.dependencies]
 mypy-extensions = ">=0.4.3"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
@@ -2316,25 +2234,6 @@ six = "*"
 
 [[package]]
 name = "platformdirs"
-version = "2.6.2"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
-    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.4", markers = "python_version < \"3.8\""}
-
-[package.extras]
-docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
-
-[[package]]
-name = "platformdirs"
 version = "3.0.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
@@ -2344,9 +2243,6 @@ files = [
     {file = "platformdirs-3.0.0-py3-none-any.whl", hash = "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"},
     {file = "platformdirs-3.0.0.tar.gz", hash = "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9"},
 ]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
@@ -2363,9 +2259,6 @@ files = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -2404,7 +2297,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=0.22", markers = "python_version < \"3.8\""}
 toml = ">=0.10.1,<0.11.0"
 
 [[package]]
@@ -2442,7 +2334,6 @@ files = [
 [package.dependencies]
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
@@ -2472,7 +2363,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 wcwidth = "*"
 
 [package.extras]
@@ -2585,18 +2475,6 @@ attrs = ">=17.4.0"
 future = ">=0.16.0"
 python-dateutil = ">=2.6.1"
 requests = ">=2.18.1"
-
-[[package]]
-name = "pycodestyle"
-version = "2.8.0"
-description = "Python style guide checker"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
-    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
-]
 
 [[package]]
 name = "pycodestyle"
@@ -2724,18 +2602,6 @@ files = [
 
 [[package]]
 name = "pyflakes"
-version = "2.4.0"
-description = "passive checker of Python programs"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
-    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
-]
-
-[[package]]
-name = "pyflakes"
 version = "3.0.1"
 description = "passive checker of Python programs"
 category = "dev"
@@ -2836,17 +2702,6 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
-name = "pyreadline"
-version = "2.1"
-description = "A python implmementation of GNU readline."
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pyreadline-2.1.zip", hash = "sha256:4530592fc2e85b25b1a9f79664433da09237c1a270e4d78ea5aa3a2c7229e2d1"},
-]
-
-[[package]]
 name = "pyreadline3"
 version = "3.4.1"
 description = "A python implementation of GNU readline."
@@ -2911,7 +2766,6 @@ files = [
 [package.dependencies]
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -3341,7 +3195,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8.0\""}
 isodate = "*"
 pyparsing = "*"
 setuptools = "*"
@@ -3365,7 +3218,6 @@ files = [
 
 [package.dependencies]
 deprecated = ">=1.2.3"
-importlib-metadata = {version = ">=1.0", markers = "python_version < \"3.8\""}
 packaging = ">=20.4"
 
 [package.extras]
@@ -3447,7 +3299,6 @@ files = [
 requests = ">=2.22.0,<3.0"
 toml = "*"
 types-toml = "*"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 urllib3 = ">=1.25.10"
 
 [package.extras]
@@ -3736,42 +3587,6 @@ files = [
 
 [[package]]
 name = "sphinx"
-version = "4.3.2"
-description = "Python documentation generator"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "Sphinx-4.3.2-py3-none-any.whl", hash = "sha256:6a11ea5dd0bdb197f9c2abc2e0ce73e01340464feaece525e64036546d24c851"},
-    {file = "Sphinx-4.3.2.tar.gz", hash = "sha256:0a8836751a68306b3fe97ecbe44db786f8479c3bf4b80e3a7f5c838657b4698c"},
-]
-
-[package.dependencies]
-alabaster = ">=0.7,<0.8"
-babel = ">=1.3"
-colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
-docutils = ">=0.14,<0.18"
-imagesize = "*"
-Jinja2 = ">=2.3"
-packaging = "*"
-Pygments = ">=2.0"
-requests = ">=2.5.0"
-setuptools = "*"
-snowballstemmer = ">=1.1"
-sphinxcontrib-applehelp = "*"
-sphinxcontrib-devhelp = "*"
-sphinxcontrib-htmlhelp = ">=2.0.0"
-sphinxcontrib-jsmath = "*"
-sphinxcontrib-qthelp = "*"
-sphinxcontrib-serializinghtml = ">=1.1.5"
-
-[package.extras]
-docs = ["sphinxcontrib-websupport"]
-lint = ["docutils-stubs", "flake8 (>=3.5.0)", "isort", "mypy (>=0.920)", "types-pkg-resources", "types-requests", "types-typed-ast"]
-test = ["cython", "html5lib", "pytest", "pytest-cov", "typed-ast"]
-
-[[package]]
-name = "sphinx"
 version = "4.5.0"
 description = "Python documentation generator"
 category = "dev"
@@ -3865,14 +3680,14 @@ testing = ["bs4", "coverage", "pygments", "pytest (>=3.6,<4)", "pytest-cov", "py
 
 [[package]]
 name = "sphinxcontrib-applehelp"
-version = "1.0.2"
-description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
+version = "1.0.4"
+description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 files = [
-    {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
-    {file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a"},
+    {file = "sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"},
+    {file = "sphinxcontrib_applehelp-1.0.4-py3-none-any.whl", hash = "sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228"},
 ]
 
 [package.extras]
@@ -3897,14 +3712,14 @@ test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-htmlhelp"
-version = "2.0.0"
+version = "2.0.1"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"},
-    {file = "sphinxcontrib_htmlhelp-2.0.0-py2.py3-none-any.whl", hash = "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07"},
+    {file = "sphinxcontrib-htmlhelp-2.0.1.tar.gz", hash = "sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff"},
+    {file = "sphinxcontrib_htmlhelp-2.0.1-py3-none-any.whl", hash = "sha256:c38cb46dccf316c79de6e5515e1770414b797162b23cd3d06e67020e1d2a6903"},
 ]
 
 [package.extras]
@@ -3971,7 +3786,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=1.7.0", markers = "python_version < \"3.8\""}
 PyEnchant = ">=3.1.1"
 Sphinx = ">=3.0.0"
 
@@ -4026,7 +3840,6 @@ py-tes = ">=0.4.2,<1"
 python-dateutil = "*"
 pytz = ">=2012"
 requests = ">=2,<3"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 all = ["apache-libcloud (>=2.2.1,<3)", "boto (>=2.48.0,<3)", "boto3 (>=1.20.46,<2)", "boto3-stubs[iam,s3,sdb] (==1.24.0)", "celery (>=5.1.0,<6)", "connexion[swagger-ui] (>=2.10.0,<3)", "cwltool (==3.1.20220628170238)", "flask (>=2.0,<3)", "flask-cors (==3.0.10)", "galaxy-tool-util", "google-cloud-storage (>=1.6.0,<2)", "gunicorn (==20.1.0)", "idna (>=2)", "kubernetes (>=12.0.1,<22)", "mypy-boto3-iam (==1.24.0)", "mypy-boto3-s3 (==1.24.0)", "mypy-boto3-sdb (==1.24.0)", "networkx (>=2,<2.8.5)", "pymesos (>=0.3.15,<0.4)", "pynacl (>=1.4.0,<2)", "ruamel.yaml (>=0.15,<0.17.22)", "ruamel.yaml (>=0.15,<=0.17.21)", "ruamel.yaml.clib (>=0.2.6)", "wdlparse (==0.1.0)", "werkzeug (>=2.0,<3)", "wes-service (>=4.0.0,<5)"]
@@ -4138,49 +3951,15 @@ test = ["mock"]
 testing = ["coverage", "mock", "nose"]
 
 [[package]]
-name = "typed-ast"
-version = "1.5.4"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
-    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
-    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
-    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
-    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
-]
-
-[[package]]
 name = "types-python-dateutil"
-version = "2.8.19.9"
+version = "2.8.19.10"
 description = "Typing stubs for python-dateutil"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-python-dateutil-2.8.19.9.tar.gz", hash = "sha256:637716fb3afbdc7eb683f641171f874937af13149cd456a8c63e8f81127a39ed"},
-    {file = "types_python_dateutil-2.8.19.9-py3-none-any.whl", hash = "sha256:142a8749c18a3e16bfc5ba95cbd54750e7e613dec30285906602cafbf43c37b4"},
+    {file = "types-python-dateutil-2.8.19.10.tar.gz", hash = "sha256:c640f2eb71b4b94a9d3bfda4c04250d29a24e51b8bad6e12fddec0cf6e96f7a3"},
+    {file = "types_python_dateutil-2.8.19.10-py3-none-any.whl", hash = "sha256:fbecd02c19cac383bf4a16248d45ffcff17c93a04c0794be5f95d42c6aa5de39"},
 ]
 
 [[package]]
@@ -4292,42 +4071,19 @@ yarl = "*"
 
 [[package]]
 name = "virtualenv"
-version = "20.16.2"
-description = "Virtual Python Environment builder"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "virtualenv-20.16.2-py2.py3-none-any.whl", hash = "sha256:635b272a8e2f77cb051946f46c60a54ace3cb5e25568228bd6b57fc70eca9ff3"},
-    {file = "virtualenv-20.16.2.tar.gz", hash = "sha256:0ef5be6d07181946891f5abc8047fda8bc2f0b4b9bf222c64e6e8963baee76db"},
-]
-
-[package.dependencies]
-distlib = ">=0.3.1,<1"
-filelock = ">=3.2,<4"
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-platformdirs = ">=2,<3"
-
-[package.extras]
-docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
-
-[[package]]
-name = "virtualenv"
-version = "20.19.0"
+version = "20.20.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.19.0-py3-none-any.whl", hash = "sha256:54eb59e7352b573aa04d53f80fc9736ed0ad5143af445a1e539aada6eb947dd1"},
-    {file = "virtualenv-20.19.0.tar.gz", hash = "sha256:37a640ba82ed40b226599c522d411e4be5edb339a0c0de030c0dc7b646d61590"},
+    {file = "virtualenv-20.20.0-py3-none-any.whl", hash = "sha256:3c22fa5a7c7aa106ced59934d2c20a2ecb7f49b4130b8bf444178a16b880fa45"},
+    {file = "virtualenv-20.20.0.tar.gz", hash = "sha256:a8a4b8ca1e28f864b7514a253f98c1d62b64e31e77325ba279248c65fb4fcef4"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.6,<1"
 filelock = ">=3.4.1,<4"
-importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.8\""}
 platformdirs = ">=2.4,<4"
 
 [package.extras]
@@ -4582,7 +4338,6 @@ files = [
 [package.dependencies]
 idna = ">=2.0"
 multidict = ">=4.0"
-typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "yaspin"
@@ -4954,5 +4709,5 @@ service = ["apispec", "apispec-webframeworks", "circus", "flask", "gunicorn", "m
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7.1"
-content-hash = "adf01e016c4dfc2f29c2a9a6ef0aa76e7da888a19674439af09d2176bcbc6412"
+python-versions = "^3.8.1"
+content-hash = "1f42446435c842d072f23e3ae53c793a8643f86d2a4845ba3b32fdca5b98a0de"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Development Status :: 4 - Beta",
@@ -50,7 +49,7 @@ readme = "README.rst"
 Changelog = "https://github.com/swissdatasciencecenter/renku-python/blob/master/CHANGES.rst"
 
 [tool.poetry.dependencies]
-python = "^3.7.1"
+python = "^3.8.1"
 appdirs = "<=1.4.4,>=1.4.3"
 attrs = ">=21.1.0,<22.2.0"
 bashlex = ">=0.16,<0.17"
@@ -69,7 +68,7 @@ filelock = ">=3.3.0,<3.8.1"
 gitpython = "==3.1.27"
 grandalf = "==0.7"
 humanize = ">=3.0.0,<4.1.0"
-importlib-resources = { version = ">=5.4.0,<5.10.0", python = "<3.9.0" }
+importlib-resources = ">=5.12.0,<5.13.0"#{ version = ">=5.4.0,<5.10.0", python = "<3.9.0" }
 inject = "<4.4.0,>=4.3.0"
 jinja2 = { version = ">=2.11.3,<3.1.3" }
 networkx = "<2.7,>=2.6.0"
@@ -122,14 +121,8 @@ walrus = { version = ">=0.8.2,<0.10.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 black = "==22.10.0"
-flake8 = [
-    { version = ">=6.0.0,<7.0.0", python = ">=3.8.1"},
-    { version = ">=4.0.0,<5.0.0", python = "<3.8.1"}
-]
-Flake8-pyproject = [
-    { version ="==1.2.2", python = ">=3.8.1"},
-    { version ="<1.0.0", python = "<3.8.1"}
-]
+flake8 = ">=6.0.0,<7.0.0"
+Flake8-pyproject = "==1.2.2"
 isort = "<5.10.2,>=5.3.2"
 mypy = ">=0.942,<1.0"
 poetry-lock-package = "^0.5.0"
@@ -139,7 +132,6 @@ types-python-dateutil = "^2.8.10"
 types-redis = ">=3.5.3,<4.1.0"
 types-requests = "<2.27.2,>=2.23.0"
 types-tabulate = "<0.8.10,>=0.7.7"
-typing-extensions = { version = ">=4.3.0,<5.0.0", python = "<3.8.0" }
 
 [tool.poetry.group.tests]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ filelock = ">=3.3.0,<3.8.1"
 gitpython = "==3.1.27"
 grandalf = "==0.7"
 humanize = ">=3.0.0,<4.1.0"
-importlib-resources = ">=5.12.0,<5.13.0"#{ version = ">=5.4.0,<5.10.0", python = "<3.9.0" }
+importlib-resources = ">=5.12.0,<5.13.0"
 inject = "<4.4.0,>=4.3.0"
 jinja2 = { version = ">=2.11.3,<3.1.3" }
 networkx = "<2.7,>=2.6.0"

--- a/renku/__init__.py
+++ b/renku/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -17,7 +16,6 @@
 # limitations under the License.
 """Renku modules."""
 
-from __future__ import absolute_import, print_function
 
 import importlib
 import importlib.util

--- a/renku/__init__.py
+++ b/renku/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/__init__.py
+++ b/renku/command/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/__init__.py
+++ b/renku/command/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/checks/__init__.py
+++ b/renku/command/checks/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/checks/activities.py
+++ b/renku/command/checks/activities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/checks/datasets.py
+++ b/renku/command/checks/datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/checks/external.py
+++ b/renku/command/checks/external.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/checks/githooks.py
+++ b/renku/command/checks/githooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/checks/migration.py
+++ b/renku/command/checks/migration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/checks/project.py
+++ b/renku/command/checks/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/checks/storage.py
+++ b/renku/command/checks/storage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/checks/validate_shacl.py
+++ b/renku/command/checks/validate_shacl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -51,7 +50,7 @@ def _shacl_graph_to_string(graph):
         res = graph.value(result, sh.resultMessage)
 
         if res:
-            message = "{0}: {1}".format(path, res)
+            message = f"{path}: {res}"
         else:
             kind = graph.value(result, sh.sourceConstraintComponent)
             focus_node = graph.value(result, sh.focusNode)
@@ -59,7 +58,7 @@ def _shacl_graph_to_string(graph):
             if isinstance(focus_node, BNode):
                 focus_node = "<Anonymous>"
 
-            message = "{0}: Type: {1}, Node ID: {2}".format(path, kind, focus_node)
+            message = f"{path}: Type: {kind}, Node ID: {focus_node}"
 
         problems.append(message)
 
@@ -82,7 +81,7 @@ def check_project_structure(**_):
     if conform:
         return True, None
 
-    problems = "{0}Invalid structure of project metadata\n\t{1}".format(WARNING, _shacl_graph_to_string(graph))
+    problems = f"{WARNING}Invalid structure of project metadata\n\t{_shacl_graph_to_string(graph)}"
 
     return False, problems
 

--- a/renku/command/checks/workflow.py
+++ b/renku/command/checks/workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/clone.py
+++ b/renku/command/clone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/clone.py
+++ b/renku/command/clone.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/command_builder/__init__.py
+++ b/renku/command/command_builder/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/command_builder/__init__.py
+++ b/renku/command/command_builder/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/command_builder/command.py
+++ b/renku/command/command_builder/command.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/command_builder/command.py
+++ b/renku/command/command_builder/command.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/command_builder/communication.py
+++ b/renku/command/command_builder/communication.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/command_builder/communication.py
+++ b/renku/command/command_builder/communication.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/command_builder/database.py
+++ b/renku/command/command_builder/database.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/command_builder/database.py
+++ b/renku/command/command_builder/database.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -82,7 +81,7 @@ class DatabaseCommand(Command):
             self.project_found = True
         except (KeyError, ImportError, ValueError):
             try:
-                with open(project_context.database_path / "project", "r") as f:
+                with open(project_context.database_path / "project") as f:
                     project = json.load(f)
                     min_version = project.get("minimum_renku_version")
                     if min_version is None:

--- a/renku/command/command_builder/lock.py
+++ b/renku/command/command_builder/lock.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/command_builder/lock.py
+++ b/renku/command/command_builder/lock.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/command_builder/migration.py
+++ b/renku/command/command_builder/migration.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/command_builder/migration.py
+++ b/renku/command/command_builder/migration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/command_builder/repo.py
+++ b/renku/command/command_builder/repo.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/command_builder/repo.py
+++ b/renku/command/command_builder/repo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/config.py
+++ b/renku/command/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/config.py
+++ b/renku/command/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -39,7 +38,7 @@ def _split_section_and_key(key):
     """
     parts = key.split(".")
     if len(parts) > 1:
-        return "{0}".format(parts[0]), ".".join(parts[1:])
+        return f"{parts[0]}", ".".join(parts[1:])
     return "renku", key
 
 
@@ -98,7 +97,7 @@ def _update_config(
     if remove:
         value = remove_value(section, section_key, global_only=global_only)
         if value is None:
-            raise errors.ParameterError('Key "{}" not found.'.format(key))
+            raise errors.ParameterError(f'Key "{key}" not found.')
     else:
         set_value(section, section_key, value, global_only=global_only)
         return value

--- a/renku/command/dataset.py
+++ b/renku/command/dataset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/dataset.py
+++ b/renku/command/dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/doctor.py
+++ b/renku/command/doctor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/format/__init__.py
+++ b/renku/command/format/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/format/activity.py
+++ b/renku/command/format/activity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -37,10 +36,13 @@ def tabulate_activities(activities: List[Activity], modified_inputs: Set[str]):
     """
     collection = []
     fields = "plan,execution_date,modified_inputs,outputs,command"
-    ActivityDisplay = NamedTuple(
-        "ActivityDisplay",
-        [("plan", str), ("execution_date", datetime), ("modified_inputs", str), ("outputs", str), ("command", str)],
-    )
+
+    class ActivityDisplay(NamedTuple):
+        plan: str
+        execution_date: datetime
+        modified_inputs: str
+        outputs: str
+        command: str
 
     for activity in activities:
         modified_usages = {

--- a/renku/command/format/dataset_files.py
+++ b/renku/command/format/dataset_files.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -78,7 +77,7 @@ def get_lfs_tracking_and_file_sizes(records, has_tag: bool):
             ("git", "lfs", "ls-files", "--name-only", "--size", "--deleted"),
             stdout=PIPE,
             cwd=project_context.path,
-            universal_newlines=True,
+            text=True,
         )
     except SubprocessError:
         pass

--- a/renku/command/format/dataset_tags.py
+++ b/renku/command/format/dataset_tags.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/format/datasets.py
+++ b/renku/command/format/datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/format/json.py
+++ b/renku/command/format/json.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/format/session.py
+++ b/renku/command/format/session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/format/tabulate.py
+++ b/renku/command/format/tabulate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/format/workflow.py
+++ b/renku/command/format/workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/gc.py
+++ b/renku/command/gc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/githooks.py
+++ b/renku/command/githooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/githooks.py
+++ b/renku/command/githooks.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/graph.py
+++ b/renku/command/graph.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/graph.py
+++ b/renku/command/graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/group.py
+++ b/renku/command/group.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/group.py
+++ b/renku/command/group.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -27,4 +26,4 @@ class OptionalGroup(click.Group):
         """Check if the first argument is an existing command."""
         if args and args[0] in self.commands:
             args.insert(0, "")
-        super(OptionalGroup, self).parse_args(ctx, args)
+        super().parse_args(ctx, args)

--- a/renku/command/init.py
+++ b/renku/command/init.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/log.py
+++ b/renku/command/log.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/log.py
+++ b/renku/command/log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/login.py
+++ b/renku/command/login.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/login.py
+++ b/renku/command/login.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/mergetool.py
+++ b/renku/command/mergetool.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/mergetool.py
+++ b/renku/command/mergetool.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -69,7 +68,7 @@ def setup_mergetool(with_attributes: bool = True):
     pattern_string = ".renku/metadata/**    merge=renkumerge\n"
 
     if attributes_path.exists():
-        with open(attributes_path, "r") as f:
+        with open(attributes_path) as f:
             content = f.readlines()
             if pattern_string in content:
                 return

--- a/renku/command/migrate.py
+++ b/renku/command/migrate.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/migrate.py
+++ b/renku/command/migrate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/move.py
+++ b/renku/command/move.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/move.py
+++ b/renku/command/move.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -181,7 +180,7 @@ def _check_existing_destinations(destinations):
 def _warn_about_ignored_destinations(destinations):
     ignored = project_context.repository.get_ignored_paths(*destinations)
     if ignored:
-        ignored_str = "\n\t".join((str(Path(p).relative_to(project_context.path)) for p in ignored))
+        ignored_str = "\n\t".join(str(Path(p).relative_to(project_context.path)) for p in ignored)
         communication.warn(f"The following moved path match .gitignore:\n\t{ignored_str}")
 
 

--- a/renku/command/options.py
+++ b/renku/command/options.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/options.py
+++ b/renku/command/options.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/project.py
+++ b/renku/command/project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/project.py
+++ b/renku/command/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/remove.py
+++ b/renku/command/remove.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/remove.py
+++ b/renku/command/remove.py
@@ -20,7 +20,7 @@
 import os
 from pathlib import Path
 from subprocess import run
-from typing import List
+from typing import List, Protocol, runtime_checkable
 
 from pydantic import validate_arguments
 
@@ -34,11 +34,6 @@ from renku.core.util import communication
 from renku.core.util.git import get_git_user
 from renku.core.util.os import delete_dataset_file, expand_directories
 from renku.domain_model.project_context import project_context
-
-try:
-    from typing_extensions import Protocol, runtime_checkable  # NOTE: Required for Python 3.7 compatibility
-except ImportError:
-    from typing import Protocol, runtime_checkable  # type: ignore
 
 
 @runtime_checkable

--- a/renku/command/remove.py
+++ b/renku/command/remove.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -107,7 +106,7 @@ def _remove(sources: List[str], edit_command: EditCommandCallable, dataset_gatew
                 edit_command(filename=str(project_context.path / ".gitattributes"))
 
     # Finally remove the files.
-    files_to_remove = set(str(project_context.path / f) for f in files.values())
+    files_to_remove = {str(project_context.path / f) for f in files.values()}
     final_sources = list(files_to_remove)
     if final_sources:
         run(["git", "rm", "-rf"] + final_sources, check=True)

--- a/renku/command/rerun.py
+++ b/renku/command/rerun.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/rerun.py
+++ b/renku/command/rerun.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/rollback.py
+++ b/renku/command/rollback.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/rollback.py
+++ b/renku/command/rollback.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/run.py
+++ b/renku/command/run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/run.py
+++ b/renku/command/run.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/save.py
+++ b/renku/command/save.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/save.py
+++ b/renku/command/save.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/__init__.py
+++ b/renku/command/schema/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/__init__.py
+++ b/renku/command/schema/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/activity.py
+++ b/renku/command/schema/activity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/activity.py
+++ b/renku/command/schema/activity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/agent.py
+++ b/renku/command/schema/agent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/agent.py
+++ b/renku/command/schema/agent.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/annotation.py
+++ b/renku/command/schema/annotation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/annotation.py
+++ b/renku/command/schema/annotation.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/calamus.py
+++ b/renku/command/schema/calamus.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -105,7 +104,7 @@ class Uri(fields._JsonLDField, marshmallow.fields.String, marshmallow.fields.Dic
         elif isinstance(value, dict):
             return super(marshmallow.fields.String, self)._deserialize(value, attr, data, **kwargs)
         else:
-            raise ValueError("Invalid type for field {}: {}".format(self.name, type(value)))
+            raise ValueError(f"Invalid type for field {self.name}: {type(value)}")
 
 
 class StringList(fields.String):

--- a/renku/command/schema/calamus.py
+++ b/renku/command/schema/calamus.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/composite_plan.py
+++ b/renku/command/schema/composite_plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/composite_plan.py
+++ b/renku/command/schema/composite_plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/dataset.py
+++ b/renku/command/schema/dataset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/dataset.py
+++ b/renku/command/schema/dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/entity.py
+++ b/renku/command/schema/entity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/entity.py
+++ b/renku/command/schema/entity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/parameter.py
+++ b/renku/command/schema/parameter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/parameter.py
+++ b/renku/command/schema/parameter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/plan.py
+++ b/renku/command/schema/plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/plan.py
+++ b/renku/command/schema/plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/project.py
+++ b/renku/command/schema/project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/project.py
+++ b/renku/command/schema/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/schema/workflow_file.py
+++ b/renku/command/schema/workflow_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/schema/workflow_file.py
+++ b/renku/command/schema/workflow_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/session.py
+++ b/renku/command/session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/session.py
+++ b/renku/command/session.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/status.py
+++ b/renku/command/status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/status.py
+++ b/renku/command/status.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/storage.py
+++ b/renku/command/storage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/storage.py
+++ b/renku/command/storage.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/template.py
+++ b/renku/command/template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/update.py
+++ b/renku/command/update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/update.py
+++ b/renku/command/update.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/util.py
+++ b/renku/command/util.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/util.py
+++ b/renku/command/util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/version.py
+++ b/renku/command/version.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/version.py
+++ b/renku/command/version.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -55,7 +54,7 @@ def find_latest_version(name: str, allow_prereleases: bool = False):
     """
     from renku.core.util import requests
 
-    response = requests.get("https://pypi.org/pypi/{name}/json".format(name=name))
+    response = requests.get(f"https://pypi.org/pypi/{name}/json")
 
     if response.status_code != 200:
         return
@@ -132,7 +131,7 @@ class VersionCache:
         try:
             with cache.open() as fp:
                 return cls(**json.load(fp)[sys.prefix])
-        except (IOError, ValueError, KeyError):
+        except (OSError, ValueError, KeyError):
             return cls()
 
     def dump(self, app_name):

--- a/renku/command/view_model/__init__.py
+++ b/renku/command/view_model/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/__init__.py
+++ b/renku/command/view_model/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/view_model/activity_graph.py
+++ b/renku/command/view_model/activity_graph.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/activity_graph.py
+++ b/renku/command/view_model/activity_graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/view_model/agent.py
+++ b/renku/command/view_model/agent.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/agent.py
+++ b/renku/command/view_model/agent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/view_model/composite_plan.py
+++ b/renku/command/view_model/composite_plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/composite_plan.py
+++ b/renku/command/view_model/composite_plan.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
 
 
 class ParameterReference(NamedTuple):
+    """Reference to a workflow parameter."""
+
     id: str
     plan_id: str
     type: str

--- a/renku/command/view_model/composite_plan.py
+++ b/renku/command/view_model/composite_plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -38,7 +37,12 @@ if TYPE_CHECKING:
     from renku.command.view_model.plan import PlanViewModel
 
 
-ParameterReference = NamedTuple("ParameterReference", [("id", str), ("plan_id", str), ("type", str), ("name", str)])
+class ParameterReference(NamedTuple):
+    id: str
+    plan_id: str
+    type: str
+    name: str
+
 
 parameter_type_mapping: Dict[type, str] = {
     CommandInput: "Input",

--- a/renku/command/view_model/dataset.py
+++ b/renku/command/view_model/dataset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/dataset.py
+++ b/renku/command/view_model/dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/view_model/graph.py
+++ b/renku/command/view_model/graph.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/graph.py
+++ b/renku/command/view_model/graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -141,7 +140,7 @@ class GraphViewModel:
 
         def node(x):
             """Return a name of the given node."""
-            return nodes.setdefault(x, "node{0}".format(len(nodes)))
+            return nodes.setdefault(x, f"node{len(nodes)}")
 
         def label(x, g):
             """Generate a label for the node."""
@@ -159,9 +158,9 @@ class GraphViewModel:
             """Format and escape literal."""
             v = html.escape(literal)
             if literal.datatype:
-                return "&quot;%s&quot;^^%s" % (v, qname(literal.datatype, g))
+                return f"&quot;{v}&quot;^^{qname(literal.datatype, g)}"
             elif literal.language:
-                return "&quot;%s&quot;@%s" % (v, literal.language)
+                return f"&quot;{v}&quot;@{literal.language}"
             return "&quot;%s&quot;" % v
 
         def qname(x, g):
@@ -212,7 +211,7 @@ class GraphViewModel:
                 fields[sn].add((qname(p, graph), formatliteral(o, graph)))
 
         for u, n in nodes.items():
-            output.write("# %s %s\n" % (u, n))
+            output.write(f"# {u} {n}\n")
             f = [
                 '<tr><td align="left"><b>%s</b></td><td align="left">' "<b>%s</b></td></tr>" % x
                 for x in sorted(types[n])

--- a/renku/command/view_model/log.py
+++ b/renku/command/view_model/log.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/log.py
+++ b/renku/command/view_model/log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/view_model/plan.py
+++ b/renku/command/view_model/plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/plan.py
+++ b/renku/command/view_model/plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/view_model/project.py
+++ b/renku/command/view_model/project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/project.py
+++ b/renku/command/view_model/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/view_model/template.py
+++ b/renku/command/view_model/template.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/template.py
+++ b/renku/command/view_model/template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/view_model/text_canvas.py
+++ b/renku/command/view_model/text_canvas.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/text_canvas.py
+++ b/renku/command/view_model/text_canvas.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 
 
 class Point(NamedTuple):
+    """A point with coordinates for rendering."""
+
     x: int
     y: int
 

--- a/renku/command/view_model/text_canvas.py
+++ b/renku/command/view_model/text_canvas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -28,7 +27,11 @@ from click import style
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-Point = NamedTuple("Point", [("x", int), ("y", int)])
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
 
 MAX_NODE_LENGTH = 40
 

--- a/renku/command/view_model/workflow_file.py
+++ b/renku/command/view_model/workflow_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/view_model/workflow_file.py
+++ b/renku/command/view_model/workflow_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/command/workflow.py
+++ b/renku/command/workflow.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/command/workflow.py
+++ b/renku/command/workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/__init__.py
+++ b/renku/core/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/__init__.py
+++ b/renku/core/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/config.py
+++ b/renku/core/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/constant.py
+++ b/renku/core/constant.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/constant.py
+++ b/renku/core/constant.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/__init__.py
+++ b/renku/core/dataset/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/__init__.py
+++ b/renku/core/dataset/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/context.py
+++ b/renku/core/dataset/context.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/context.py
+++ b/renku/core/dataset/context.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/dataset.py
+++ b/renku/core/dataset/dataset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/dataset.py
+++ b/renku/core/dataset/dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/dataset_add.py
+++ b/renku/core/dataset/dataset_add.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/dataset_add.py
+++ b/renku/core/dataset/dataset_add.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -115,7 +114,7 @@ def add_to_dataset(
             "with '--create' option for automatic dataset creation.".format(dataset_name)
         )
     except (FileNotFoundError, errors.GitCommandError) as e:
-        raise errors.ParameterError("Could not find paths/URLs: \n{0}".format("\n".join(urls))) from e
+        raise errors.ParameterError("Could not find paths/URLs: \n{}".format("\n".join(urls))) from e
     else:
         project_context.database.commit()
         return dataset

--- a/renku/core/dataset/datasets_provenance.py
+++ b/renku/core/dataset/datasets_provenance.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/datasets_provenance.py
+++ b/renku/core/dataset/datasets_provenance.py
@@ -18,18 +18,13 @@
 """Datasets Provenance."""
 
 from datetime import datetime
-from typing import TYPE_CHECKING, List, Optional, Union, overload
+from typing import TYPE_CHECKING, List, Literal, Optional, Union, overload
 from uuid import UUID
 
 from renku.command.command_builder.command import inject
 from renku.core import errors
 from renku.core.interface.dataset_gateway import IDatasetGateway
 from renku.core.util import communication
-
-try:
-    from typing_extensions import Literal  # NOTE: Required for Python 3.7 compatibility
-except ImportError:
-    from typing import Literal  # type: ignore
 
 if TYPE_CHECKING:
     from renku.domain_model.dataset import Dataset, DatasetTag

--- a/renku/core/dataset/datasets_provenance.py
+++ b/renku/core/dataset/datasets_provenance.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/pointer_file.py
+++ b/renku/core/dataset/pointer_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/pointer_file.py
+++ b/renku/core/dataset/pointer_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/__init__.py
+++ b/renku/core/dataset/providers/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/__init__.py
+++ b/renku/core/dataset/providers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/api.py
+++ b/renku/core/dataset/providers/api.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/azure.py
+++ b/renku/core/dataset/providers/azure.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/azure.py
+++ b/renku/core/dataset/providers/azure.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/cloud.py
+++ b/renku/core/dataset/providers/cloud.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/cloud.py
+++ b/renku/core/dataset/providers/cloud.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/dataverse.py
+++ b/renku/core/dataset/providers/dataverse.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/dataverse.py
+++ b/renku/core/dataset/providers/dataverse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/dataverse_metadata_templates.py
+++ b/renku/core/dataset/providers/dataverse_metadata_templates.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/dataverse_metadata_templates.py
+++ b/renku/core/dataset/providers/dataverse_metadata_templates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/doi.py
+++ b/renku/core/dataset/providers/doi.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/doi.py
+++ b/renku/core/dataset/providers/doi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -57,7 +56,7 @@ class DOIProvider(ProviderApi, ImportProviderInterface):
             response = requests.get(url, headers=self.headers)
 
             if response.status_code != 200:
-                raise LookupError("record not found. Status: {}".format(response.status_code))
+                raise LookupError(f"record not found. Status: {response.status_code}")
 
             return response
 

--- a/renku/core/dataset/providers/factory.py
+++ b/renku/core/dataset/providers/factory.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/factory.py
+++ b/renku/core/dataset/providers/factory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/git.py
+++ b/renku/core/dataset/providers/git.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/git.py
+++ b/renku/core/dataset/providers/git.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -113,7 +112,7 @@ class GitProvider(ProviderApi, AddProviderInterface):
                 normalized_source = os.path.normpath(source)
                 absolute_source = os.path.join(remote_repository.path, normalized_source)  # type: ignore
                 # NOTE: Path.glob("root/**") does not return correct results (e.g. it include ``root`` in the result)
-                subpaths = set(Path(p) for p in glob.glob(absolute_source))
+                subpaths = {Path(p) for p in glob.glob(absolute_source)}
                 if len(subpaths) == 0:
                     raise errors.ParameterError("No such file or directory", param_hint=str(source))
                 paths |= subpaths

--- a/renku/core/dataset/providers/local.py
+++ b/renku/core/dataset/providers/local.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/local.py
+++ b/renku/core/dataset/providers/local.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/models.py
+++ b/renku/core/dataset/providers/models.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/olos.py
+++ b/renku/core/dataset/providers/olos.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/olos.py
+++ b/renku/core/dataset/providers/olos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/renku.py
+++ b/renku/core/dataset/providers/renku.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/renku.py
+++ b/renku/core/dataset/providers/renku.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/repository.py
+++ b/renku/core/dataset/providers/repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -62,6 +61,6 @@ def make_request(url, accept: str = "application/json"):
 
     response = requests.get(url, headers={"Accept": accept})
     if response.status_code != 200:
-        raise LookupError("record not found. Status: {}".format(response.status_code))
+        raise LookupError(f"record not found. Status: {response.status_code}")
 
     return response

--- a/renku/core/dataset/providers/repository.py
+++ b/renku/core/dataset/providers/repository.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/s3.py
+++ b/renku/core/dataset/providers/s3.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/s3.py
+++ b/renku/core/dataset/providers/s3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/web.py
+++ b/renku/core/dataset/providers/web.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/providers/web.py
+++ b/renku/core/dataset/providers/web.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/providers/zenodo.py
+++ b/renku/core/dataset/providers/zenodo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -521,7 +520,7 @@ class ZenodoDeposition:
             if response.status_code == 400:
                 err_response = response.json()
                 messages = [
-                    '"{0}" failed with "{1}"'.format(err["field"], err["message"]) for err in err_response["errors"]
+                    '"{}" failed with "{}"'.format(err["field"], err["message"]) for err in err_response["errors"]
                 ]
 
                 raise errors.ExportError(

--- a/renku/core/dataset/providers/zenodo.py
+++ b/renku/core/dataset/providers/zenodo.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/request_model.py
+++ b/renku/core/dataset/request_model.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/request_model.py
+++ b/renku/core/dataset/request_model.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/dataset/tag.py
+++ b/renku/core/dataset/tag.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/dataset/tag.py
+++ b/renku/core/dataset/tag.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/errors.py
+++ b/renku/core/errors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -68,7 +67,7 @@ class ParameterError(RenkuException):
         """Build a custom message."""
         if param_hint:
             if isinstance(param_hint, (tuple, list)):
-                param_hint = " / ".join('"{}"'.format(x) for x in param_hint)
+                param_hint = " / ".join(f'"{x}"' for x in param_hint)
             message = f"Invalid parameter value for {param_hint}: {message}"
         else:
             if show_prefix:
@@ -119,7 +118,7 @@ class DirtyRepository(RenkuException):
 
     def __init__(self, repository):
         """Build a custom message."""
-        super(DirtyRepository, self).__init__(
+        super().__init__(
             "The repository is dirty. "
             'Please use the "git" command to clean it.'
             "\n\n" + str(repository.status()) + "\n\n"
@@ -133,7 +132,7 @@ class DirtyRenkuDirectory(RenkuException):
 
     def __init__(self, repository):
         """Build a custom message."""
-        super(DirtyRenkuDirectory, self).__init__(
+        super().__init__(
             (
                 "The renku directory {0} contains uncommitted changes.\n"
                 'Please use "git" command to resolve.\n'
@@ -151,7 +150,7 @@ class ProtectedFiles(RenkuException):
 
     def __init__(self, ignored: List[Union[Path, str]]):
         """Build a custom message."""
-        super(ProtectedFiles, self).__init__(
+        super().__init__(
             "The following paths are protected as part of renku:"
             "\n\n" + "\n".join("\t" + click.style(str(path), fg="yellow") for path in ignored) + "\n"
             "They cannot be used in renku commands."
@@ -187,7 +186,7 @@ class NothingToCommit(RenkuException):
 
     def __init__(self):
         """Build a custom message."""
-        super(NothingToCommit, self).__init__("There is nothing to commit.")
+        super().__init__("There is nothing to commit.")
 
 
 class CommitMessageEmpty(RenkuException):
@@ -195,7 +194,7 @@ class CommitMessageEmpty(RenkuException):
 
     def __init__(self):
         """Build a custom message."""
-        super(CommitMessageEmpty, self).__init__("Invalid commit message.")
+        super().__init__("Invalid commit message.")
 
 
 class FailedMerge(RenkuException):
@@ -203,8 +202,8 @@ class FailedMerge(RenkuException):
 
     def __init__(self, repository, branch, merge_args):
         """Build a custom message."""
-        super(FailedMerge, self).__init__(
-            "Failed merge of branch {0} with args {1}".format(branch, ",".join(merge_args))
+        super().__init__(
+            "Failed merge of branch {} with args {}".format(branch, ",".join(merge_args))
             + "The automatic merge failed.\n\n"
             'Please use the "git" command to clean it.'
             "\n\n" + str(repository.status())
@@ -216,7 +215,7 @@ class UnmodifiedOutputs(RenkuException):
 
     def __init__(self, repository, unmodified):
         """Build a custom message."""
-        super(UnmodifiedOutputs, self).__init__(
+        super().__init__(
             "There are no detected new outputs or changes.\n"
             "\nIf any of the following files should be considered as outputs,"
             "\nthey need to be removed first in order to be detected "
@@ -247,7 +246,7 @@ class OutputsNotFound(RenkuException):
             "manually."
         )
 
-        super(OutputsNotFound, self).__init__(msg)
+        super().__init__(msg)
 
 
 class InvalidInputPath(RenkuException):
@@ -262,12 +261,12 @@ class InvalidSuccessCode(RenkuException):
         if message:
             msg = message
         elif not success_codes:
-            msg = "Command returned non-zero exit status {0}.".format(return_code)
+            msg = f"Command returned non-zero exit status {return_code}."
         else:
-            msg = "Command returned {0} exit status, but it expects {1}".format(
-                return_code, ", ".join((str(code) for code in success_codes))
+            msg = "Command returned {} exit status, but it expects {}".format(
+                return_code, ", ".join(str(code) for code in success_codes)
             )
-        super(InvalidSuccessCode, self).__init__(msg)
+        super().__init__(msg)
 
 
 class DatasetNotFound(DatasetException):
@@ -346,7 +345,7 @@ class ExternalStorageNotInstalled(RenkuException):
             'otherwise install LFS with "git lfs install --local".'
         )
 
-        super(ExternalStorageNotInstalled, self).__init__(msg)
+        super().__init__(msg)
 
 
 class ExternalStorageDisabled(RenkuException):
@@ -365,7 +364,7 @@ class ExternalStorageDisabled(RenkuException):
             'otherwise install e.g. git-LFS with "git lfs install --local".'
         )
 
-        super(ExternalStorageDisabled, self).__init__(msg)
+        super().__init__(msg)
 
 
 class UninitializedProject(RenkuException):
@@ -376,7 +375,7 @@ class UninitializedProject(RenkuException):
         msg = "{repo_path} does not seem to be a Renku project.\n" 'Initialize it with "renku init"'.format(
             repo_path=repo_path
         )
-        super(UninitializedProject, self).__init__(msg)
+        super().__init__(msg)
 
 
 class InvalidAccessToken(RenkuException):
@@ -385,7 +384,7 @@ class InvalidAccessToken(RenkuException):
     def __init__(self):
         """Build a custom message."""
         msg = "Invalid access token.\n" "Please, update access token."
-        super(InvalidAccessToken, self).__init__(msg)
+        super().__init__(msg)
 
 
 class GitError(RenkuException):
@@ -527,7 +526,7 @@ class NodeNotFoundError(RenkuException):
             "NodeJs could not be found on this system\n"
             "Please install it, for details see https://nodejs.org/en/download/package-manager/"
         )
-        super(NodeNotFoundError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class SSHNotFoundError(RenkuException):
@@ -536,7 +535,7 @@ class SSHNotFoundError(RenkuException):
     def __init__(self):
         """Build a custom message."""
         msg = "SSH client (ssh) could not be found on this system"
-        super(SSHNotFoundError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class SSHNotSetupError(RenkuException):
@@ -545,7 +544,7 @@ class SSHNotSetupError(RenkuException):
     def __init__(self):
         """Build a custom message."""
         msg = "SSH is not set up correctly, use 'renku session ssh-setup' to set it up."
-        super(SSHNotSetupError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class ObjectNotFoundError(RenkuException):

--- a/renku/core/gc.py
+++ b/renku/core/gc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/git.py
+++ b/renku/core/git.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/git.py
+++ b/renku/core/git.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/githooks.py
+++ b/renku/core/githooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/githooks.py
+++ b/renku/core/githooks.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/init.py
+++ b/renku/core/init.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -87,7 +86,7 @@ def create_backup_branch(path):
                     commit=repository.head.commit,
                     merge_args=["--no-ff", "-s", "recursive", "-X", "ours", "--allow-unrelated-histories"],
                 ):
-                    communication.warn("Saving current data in branch {0}".format(branch_name))
+                    communication.warn(f"Saving current data in branch {branch_name}")
         except AttributeError:
             communication.echo("Warning! Overwriting non-empty folder.")
         except errors.GitCommandError:

--- a/renku/core/interface/__init__.py
+++ b/renku/core/interface/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/interface/__init__.py
+++ b/renku/core/interface/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/interface/activity_gateway.py
+++ b/renku/core/interface/activity_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/interface/activity_gateway.py
+++ b/renku/core/interface/activity_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/interface/database_gateway.py
+++ b/renku/core/interface/database_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/interface/database_gateway.py
+++ b/renku/core/interface/database_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/interface/dataset_gateway.py
+++ b/renku/core/interface/dataset_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/interface/dataset_gateway.py
+++ b/renku/core/interface/dataset_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/interface/plan_gateway.py
+++ b/renku/core/interface/plan_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/interface/plan_gateway.py
+++ b/renku/core/interface/plan_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/interface/project_gateway.py
+++ b/renku/core/interface/project_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/interface/project_gateway.py
+++ b/renku/core/interface/project_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/interface/storage.py
+++ b/renku/core/interface/storage.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/interface/storage.py
+++ b/renku/core/interface/storage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/interface/workflow_file_parser.py
+++ b/renku/core/interface/workflow_file_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/interface/workflow_file_parser.py
+++ b/renku/core/interface/workflow_file_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -40,7 +39,7 @@ class IWorkflowFileParser(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def parse(self, path: Union[Path, str]) -> "WorkflowFile":
+    def parse(self, path: Union[Path, str]) -> WorkflowFile:
         """Parse a given workflow file using the provider.
 
         Args:

--- a/renku/core/login.py
+++ b/renku/core/login.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/login.py
+++ b/renku/core/login.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/__init__.py
+++ b/renku/core/migration/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/__init__.py
+++ b/renku/core/migration/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/m_0003__0_pyld2.py
+++ b/renku/core/migration/m_0003__0_pyld2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/m_0003__1_jsonld.py
+++ b/renku/core/migration/m_0003__1_jsonld.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -192,7 +191,7 @@ def _migrate_absolute_paths(data):
     for file_ in files:
         path = Path(file_.get("path"), ".")
         if path.is_absolute():
-            file_["path"] = str(path.relative_to((os.getcwd())))
+            file_["path"] = str(path.relative_to(os.getcwd()))
     data["files"] = files
     return data
 

--- a/renku/core/migration/m_0003__2_initial.py
+++ b/renku/core/migration/m_0003__2_initial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -107,7 +106,7 @@ def _migrate_datasets_pre_v0_3():
         dataset.to_yaml(new_path)
 
         Path(old_path).unlink()
-        ref = LinkReference.create(name="datasets/{0}".format(name), force=True)
+        ref = LinkReference.create(name=f"datasets/{name}", force=True)
         ref.set_reference(new_path)
 
     if changed:
@@ -132,7 +131,7 @@ def _migrate_broken_dataset_paths(migration_context):
 
         # migrate the refs
         if not is_using_temporary_datasets_path():
-            ref = LinkReference.create(name="datasets/{0}".format(dataset.name), force=True)
+            ref = LinkReference.create(name=f"datasets/{dataset.name}", force=True)
             ref.set_reference(expected_path / OLD_METADATA_PATH)
 
         if not expected_path.exists():

--- a/renku/core/migration/m_0004__0_pyld2.py
+++ b/renku/core/migration/m_0004__0_pyld2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/m_0004__submodules.py
+++ b/renku/core/migration/m_0004__submodules.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/m_0005__1_pyld2.py
+++ b/renku/core/migration/m_0005__1_pyld2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/m_0005__2_cwl.py
+++ b/renku/core/migration/m_0005__2_cwl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -312,7 +311,7 @@ def _migrate_single_step(migration_context, cmd_line_tool, path, commit=None, pa
     if not persist:
         return run, None
 
-    step_name = "{0}_{1}.yaml".format(uuid.uuid4().hex, secure_filename("_".join(cmd_line_tool.baseCommand)))
+    step_name = "{}_{}.yaml".format(uuid.uuid4().hex, secure_filename("_".join(cmd_line_tool.baseCommand)))
 
     absolute_path = project_context.metadata_path / OLD_WORKFLOW_PATH / step_name
     path = absolute_path.relative_to(project_context.path)
@@ -340,7 +339,7 @@ def _migrate_composite_step(migration_context, workflow, path, commit=None):
     identifier = sha1(label.encode("utf-8")).hexdigest()
     run._id = Run.generate_id(identifier=identifier)
 
-    name = "{0}_migrated.yaml".format(uuid.uuid4().hex)
+    name = f"{uuid.uuid4().hex}_migrated.yaml"
 
     wf_path = project_context.metadata_path / OLD_WORKFLOW_PATH
     run.path = (wf_path / name).relative_to(project_context.path)

--- a/renku/core/migration/m_0006__dataset_context.py
+++ b/renku/core/migration/m_0006__dataset_context.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/m_0007__source_url.py
+++ b/renku/core/migration/m_0007__source_url.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/m_0008__dataset_metadata.py
+++ b/renku/core/migration/m_0008__dataset_metadata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/m_0009__new_metadata_storage.py
+++ b/renku/core/migration/m_0009__new_metadata_storage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/m_0010__metadata_fixes.py
+++ b/renku/core/migration/m_0010__metadata_fixes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -99,7 +98,7 @@ def migrate_old_metadata_namespaces():
                     with io.TextIOWrapper(compression_writer) as out:
                         json.dump(data, out, ensure_ascii=False)
             else:
-                with open(path, "wt") as ft:
+                with open(path, "w") as ft:
                     json.dump(data, ft, ensure_ascii=False, sort_keys=True, indent=2)
 
 

--- a/renku/core/migration/migrate.py
+++ b/renku/core/migration/migrate.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/migrate.py
+++ b/renku/core/migration/migrate.py
@@ -215,7 +215,7 @@ def _update_dockerfile(check_only=False):
     """Update the dockerfile to the newest version of renku."""
     from renku import __version__
 
-    if not project_context.docker_path.exists():
+    if not project_context.dockerfile_path.exists():
         return False, None, None
 
     communication.echo("Updating dockerfile...")

--- a/renku/core/migration/migrate.py
+++ b/renku/core/migration/migrate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -216,12 +215,12 @@ def _update_dockerfile(check_only=False):
     """Update the dockerfile to the newest version of renku."""
     from renku import __version__
 
-    if not project_context.dockerfile_path.exists():
+    if not project_context.docker_path.exists():
         return False, None, None
 
     communication.echo("Updating dockerfile...")
 
-    with open(project_context.dockerfile_path, "r") as f:
+    with open(project_context.dockerfile_path) as f:
         dockerfile_content = f.read()
 
     docker_version = read_renku_version_from_dockerfile()
@@ -273,7 +272,7 @@ def get_migrations():
             continue
 
         version = int(match.groups()[0])
-        path = "renku.core.migration.{}".format(Path(entry.name).stem)
+        path = f"renku.core.migration.{Path(entry.name).stem}"
         migrations.append((version, path))
 
     migrations = sorted(migrations, key=lambda v: v[1].lower())

--- a/renku/core/migration/models/__init__.py
+++ b/renku/core/migration/models/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/models/__init__.py
+++ b/renku/core/migration/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/models/migration.py
+++ b/renku/core/migration/models/migration.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/models/migration.py
+++ b/renku/core/migration/models/migration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/models/refs.py
+++ b/renku/core/migration/models/refs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -57,7 +56,7 @@ class LinkReference:
     def name_validator(self, attribute, value):
         """Validate reference name."""
         if not self.check_ref_format(value):
-            raise errors.ParameterError('The reference name "{0}" is not valid.'.format(value))
+            raise errors.ParameterError(f'The reference name "{value}" is not valid.')
 
     @property
     def path(self):

--- a/renku/core/migration/models/refs.py
+++ b/renku/core/migration/models/refs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/models/v10.py
+++ b/renku/core/migration/models/v10.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/models/v10.py
+++ b/renku/core/migration/models/v10.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/models/v3.py
+++ b/renku/core/migration/models/v3.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/models/v3.py
+++ b/renku/core/migration/models/v3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/models/v7.py
+++ b/renku/core/migration/models/v7.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/models/v7.py
+++ b/renku/core/migration/models/v7.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/models/v8.py
+++ b/renku/core/migration/models/v8.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/models/v8.py
+++ b/renku/core/migration/models/v8.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/migration/models/v9.py
+++ b/renku/core/migration/models/v9.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/models/v9.py
+++ b/renku/core/migration/models/v9.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -398,7 +397,7 @@ class Collection(Entity):
 
 
 @attr.s(eq=False, order=False)
-class MappedIOStream(object):
+class MappedIOStream:
     """Represents an IO stream (``stdin``, ``stdout``, ``stderr``)."""
 
     _id = attr.ib(default=None, kw_only=True)
@@ -415,11 +414,11 @@ class MappedIOStream(object):
             host = project_context.remote.host or host
         host = os.environ.get("RENKU_DOMAIN") or host
 
-        return urljoin("https://{host}".format(host=host), posixpath.join("/iostreams", self.stream_type))
+        return urljoin(f"https://{host}", posixpath.join("/iostreams", self.stream_type))
 
     def default_label(self):
         """Set default label."""
-        return 'Stream mapping for stream "{}"'.format(self.stream_type)
+        return f'Stream mapping for stream "{self.stream_type}"'
 
     def __attrs_post_init__(self):
         """Post-init hook."""
@@ -488,11 +487,11 @@ class CommandArgument(CommandParameter):
             id_ = str(position)
         else:
             id_ = uuid.uuid4().hex
-        return "{}/arguments/{}".format(run_id, id_)
+        return f"{run_id}/arguments/{id_}"
 
     def default_label(self):
         """Set default label."""
-        return 'Command Argument "{}"'.format(self.default_value)
+        return f'Command Argument "{self.default_value}"'
 
     def default_name(self):
         """Create a default name."""
@@ -521,11 +520,11 @@ class CommandInput(CommandParameter):
             id_ = str(position)
         else:
             id_ = uuid.uuid4().hex
-        return "{}/inputs/{}".format(run_id, id_)
+        return f"{run_id}/inputs/{id_}"
 
     def default_label(self):
         """Set default label."""
-        return 'Command Input "{}"'.format(self.default_value)
+        return f'Command Input "{self.default_value}"'
 
     def default_name(self):
         """Create a default name."""
@@ -556,11 +555,11 @@ class CommandOutput(CommandParameter):
             id_ = str(position)
         else:
             id_ = uuid.uuid4().hex
-        return "{}/outputs/{}".format(run_id, id_)
+        return f"{run_id}/outputs/{id_}"
 
     def default_label(self):
         """Set default label."""
-        return 'Command Output "{}"'.format(self.default_value)
+        return f'Command Output "{self.default_value}"'
 
     def default_name(self):
         """Create a default name."""
@@ -626,7 +625,7 @@ class Run(CommitMixin):
         if not identifier:
             identifier = str(uuid.uuid4())
 
-        return urljoin("https://{host}".format(host=host), posixpath.join("/runs", quote(identifier, safe="")))
+        return urljoin(f"https://{host}", posixpath.join("/runs", quote(identifier, safe="")))
 
     def __lt__(self, other):
         """Compares two subprocesses order based on their dependencies."""
@@ -859,7 +858,7 @@ class Activity(CommitMixin):
     @agents.default
     def default_agents(self):
         """Set person agent to be the author of the commit."""
-        renku_agent = SoftwareAgent(label="renku {0}".format(__version__), id=version_url)
+        renku_agent = SoftwareAgent(label=f"renku {__version__}", id=version_url)
         if self.commit:
             return [Person.from_commit(self.commit), renku_agent]
         return [renku_agent]
@@ -932,7 +931,7 @@ class ProcessRun(Activity):
         host = os.environ.get("RENKU_DOMAIN") or host
 
         return urljoin(
-            "https://{host}".format(host=host),
+            f"https://{host}",
             posixpath.join("/activities", f"commit/{commit_hexsha}"),
         )
 
@@ -1163,7 +1162,7 @@ class Person:
         initials = [name[0] for name in names]
         initials.pop()
 
-        return "{0}.{1}".format(".".join(initials), last_name)
+        return "{}.{}".format(".".join(initials), last_name)
 
     @property
     def full_identity(self):
@@ -1267,7 +1266,7 @@ def _extract_doi(value):
 
 
 @attr.s(slots=True)
-class DatasetTag(object):
+class DatasetTag:
     """Represents a Tag of an instance of a dataset."""
 
     name = attr.ib(default=None, kw_only=True, validator=instance_of(str))
@@ -1409,7 +1408,7 @@ class DatasetFile(Entity):
         parsed_id = urlparse(self._id)
 
         if not parsed_id.scheme:
-            self._id = "file://{}".format(self._id)
+            self._id = f"file://{self._id}"
 
         if not self.url:
             self.url = self.default_url()

--- a/renku/core/migration/utils/__init__.py
+++ b/renku/core/migration/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/utils/__init__.py
+++ b/renku/core/migration/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -47,7 +46,7 @@ def generate_url_id(url_str, url_id):
         host = project_context.remote.host or host
     host = os.environ.get("RENKU_DOMAIN") or host
 
-    return urljoin("https://{host}".format(host=host), posixpath.join("/urls", quote(id_, safe="")))
+    return urljoin(f"https://{host}", posixpath.join("/urls", quote(id_, safe="")))
 
 
 def generate_dataset_tag_id(name, commit):
@@ -57,9 +56,9 @@ def generate_dataset_tag_id(name, commit):
         host = project_context.remote.host or host
     host = os.environ.get("RENKU_DOMAIN") or host
 
-    name = "{0}@{1}".format(name, commit)
+    name = f"{name}@{commit}"
 
-    return urljoin("https://{host}".format(host=host), posixpath.join("/dataset-tags", quote(name, safe="")))
+    return urljoin(f"https://{host}", posixpath.join("/dataset-tags", quote(name, safe="")))
 
 
 def generate_dataset_id(identifier):

--- a/renku/core/migration/utils/conversion.py
+++ b/renku/core/migration/utils/conversion.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/migration/utils/conversion.py
+++ b/renku/core/migration/utils/conversion.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/plugin/__init__.py
+++ b/renku/core/plugin/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/plugin/__init__.py
+++ b/renku/core/plugin/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/plugin/dataset_provider.py
+++ b/renku/core/plugin/dataset_provider.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/plugin/dataset_provider.py
+++ b/renku/core/plugin/dataset_provider.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/plugin/implementations/__init__.py
+++ b/renku/core/plugin/implementations/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/plugin/implementations/__init__.py
+++ b/renku/core/plugin/implementations/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/plugin/pluginmanager.py
+++ b/renku/core/plugin/pluginmanager.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/plugin/pluginmanager.py
+++ b/renku/core/plugin/pluginmanager.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/plugin/provider.py
+++ b/renku/core/plugin/provider.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/plugin/provider.py
+++ b/renku/core/plugin/provider.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/plugin/run.py
+++ b/renku/core/plugin/run.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/plugin/run.py
+++ b/renku/core/plugin/run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/plugin/session.py
+++ b/renku/core/plugin/session.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/plugin/session.py
+++ b/renku/core/plugin/session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/plugin/workflow.py
+++ b/renku/core/plugin/workflow.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/plugin/workflow.py
+++ b/renku/core/plugin/workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/plugin/workflow.py
+++ b/renku/core/plugin/workflow.py
@@ -18,19 +18,13 @@
 """Plugin hooks for renku workflow customization."""
 
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Protocol, Tuple
 
 import pluggy
 
 from renku.core import errors
 from renku.domain_model.workflow.converters import IWorkflowConverter
 from renku.domain_model.workflow.plan import Plan
-
-try:
-    from typing_extensions import Protocol  # NOTE: Required for Python 3.7 compatibility
-except ImportError:
-    from typing import Protocol  # type: ignore
-
 
 hookspec = pluggy.HookspecMarker("renku")
 

--- a/renku/core/plugin/workflow_file_parser.py
+++ b/renku/core/plugin/workflow_file_parser.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/plugin/workflow_file_parser.py
+++ b/renku/core/plugin/workflow_file_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/project.py
+++ b/renku/core/project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/project.py
+++ b/renku/core/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/session/__init__.py
+++ b/renku/core/session/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/session/__init__.py
+++ b/renku/core/session/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/session/docker.py
+++ b/renku/core/session/docker.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/session/docker.py
+++ b/renku/core/session/docker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/session/renkulab.py
+++ b/renku/core/session/renkulab.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/session/renkulab.py
+++ b/renku/core/session/renkulab.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/session/session.py
+++ b/renku/core/session/session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -42,9 +41,10 @@ def _safe_get_provider(provider: str) -> ISessionProvider:
         raise errors.ParameterError(f"Session provider '{provider}' is not available!")
 
 
-SessionList = NamedTuple(
-    "SessionList", [("sessions", List[Session]), ("all_local", bool), ("warning_messages", List[str])]
-)
+class SessionList(NamedTuple):
+    sessions: List[Session]
+    all_local: bool
+    warning_messages: List[str]
 
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))

--- a/renku/core/session/session.py
+++ b/renku/core/session/session.py
@@ -42,6 +42,8 @@ def _safe_get_provider(provider: str) -> ISessionProvider:
 
 
 class SessionList(NamedTuple):
+    """Session list return."""
+
     sessions: List[Session]
     all_local: bool
     warning_messages: List[str]

--- a/renku/core/session/session.py
+++ b/renku/core/session/session.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/session/utils.py
+++ b/renku/core/session/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/session/utils.py
+++ b/renku/core/session/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/storage.py
+++ b/renku/core/storage.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/storage.py
+++ b/renku/core/storage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -101,7 +100,7 @@ def check_external_storage_wrapper(fn):
     return wrapper
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def storage_installed():
     """Verify that git-lfs is installed and on system PATH."""
     return bool(which("git-lfs"))
@@ -159,7 +158,7 @@ def init_external_storage(force=False):
             stdout=PIPE,
             stderr=STDOUT,
             cwd=project_context.path,
-            universal_newlines=True,
+            text=True,
         )
 
         if result.returncode != 0:
@@ -351,7 +350,7 @@ def clean_storage_cache(*check_paths):
         current_repository = repositories[project_path]
 
         for path in paths:
-            with open(path, "r") as tracked_file:
+            with open(path) as tracked_file:
                 try:
                     header = tracked_file.read(len(_LFS_HEADER))
                     if header == _LFS_HEADER:
@@ -363,9 +362,7 @@ def clean_storage_cache(*check_paths):
             with tempfile.NamedTemporaryFile(mode="w+t", encoding="utf-8", delete=False) as tmp, open(
                 path, "r+t"
             ) as input_file:
-                result = run(
-                    _CMD_STORAGE_CLEAN, cwd=project_path, stdin=input_file, stdout=tmp, universal_newlines=True
-                )
+                result = run(_CMD_STORAGE_CLEAN, cwd=project_path, stdin=input_file, stdout=tmp, text=True)
 
                 if result.returncode != 0:
                     raise errors.GitLFSError(f"Error executing 'git lfs clean: \n {result.stdout}")
@@ -501,7 +498,7 @@ def check_lfs_migrate_info(everything=False, use_size_filter=True):
             stdout=PIPE,
             stderr=STDOUT,
             cwd=project_context.path,
-            universal_newlines=True,
+            text=True,
         )
     except (KeyboardInterrupt, OSError) as e:
         raise errors.GitError(f"Couldn't run 'git lfs migrate info':\n{e}")
@@ -509,7 +506,7 @@ def check_lfs_migrate_info(everything=False, use_size_filter=True):
     if lfs_output.returncode != 0:
         # NOTE: try running without --pointers (old versions of git lfs)
         try:
-            lfs_output = run(command, stdout=PIPE, stderr=STDOUT, cwd=project_context.path, universal_newlines=True)
+            lfs_output = run(command, stdout=PIPE, stderr=STDOUT, cwd=project_context.path, text=True)
         except (KeyboardInterrupt, OSError) as e:
             raise errors.GitError(f"Couldn't run 'git lfs migrate info':\n{e}")
 
@@ -547,14 +544,14 @@ def migrate_files_to_lfs(paths):
     command = _CMD_STORAGE_MIGRATE_IMPORT + includes + excludes + object_map
 
     try:
-        lfs_output = run(command, stdout=PIPE, stderr=STDOUT, cwd=project_context.path, universal_newlines=True)
+        lfs_output = run(command, stdout=PIPE, stderr=STDOUT, cwd=project_context.path, text=True)
     except (KeyboardInterrupt, OSError) as e:
         raise errors.GitError(f"Couldn't run 'git lfs migrate import':\n{e}")
 
     if lfs_output.returncode != 0:
         raise errors.GitLFSError(f"Error executing 'git lfs migrate import: \n {lfs_output.stdout}")
 
-    with open(map_path, "r", newline="") as csvfile:
+    with open(map_path, newline="") as csvfile:
         reader = csv.reader(csvfile, delimiter=",")
 
         commit_sha_mapping = [(r[0], r[1]) for r in reader]

--- a/renku/core/template/__init__.py
+++ b/renku/core/template/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/template/__init__.py
+++ b/renku/core/template/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/template/template.py
+++ b/renku/core/template/template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -105,7 +104,7 @@ def write_template_checksum(checksums: Dict):
 def read_template_checksum() -> Dict[str, str]:
     """Read templates checksum file for a project."""
     if has_template_checksum():
-        with open(project_context.template_checksums_path, "r") as checksum_file:
+        with open(project_context.template_checksums_path) as checksum_file:
             return json.load(checksum_file)
 
     return {}

--- a/renku/core/template/usecase.py
+++ b/renku/core/template/usecase.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -286,12 +285,14 @@ def select_template(templates_source: TemplatesSource, id: Optional[str] = None)
         if not communication.has_prompt():
             raise errors.InvalidTemplateError("Cannot select a template")
 
-        Selection = NamedTuple("Selection", [("index", int), ("id", str)])
+        class Selection(NamedTuple):
+            number: int
+            id: str
 
-        templates = [Selection(index=i, id=t.id) for i, t in enumerate(templates_source.templates, start=1)]
-        tables = tabulate(templates, headers=["index", "id"])
+        templates = [Selection(number=i, id=t.id) for i, t in enumerate(templates_source.templates, start=1)]
+        tables = tabulate(templates, headers=["number", "id"])
 
-        message = f"{tables}\nPlease choose a template by typing its index"
+        message = f"{tables}\nPlease choose a template by typing its number"
 
         template_index = communication.prompt(
             msg=message, type=click.IntRange(1, len(templates_source.templates)), show_default=False, show_choices=False

--- a/renku/core/util/__init__.py
+++ b/renku/core/util/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/communication.py
+++ b/renku/core/util/communication.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/communication.py
+++ b/renku/core/util/communication.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/contexts.py
+++ b/renku/core/util/contexts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/contexts.py
+++ b/renku/core/util/contexts.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/dataset.py
+++ b/renku/core/util/dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/datetime8601.py
+++ b/renku/core/util/datetime8601.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/doi.py
+++ b/renku/core/util/doi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/file_size.py
+++ b/renku/core/util/file_size.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/git.py
+++ b/renku/core/util/git.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -887,7 +886,7 @@ def get_file_size(repository_path: Path, path: str) -> Optional[int]:
             ("git", "lfs", "ls-files", "--name-only", "--size"),
             stdout=PIPE,
             cwd=repository_path,
-            universal_newlines=True,
+            text=True,
         )
     except SubprocessError:
         pass

--- a/renku/core/util/git.py
+++ b/renku/core/util/git.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/jwt.py
+++ b/renku/core/util/jwt.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/jwt.py
+++ b/renku/core/util/jwt.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/metadata.py
+++ b/renku/core/util/metadata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/os.py
+++ b/renku/core/util/os.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/os.py
+++ b/renku/core/util/os.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -168,7 +167,7 @@ def unmount_path(path: Union[Path, str]) -> None:
 
     def execute_command(*command: str) -> bool:
         try:
-            subprocess.run(command, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(command, check=True, text=True, capture_output=True)
         except (subprocess.CalledProcessError, FileNotFoundError):
             return False
         else:

--- a/renku/core/util/requests.py
+++ b/renku/core/util/requests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/shacl.py
+++ b/renku/core/util/shacl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -34,7 +33,7 @@ def validate_graph(graph, shacl_path=None, format="nquads"):
     """
     shacl: Union[str, bytes]
     if shacl_path:
-        with open(shacl_path, "r", encoding="utf-8") as f:
+        with open(shacl_path, encoding="utf-8") as f:
             shacl = f.read()
     else:
         shacl = importlib_resources.files("renku.data").joinpath("shacl_shape.json").read_bytes()

--- a/renku/core/util/shacl.py
+++ b/renku/core/util/shacl.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/ssh.py
+++ b/renku/core/util/ssh.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/ssh.py
+++ b/renku/core/util/ssh.py
@@ -31,6 +31,8 @@ from renku.domain_model.project_context import project_context
 
 
 class SSHKeyPair(NamedTuple):
+    """A public/private key pair for SSH."""
+
     private_key: str
     public_key: str
 

--- a/renku/core/util/ssh.py
+++ b/renku/core/util/ssh.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -30,7 +29,10 @@ from renku.core.session.utils import get_renku_url
 from renku.core.util import communication
 from renku.domain_model.project_context import project_context
 
-SSHKeyPair = NamedTuple("SSHKeyPair", [("private_key", str), ("public_key", str)])
+
+class SSHKeyPair(NamedTuple):
+    private_key: str
+    public_key: str
 
 
 def generate_ssh_keys() -> SSHKeyPair:

--- a/renku/core/util/tabulate.py
+++ b/renku/core/util/tabulate.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/tabulate.py
+++ b/renku/core/util/tabulate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/template_vars.py
+++ b/renku/core/util/template_vars.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -31,7 +30,7 @@ class TemplateVariableFormatter(Formatter):
     RESERVED_KEYS = ["iter_index"]
 
     def __init__(self):
-        super(TemplateVariableFormatter, self).__init__()
+        super().__init__()
 
     def apply(self, param: str, parameters: Mapping[str, Any] = {}) -> str:
         """Renders the parameter template into its final value."""

--- a/renku/core/util/template_vars.py
+++ b/renku/core/util/template_vars.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/urls.py
+++ b/renku/core/util/urls.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/util.py
+++ b/renku/core/util/util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/uuid.py
+++ b/renku/core/util/uuid.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/util/uuid.py
+++ b/renku/core/util/uuid.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/yaml.py
+++ b/renku/core/util/yaml.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/util/yaml.py
+++ b/renku/core/util/yaml.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/__init__.py
+++ b/renku/core/workflow/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/__init__.py
+++ b/renku/core/workflow/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/activity.py
+++ b/renku/core/workflow/activity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/activity.py
+++ b/renku/core/workflow/activity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/converters/__init__.py
+++ b/renku/core/workflow/converters/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/converters/__init__.py
+++ b/renku/core/workflow/converters/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/converters/cwl.py
+++ b/renku/core/workflow/converters/cwl.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/converters/cwl.py
+++ b/renku/core/workflow/converters/cwl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -42,7 +41,7 @@ class CommandLineTool(cwl.CommandLineTool):
 
     def get_dict(self):
         """Set outputs to empty if not set."""
-        d = super(CommandLineTool, self).get_dict()  # type: ignore[misc]
+        d = super().get_dict()  # type: ignore[misc]
         if "outputs" not in d:
             d["outputs"] = []
         return d
@@ -53,7 +52,7 @@ class WorkflowStep(cwl.WorkflowStep):
 
     def get_dict(self):
         """Set out to empty if not set."""
-        d = super(WorkflowStep, self).get_dict()  # type: ignore[misc]
+        d = super().get_dict()  # type: ignore[misc]
         if "out" not in d:
             d["out"] = []
         return d
@@ -188,7 +187,7 @@ class CWLExporter(IWorkflowConverter):
 
         for i, wf in enumerate(nx.topological_sort(graph.workflow_graph)):
             step_clitool = CWLExporter._convert_step(workflow=wf, basedir=basedir, resolve_paths=resolve_paths)
-            step = WorkflowStep(in_=[], out=[], run=step_clitool, id="step_{}".format(i))
+            step = WorkflowStep(in_=[], out=[], run=step_clitool, id=f"step_{i}")
 
             for input in wf.inputs:
                 input_path = input.actual_value
@@ -201,18 +200,16 @@ class CWLExporter(IWorkflowConverter):
                     # output of a previous step, refer to it
                     consumed_outputs.add(outputs[input_path][0])
                     step.in_.append(
-                        cwl.WorkflowStepInput(
-                            sanitized_id, source="{}/{}".format(outputs[input_path][1], outputs[input_path][0])
-                        )
+                        cwl.WorkflowStepInput(sanitized_id, source=f"{outputs[input_path][1]}/{outputs[input_path][0]}")
                     )
                 else:
                     # input isn't output and doesn't exist yet, add new
-                    inputs[input_path] = "input_{}".format(input_index)
+                    inputs[input_path] = f"input_{input_index}"
                     step.in_.append(cwl.WorkflowStepInput(sanitized_id, source=inputs[input_path]))
                     input_index += 1
 
             for parameter in wf.parameters:
-                argument_id = "argument_{}".format(argument_index)
+                argument_id = f"argument_{argument_index}"
                 arguments[argument_id] = parameter.actual_value
                 step.in_.append(cwl.WorkflowStepInput(CWLExporter._sanitize_id(parameter.id), source=argument_id))
                 argument_index += 1
@@ -221,7 +218,7 @@ class CWLExporter(IWorkflowConverter):
                 sanitized_id = CWLExporter._sanitize_id(output.id)
 
                 if output.mapped_to:
-                    sanitized_id = "output_{}".format(output.mapped_to.stream_type)
+                    sanitized_id = f"output_{output.mapped_to.stream_type}"
                 outputs[output.actual_value] = (sanitized_id, step.id)
                 step.out.append(cwl.WorkflowStepOutput(sanitized_id))
 
@@ -253,9 +250,7 @@ class CWLExporter(IWorkflowConverter):
         for index, (path, (id_, step_id)) in enumerate(outputs.items(), 1):
             type_ = "Directory" if os.path.isdir(path) else "File"
             workflow_object.outputs.append(
-                cwl.WorkflowOutputParameter(
-                    id="output_{}".format(index), outputSource="{}/{}".format(step_id, id_), type=type_
-                )
+                cwl.WorkflowOutputParameter(id=f"output_{index}", outputSource=f"{step_id}/{id_}", type=type_)
             )
 
         return workflow_object
@@ -318,7 +313,7 @@ class CWLExporter(IWorkflowConverter):
             tool_input = CWLExporter._convert_input(input_, basedir, resolve_paths=resolve_paths)
 
             workdir_req.listing.append(
-                cwl.Dirent(entry="$(inputs.{})".format(tool_input.id), entryname=input_.actual_value, writable=False)
+                cwl.Dirent(entry=f"$(inputs.{tool_input.id})", entryname=input_.actual_value, writable=False)
             )
 
             environment_variables.append(
@@ -326,7 +321,7 @@ class CWLExporter(IWorkflowConverter):
             )
             tool_object.inputs.append(tool_input)
             if input_.mapped_to:
-                tool_object.stdin = "$(inputs.{}.path)".format(tool_input.id)
+                tool_object.stdin = f"$(inputs.{tool_input.id}.path)"
                 jsrequirement = True
 
         for parameter in workflow.parameters:
@@ -432,7 +427,7 @@ class CWLExporter(IWorkflowConverter):
         if output.mapped_to:
             return (
                 cwl.CommandOutputParameter(
-                    id="output_{}".format(output.mapped_to.stream_type),
+                    id=f"output_{output.mapped_to.stream_type}",
                     type=output.mapped_to.stream_type,
                     streamable=False,
                 ),
@@ -460,7 +455,7 @@ class CWLExporter(IWorkflowConverter):
                     separate = True
 
             arg = cwl.CommandInputParameter(
-                id="{}_arg".format(sanitized_id),
+                id=f"{sanitized_id}_arg",
                 type="string",
                 inputBinding=cwl.CommandLineBinding(position=output.position, prefix=prefix, separate=separate),
                 default=output.actual_value,
@@ -468,7 +463,7 @@ class CWLExporter(IWorkflowConverter):
             outp = cwl.CommandOutputParameter(
                 id=sanitized_id,
                 type=type_,
-                outputBinding=cwl.CommandOutputBinding(glob="$(inputs.{})".format(arg.id)),
+                outputBinding=cwl.CommandOutputBinding(glob=f"$(inputs.{arg.id})"),
             )
             return outp, arg
 

--- a/renku/core/workflow/converters/renku.py
+++ b/renku/core/workflow/converters/renku.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/converters/renku.py
+++ b/renku/core/workflow/converters/renku.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/execute.py
+++ b/renku/core/workflow/execute.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/execute.py
+++ b/renku/core/workflow/execute.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -243,7 +242,7 @@ def _extract_iterate_parameters(values: Dict[str, Any], index_pattern: re.Patter
                 if tag in iter_params["tagged"]:
                     iter_params["tagged"][tag].update([(f"{param_name}.{ik}", iv) for ik, iv in param.items()])
                 else:
-                    iter_params["tagged"][tag] = dict([(f"{param_name}.{ik}", iv) for ik, iv in param.items()])
+                    iter_params["tagged"][tag] = {f"{param_name}.{ik}": iv for ik, iv in param.items()}
             params[param_name] = inner_params
         else:
             params[param_name] = param_value
@@ -346,8 +345,7 @@ def _build_iterations(
     def _flatten(values):
         for i in values:
             if isinstance(i, (list, tuple)):
-                for k in i:
-                    yield k
+                yield from i
             else:
                 yield i
 

--- a/renku/core/workflow/model/__init__.py
+++ b/renku/core/workflow/model/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/model/__init__.py
+++ b/renku/core/workflow/model/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/model/concrete_execution_graph.py
+++ b/renku/core/workflow/model/concrete_execution_graph.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/model/concrete_execution_graph.py
+++ b/renku/core/workflow/model/concrete_execution_graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/model/workflow_file.py
+++ b/renku/core/workflow/model/workflow_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/model/workflow_file.py
+++ b/renku/core/workflow/model/workflow_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/parser/__init__.py
+++ b/renku/core/workflow/parser/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/parser/__init__.py
+++ b/renku/core/workflow/parser/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/parser/renku.py
+++ b/renku/core/workflow/parser/renku.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/parser/renku.py
+++ b/renku/core/workflow/parser/renku.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/plan.py
+++ b/renku/core/workflow/plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/plan.py
+++ b/renku/core/workflow/plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -795,10 +794,10 @@ def get_plans_with_metadata(activity_gateway: IActivityGateway, plan_gateway: IP
 
     all_activities = activity_gateway.get_all_activities()
     activity_map = _reverse_activity_plan_map(list(all_activities))
-    latest_plan_chains: Set[Tuple[AbstractPlan]] = set(
+    latest_plan_chains: Set[Tuple[AbstractPlan]] = {
         cast(Tuple[AbstractPlan], tuple(get_derivative_chain(p)))
         for p in plan_gateway.get_newest_plans_by_names().values()
-    )
+    }
 
     result: Dict[str, Union[Plan, CompositePlan]] = {}
     touches_file_cache: Dict[str, bool] = {}

--- a/renku/core/workflow/plan_factory.py
+++ b/renku/core/workflow/plan_factory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -306,7 +305,7 @@ class PlanFactory:
             candidate = self._resolve_existing_subpath(self.working_dir / candidate_path)
 
             if candidate is None:
-                raise errors.UsageError('Path "{0}" does not exist inside the current project.'.format(candidate_path))
+                raise errors.UsageError(f'Path "{candidate_path}" does not exist inside the current project.')
 
             glob = str(candidate.relative_to(self.working_dir))
 

--- a/renku/core/workflow/plan_factory.py
+++ b/renku/core/workflow/plan_factory.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/providers/__init__.py
+++ b/renku/core/workflow/providers/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/providers/__init__.py
+++ b/renku/core/workflow/providers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/providers/cwltool.py
+++ b/renku/core/workflow/providers/cwltool.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/providers/cwltool.py
+++ b/renku/core/workflow/providers/cwltool.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/providers/local.py
+++ b/renku/core/workflow/providers/local.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/providers/local.py
+++ b/renku/core/workflow/providers/local.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/providers/toil.py
+++ b/renku/core/workflow/providers/toil.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -50,7 +49,7 @@ class AbstractToilJob(Job):
     """Toil job implementation for a renku ``Plan``."""
 
     def __init__(self, workflow: Plan, *args, **kwargs):
-        super(AbstractToilJob, self).__init__(unitName=workflow.name, displayName=workflow.name, *args, **kwargs)
+        super().__init__(unitName=workflow.name, displayName=workflow.name, *args, **kwargs)
         self.workflow: Plan = workflow
         self._input_files: Dict[str, FileID] = {}
         self._parents_promise: List[Promise] = []

--- a/renku/core/workflow/providers/toil.py
+++ b/renku/core/workflow/providers/toil.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/run.py
+++ b/renku/core/workflow/run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/run.py
+++ b/renku/core/workflow/run.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/types.py
+++ b/renku/core/workflow/types.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/types.py
+++ b/renku/core/workflow/types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/core/workflow/value_resolution.py
+++ b/renku/core/workflow/value_resolution.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/value_resolution.py
+++ b/renku/core/workflow/value_resolution.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -67,7 +66,7 @@ class PlanValueResolver(ValueResolver):
     """
 
     def __init__(self, plan: Plan, values: Dict[str, Any]):
-        super(PlanValueResolver, self).__init__(plan, values)
+        super().__init__(plan, values)
 
     def apply(self) -> AbstractPlan:
         """Applies values and default_values to a ``Plan``.
@@ -112,7 +111,7 @@ class CompositePlanValueResolver(ValueResolver):
     """
 
     def __init__(self, plan: CompositePlan, values: Optional[Dict[str, Any]] = None):
-        super(CompositePlanValueResolver, self).__init__(plan, values)
+        super().__init__(plan, values)
 
     def apply(self) -> AbstractPlan:
         """Applies values and default_values to a ``CompositePlan``.

--- a/renku/core/workflow/workflow_file.py
+++ b/renku/core/workflow/workflow_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/core/workflow/workflow_file.py
+++ b/renku/core/workflow/workflow_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/data/pre-commit.sh
+++ b/renku/data/pre-commit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/__init__.py
+++ b/renku/domain_model/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/__init__.py
+++ b/renku/domain_model/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/dataset.py
+++ b/renku/domain_model/dataset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/dataset.py
+++ b/renku/domain_model/dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/dataset_provider.py
+++ b/renku/domain_model/dataset_provider.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/dataset_provider.py
+++ b/renku/domain_model/dataset_provider.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/datastructures.py
+++ b/renku/domain_model/datastructures.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/datastructures.py
+++ b/renku/domain_model/datastructures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/entity.py
+++ b/renku/domain_model/entity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/entity.py
+++ b/renku/domain_model/entity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/enums.py
+++ b/renku/domain_model/enums.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2020- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/git.py
+++ b/renku/domain_model/git.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -80,7 +79,7 @@ def filter_repo_name(repo_name: str) -> str:
 
 
 @attr.s()
-class GitURL(object):
+class GitURL:
     """Parser for common Git URLs."""
 
     # Initial value

--- a/renku/domain_model/git.py
+++ b/renku/domain_model/git.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/project.py
+++ b/renku/domain_model/project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/project.py
+++ b/renku/domain_model/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/project_context.py
+++ b/renku/domain_model/project_context.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/project_context.py
+++ b/renku/domain_model/project_context.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/provenance/__init__.py
+++ b/renku/domain_model/provenance/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/provenance/__init__.py
+++ b/renku/domain_model/provenance/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/provenance/activity.py
+++ b/renku/domain_model/provenance/activity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/provenance/activity.py
+++ b/renku/domain_model/provenance/activity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/provenance/agent.py
+++ b/renku/domain_model/provenance/agent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -161,7 +160,7 @@ class Person(Agent):
         initials = [name[0] for name in names]
         initials.pop()
 
-        return "{0}.{1}".format(".".join(initials), last_name)
+        return "{}.{}".format(".".join(initials), last_name)
 
     @property
     def full_identity(self):

--- a/renku/domain_model/provenance/agent.py
+++ b/renku/domain_model/provenance/agent.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/provenance/annotation.py
+++ b/renku/domain_model/provenance/annotation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/provenance/annotation.py
+++ b/renku/domain_model/provenance/annotation.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/provenance/parameter.py
+++ b/renku/domain_model/provenance/parameter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/provenance/parameter.py
+++ b/renku/domain_model/provenance/parameter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/session.py
+++ b/renku/domain_model/session.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/session.py
+++ b/renku/domain_model/session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -80,7 +79,7 @@ class ISessionProvider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def session_provider(self) -> "ISessionProvider":
+    def session_provider(self) -> ISessionProvider:
         """Supported session provider.
 
         Returns:
@@ -89,12 +88,12 @@ class ISessionProvider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_start_parameters(self) -> List["ProviderParameter"]:
+    def get_start_parameters(self) -> List[ProviderParameter]:
         """Returns parameters that can be set for session start."""
         pass
 
     @abstractmethod
-    def get_open_parameters(self) -> List["ProviderParameter"]:
+    def get_open_parameters(self) -> List[ProviderParameter]:
         """Returns parameters that can be set for session open."""
         pass
 

--- a/renku/domain_model/sort.py
+++ b/renku/domain_model/sort.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/sort.py
+++ b/renku/domain_model/sort.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/template.py
+++ b/renku/domain_model/template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -296,9 +295,7 @@ class Template:
         existing_prohibited_paths: Set[str] = set()
 
         for pattern in self.PROHIBITED_PATHS:
-            matches = set(
-                m for m in self.path.glob(pattern) if str(m.relative_to(self.path)) not in self.REQUIRED_FILES
-            )
+            matches = {m for m in self.path.glob(pattern) if str(m.relative_to(self.path)) not in self.REQUIRED_FILES}
             if matches:
                 existing_prohibited_paths.update(str(m.relative_to(self.path)) for m in matches)
 

--- a/renku/domain_model/workflow/__init__.py
+++ b/renku/domain_model/workflow/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/workflow/__init__.py
+++ b/renku/domain_model/workflow/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/workflow/composite_plan.py
+++ b/renku/domain_model/workflow/composite_plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/workflow/composite_plan.py
+++ b/renku/domain_model/workflow/composite_plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/workflow/converters/__init__.py
+++ b/renku/domain_model/workflow/converters/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/workflow/converters/__init__.py
+++ b/renku/domain_model/workflow/converters/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/workflow/parameter.py
+++ b/renku/domain_model/workflow/parameter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/workflow/parameter.py
+++ b/renku/domain_model/workflow/parameter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/workflow/plan.py
+++ b/renku/domain_model/workflow/plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/workflow/plan.py
+++ b/renku/domain_model/workflow/plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/domain_model/workflow/provider.py
+++ b/renku/domain_model/workflow/provider.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -40,7 +39,7 @@ class IWorkflowProvider(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def workflow_execute(self, dag: "nx.DiGraph", basedir: Path, config: Dict[str, Any]):
+    def workflow_execute(self, dag: nx.DiGraph, basedir: Path, config: Dict[str, Any]):
         """Executes a given ``AbstractPlan`` using the provider.
 
         Returns:

--- a/renku/domain_model/workflow/provider.py
+++ b/renku/domain_model/workflow/provider.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/workflow/workflow_file.py
+++ b/renku/domain_model/workflow/workflow_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/domain_model/workflow/workflow_file.py
+++ b/renku/domain_model/workflow/workflow_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/__init__.py
+++ b/renku/infrastructure/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/__init__.py
+++ b/renku/infrastructure/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/database.py
+++ b/renku/infrastructure/database.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -794,7 +793,7 @@ class Storage:
                 with io.TextIOWrapper(compressor) as out:
                     json.dump(data, out, ensure_ascii=False)
         else:
-            with open(path, "wt") as ft:
+            with open(path, "w") as ft:
                 json.dump(data, ft, ensure_ascii=False, sort_keys=True, indent=2)
 
     def load(self, filename: str, absolute: bool = False):
@@ -1031,7 +1030,7 @@ class ObjectReader:
                 # NOTE: we had a circular reference, we return the (not yet finalized) class here
                 return self._deserialization_cache[data["@renku_data_value"]]
             elif object_type == SET_TYPE:
-                return set([self._deserialize_helper(value) for value in data["@renku_data_value"]])
+                return {self._deserialize_helper(value) for value in data["@renku_data_value"]}
             elif object_type == FROZEN_SET_TYPE:
                 return frozenset([self._deserialize_helper(value) for value in data["@renku_data_value"]])
 

--- a/renku/infrastructure/database.py
+++ b/renku/infrastructure/database.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/gateway/__init__.py
+++ b/renku/infrastructure/gateway/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/gateway/__init__.py
+++ b/renku/infrastructure/gateway/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/gateway/activity_gateway.py
+++ b/renku/infrastructure/gateway/activity_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/gateway/activity_gateway.py
+++ b/renku/infrastructure/gateway/activity_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/gateway/database_gateway.py
+++ b/renku/infrastructure/gateway/database_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/gateway/database_gateway.py
+++ b/renku/infrastructure/gateway/database_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/gateway/dataset_gateway.py
+++ b/renku/infrastructure/gateway/dataset_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/gateway/dataset_gateway.py
+++ b/renku/infrastructure/gateway/dataset_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/gateway/plan_gateway.py
+++ b/renku/infrastructure/gateway/plan_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/gateway/plan_gateway.py
+++ b/renku/infrastructure/gateway/plan_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/gateway/project_gateway.py
+++ b/renku/infrastructure/gateway/project_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/gateway/project_gateway.py
+++ b/renku/infrastructure/gateway/project_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/git_merger.py
+++ b/renku/infrastructure/git_merger.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/git_merger.py
+++ b/renku/infrastructure/git_merger.py
@@ -42,6 +42,8 @@ from renku.version import __version__
 
 
 class RemoteEntry(NamedTuple):
+    """Reference to an entry in a database on a separate branch."""
+
     reference: str
     database: Database
     path: Path

--- a/renku/infrastructure/git_merger.py
+++ b/renku/infrastructure/git_merger.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -41,9 +40,12 @@ from renku.infrastructure.database import Database, Index
 from renku.infrastructure.repository import Repository
 from renku.version import __version__
 
-RemoteEntry = NamedTuple(
-    "RemoteEntry", [("reference", str), ("database", Database), ("path", Path), ("repository", Repository)]
-)
+
+class RemoteEntry(NamedTuple):
+    reference: str
+    database: Database
+    path: Path
+    repository: Repository
 
 
 class GitMerger:

--- a/renku/infrastructure/immutable.py
+++ b/renku/infrastructure/immutable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/immutable.py
+++ b/renku/infrastructure/immutable.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/persistent.py
+++ b/renku/infrastructure/persistent.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/persistent.py
+++ b/renku/infrastructure/persistent.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/repository.py
+++ b/renku/infrastructure/repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -138,7 +137,7 @@ class BaseRepository:
         return RemoteManager(self._repository)
 
     @property  # type: ignore
-    @lru_cache()
+    @lru_cache
     def submodules(self) -> "SubmoduleManager":
         """Return a list of submodules."""
         if self._repository is None:
@@ -975,7 +974,7 @@ class BaseRepository:
     def hash_string(content: str) -> str:
         """Calculate the object-hash for a blob with specified content."""
         content_bytes = content.encode("utf-8")
-        data = f"blob {len(content_bytes)}\0".encode("utf-8") + content_bytes
+        data = f"blob {len(content_bytes)}\0".encode() + content_bytes
         return hashlib.sha1(data).hexdigest()  # nosec
 
 

--- a/renku/infrastructure/repository.py
+++ b/renku/infrastructure/repository.py
@@ -36,6 +36,7 @@ from typing import (
     Dict,
     Generator,
     List,
+    Literal,
     NamedTuple,
     Optional,
     Sequence,
@@ -52,11 +53,6 @@ import git
 
 from renku.core import errors
 from renku.core.util.os import delete_dataset_file, get_absolute_path
-
-try:
-    from typing_extensions import Literal  # NOTE: Required for Python 3.7 compatibility
-except ImportError:
-    from typing import Literal  # type: ignore
 
 NULL_TREE = git.NULL_TREE
 _MARKER = object()

--- a/renku/infrastructure/repository.py
+++ b/renku/infrastructure/repository.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/storage/__init__.py
+++ b/renku/infrastructure/storage/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/storage/__init__.py
+++ b/renku/infrastructure/storage/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/storage/factory.py
+++ b/renku/infrastructure/storage/factory.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/infrastructure/storage/factory.py
+++ b/renku/infrastructure/storage/factory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/infrastructure/storage/rclone.py
+++ b/renku/infrastructure/storage/rclone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -127,7 +126,7 @@ def run_rclone_command(command: str, *args: Any, env=None, **kwargs) -> str:
 
     full_command = ("rclone", command, *transform_kwargs(**kwargs), *transform_args(*args))
     try:
-        result = subprocess.run(full_command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os_env)
+        result = subprocess.run(full_command, text=True, capture_output=True, env=os_env)
     except FileNotFoundError:
         raise errors.RCloneException("RClone is not installed. See https://rclone.org/install/")
 

--- a/renku/infrastructure/storage/rclone.py
+++ b/renku/infrastructure/storage/rclone.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/__init__.py
+++ b/renku/ui/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/__init__.py
+++ b/renku/ui/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/api/__init__.py
+++ b/renku/ui/api/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/api/__init__.py
+++ b/renku/ui/api/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/api/graph/__init__.py
+++ b/renku/ui/api/graph/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/api/graph/__init__.py
+++ b/renku/ui/api/graph/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/api/graph/rdf.py
+++ b/renku/ui/api/graph/rdf.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/api/graph/rdf.py
+++ b/renku/ui/api/graph/rdf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/api/models/__init__.py
+++ b/renku/ui/api/models/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/api/models/__init__.py
+++ b/renku/ui/api/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/api/models/activity.py
+++ b/renku/ui/api/models/activity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/api/models/activity.py
+++ b/renku/ui/api/models/activity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/api/models/dataset.py
+++ b/renku/ui/api/models/dataset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/api/models/dataset.py
+++ b/renku/ui/api/models/dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/api/models/parameter.py
+++ b/renku/ui/api/models/parameter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/api/models/parameter.py
+++ b/renku/ui/api/models/parameter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/api/models/plan.py
+++ b/renku/ui/api/models/plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/api/models/plan.py
+++ b/renku/ui/api/models/plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/api/models/project.py
+++ b/renku/ui/api/models/project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/api/models/project.py
+++ b/renku/ui/api/models/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/api/util.py
+++ b/renku/ui/api/util.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/api/util.py
+++ b/renku/ui/api/util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/__init__.py
+++ b/renku/ui/cli/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/__init__.py
+++ b/renku/ui/cli/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/__main__.py
+++ b/renku/ui/cli/__main__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/__main__.py
+++ b/renku/ui/cli/__main__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/clone.py
+++ b/renku/ui/cli/clone.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/clone.py
+++ b/renku/ui/cli/clone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/config.py
+++ b/renku/ui/cli/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/config.py
+++ b/renku/ui/cli/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/dataset.py
+++ b/renku/ui/cli/dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -747,11 +746,9 @@ def edit(name, title, description, creators, metadata, metadata_source, keywords
 
     if not updated:
         click.echo(
-            (
-                "Nothing to update. "
-                "Check available fields with `renku dataset edit --help`\n\n"
-                'Hint: `renku dataset edit --title "new title"`'
-            )
+            "Nothing to update. "
+            "Check available fields with `renku dataset edit --help`\n\n"
+            'Hint: `renku dataset edit --title "new title"`'
         )
     else:
         click.echo("Successfully updated: {}.".format(", ".join(updated.keys())))
@@ -906,11 +903,9 @@ def unlink(name, include, exclude, yes):
 
     if not include and not exclude:
         raise errors.ParameterError(
-            (
-                "include or exclude filters not found.\n"
-                "Check available filters with 'renku dataset unlink --help'\n"
-                "Hint: 'renku dataset unlink my-dataset -I path'"
-            )
+            "include or exclude filters not found.\n"
+            "Check available filters with 'renku dataset unlink --help'\n"
+            "Hint: 'renku dataset unlink my-dataset -I path'"
         )
 
     communicator = ClickCallback()

--- a/renku/ui/cli/dataset.py
+++ b/renku/ui/cli/dataset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/doctor.py
+++ b/renku/ui/cli/doctor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/doctor.py
+++ b/renku/ui/cli/doctor.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/env.py
+++ b/renku/ui/cli/env.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/env.py
+++ b/renku/ui/cli/env.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/exception_handler.py
+++ b/renku/ui/cli/exception_handler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -154,7 +153,7 @@ class IssueFromTraceback(RenkuExceptionsHandler):
                 scope.user = {"name": user.name, "email": user.email}
 
             event_id = capture_exception()
-            click.echo(_BUG + "Recorded in Sentry with ID: {0}\n".format(event_id), err=True)
+            click.echo(_BUG + f"Recorded in Sentry with ID: {event_id}\n", err=True)
             raise
 
     def _handle_github(self):

--- a/renku/ui/cli/exception_handler.py
+++ b/renku/ui/cli/exception_handler.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/gc.py
+++ b/renku/ui/cli/gc.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/gc.py
+++ b/renku/ui/cli/gc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/githooks.py
+++ b/renku/ui/cli/githooks.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/githooks.py
+++ b/renku/ui/cli/githooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/graph.py
+++ b/renku/ui/cli/graph.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/graph.py
+++ b/renku/ui/cli/graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/init.py
+++ b/renku/ui/cli/init.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/init.py
+++ b/renku/ui/cli/init.py
@@ -133,7 +133,7 @@ in the template will be left untouched by the command.
 .. code-block:: console
 
     $ echo "# Example\nThis is a README." > README.md
-    $ echo "FROM python:3.7-alpine" > Dockerfile
+    $ echo "FROM python:3.10-alpine" > Dockerfile
     $ renku init
 
     INDEX  ID              PARAMETERS

--- a/renku/ui/cli/init.py
+++ b/renku/ui/cli/init.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -68,12 +67,12 @@ You can take inspiration from the
     https://github.com/SwissDataScienceCenter/renku-project-template@master
     ... OK
 
-    INDEX ID             DESCRIPTION                PARAMETERS
+    NUMBER ID             DESCRIPTION                PARAMETERS
     ----- -------------- -------------------------- ----------------------
     1     python-minimal Basic Python Project:[...] description: proj[...]
     2     R-minimal      Basic R Project: The [...] description: proj[...]
 
-    Please choose a template by typing the index:
+    Please choose a template by typing the number:
 
 Provide parameters
 ~~~~~~~~~~~~~~~~~~
@@ -136,14 +135,14 @@ in the template will be left untouched by the command.
     $ echo "FROM python:3.10-alpine" > Dockerfile
     $ renku init
 
-    INDEX  ID              PARAMETERS
+    NUMBER  ID              PARAMETERS
     -------  --------------  ------------
         1  python-minimal  description
         2  R-minimal       description
         3  bioc-minimal    description
         4  julia-minimal   description
         5  minimal
-    Please choose a template by typing the index: 1
+    Please choose a template by typing the number: 1
     The template requires a value for "description": Test Project
     Initializing Git repository...
     Warning: The following files exist in the directory and will be overwritten:

--- a/renku/ui/cli/log.py
+++ b/renku/ui/cli/log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/log.py
+++ b/renku/ui/cli/log.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/login.py
+++ b/renku/ui/cli/login.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/login.py
+++ b/renku/ui/cli/login.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/mergetool.py
+++ b/renku/ui/cli/mergetool.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/migrate.py
+++ b/renku/ui/cli/migrate.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/migrate.py
+++ b/renku/ui/cli/migrate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/move.py
+++ b/renku/ui/cli/move.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/project.py
+++ b/renku/ui/cli/project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/project.py
+++ b/renku/ui/cli/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/remove.py
+++ b/renku/ui/cli/remove.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/rerun.py
+++ b/renku/ui/cli/rerun.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/rerun.py
+++ b/renku/ui/cli/rerun.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/rollback.py
+++ b/renku/ui/cli/rollback.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/rollback.py
+++ b/renku/ui/cli/rollback.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/run.py
+++ b/renku/ui/cli/run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/run.py
+++ b/renku/ui/cli/run.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/save.py
+++ b/renku/ui/cli/save.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/service.py
+++ b/renku/ui/cli/service.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/session.py
+++ b/renku/ui/cli/session.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/session.py
+++ b/renku/ui/cli/session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/status.py
+++ b/renku/ui/cli/status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/status.py
+++ b/renku/ui/cli/status.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/storage.py
+++ b/renku/ui/cli/storage.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/storage.py
+++ b/renku/ui/cli/storage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/template.py
+++ b/renku/ui/cli/template.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/template.py
+++ b/renku/ui/cli/template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/update.py
+++ b/renku/ui/cli/update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/update.py
+++ b/renku/ui/cli/update.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/utils/__init__.py
+++ b/renku/ui/cli/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/utils/callback.py
+++ b/renku/ui/cli/utils/callback.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/utils/callback.py
+++ b/renku/ui/cli/utils/callback.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -75,7 +74,7 @@ class StandardOutput(CommunicationCallback):
     def start_progress(self, name, total, **kwargs):
         """Start a new tqdm progressbar."""
         if name in self._progress_bars:
-            raise ValueError("Name {} is already a registered progressbar.".format(name))
+            raise ValueError(f"Name {name} is already a registered progressbar.")
 
         if "type" not in kwargs:
             kwargs["type"] = "download"

--- a/renku/ui/cli/utils/click.py
+++ b/renku/ui/cli/utils/click.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -35,7 +34,7 @@ class CaseInsensitiveChoice(click.Choice):
         """Convert value to its choice value."""
         if value is None:
             return None
-        return super(CaseInsensitiveChoice, self).convert(value.lower(), param, ctx)
+        return super().convert(value.lower(), param, ctx)
 
 
 class MutuallyExclusiveOption(click.Option):
@@ -59,7 +58,7 @@ class MutuallyExclusiveOption(click.Option):
         if self.mutually_exclusive:
             ex_str = ", ".join(self.mutually_exclusive_names)
             kwargs["help"] = f"{_help} NOTE: This argument is mutually exclusive with arguments: [{ex_str}]."
-        super(MutuallyExclusiveOption, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def handle_parse_result(self, ctx, opts, args):
         """Handles the parse result for the option."""
@@ -69,7 +68,7 @@ class MutuallyExclusiveOption(click.Option):
                 "arguments `{}`.".format(self.name, ", ".join(sorted(self.mutually_exclusive_names)))
             )
 
-        return super(MutuallyExclusiveOption, self).handle_parse_result(ctx, opts, args)
+        return super().handle_parse_result(ctx, opts, args)
 
 
 def create_options(providers, parameter_function: str):

--- a/renku/ui/cli/utils/click.py
+++ b/renku/ui/cli/utils/click.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/utils/color.py
+++ b/renku/ui/cli/utils/color.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/utils/color.py
+++ b/renku/ui/cli/utils/color.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/utils/curses.py
+++ b/renku/ui/cli/utils/curses.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/utils/curses.py
+++ b/renku/ui/cli/utils/curses.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/utils/plugins.py
+++ b/renku/ui/cli/utils/plugins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/utils/plugins.py
+++ b/renku/ui/cli/utils/plugins.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/utils/terminal.py
+++ b/renku/ui/cli/utils/terminal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/cli/utils/terminal.py
+++ b/renku/ui/cli/utils/terminal.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/cli/workflow.py
+++ b/renku/ui/cli/workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -1187,9 +1186,7 @@ def execute(
 
     if result.output:
         click.echo(
-            "Unchanged files:\n\n\t{0}".format(
-                "\n\t".join(click.style(path, fg=color.YELLOW) for path in result.output)
-            )
+            "Unchanged files:\n\n\t{}".format("\n\t".join(click.style(path, fg=color.YELLOW) for path in result.output))
         )
 
 

--- a/renku/ui/cli/workflow.py
+++ b/renku/ui/cli/workflow.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/service/__init__.py
+++ b/renku/ui/service/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/__init__.py
+++ b/renku/ui/service/cache/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/base.py
+++ b/renku/ui/service/cache/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/config.py
+++ b/renku/ui/service/cache/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/files.py
+++ b/renku/ui/service/cache/files.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/jobs.py
+++ b/renku/ui/service/cache/jobs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -60,7 +59,7 @@ class JobManagementCache(BaseCache):
     @staticmethod
     def get_jobs(user):
         """Get all user jobs."""
-        return Job.query((Job.user_id == user.user_id))
+        return Job.query(Job.user_id == user.user_id)
 
     @staticmethod
     def invalidate_job(user, job_id):

--- a/renku/ui/service/cache/models/__init__.py
+++ b/renku/ui/service/cache/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/models/file.py
+++ b/renku/ui/service/cache/models/file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/models/job.py
+++ b/renku/ui/service/cache/models/job.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/models/project.py
+++ b/renku/ui/service/cache/models/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/models/user.py
+++ b/renku/ui/service/cache/models/user.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/projects.py
+++ b/renku/ui/service/cache/projects.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/serializers/__init__.py
+++ b/renku/ui/service/cache/serializers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/serializers/file.py
+++ b/renku/ui/service/cache/serializers/file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/serializers/job.py
+++ b/renku/ui/service/cache/serializers/job.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/serializers/project.py
+++ b/renku/ui/service/cache/serializers/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/serializers/user.py
+++ b/renku/ui/service/cache/serializers/user.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/cache/users.py
+++ b/renku/ui/service/cache/users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/config.py
+++ b/renku/ui/service/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/__init__.py
+++ b/renku/ui/service/controllers/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/service/controllers/__init__.py
+++ b/renku/ui/service/controllers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/api/__init__.py
+++ b/renku/ui/service/controllers/api/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/service/controllers/api/__init__.py
+++ b/renku/ui/service/controllers/api/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/api/abstract.py
+++ b/renku/ui/service/controllers/api/abstract.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/api/mixins.py
+++ b/renku/ui/service/controllers/api/mixins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -50,7 +49,7 @@ PROJECT_FETCH_TIME = 30
 
 def local_identity(method):
     """Ensure identity on local execution."""
-    # noqa
+
     @wraps(method)
     def _impl(self, *method_args, **method_kwargs):
         """Implementation of method wrapper."""

--- a/renku/ui/service/controllers/cache_files_delete_chunks.py
+++ b/renku/ui/service/controllers/cache_files_delete_chunks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -35,7 +34,7 @@ class DeleteFileChunksCtrl(ServiceCtrl, RenkuOperationMixin):
     def __init__(self, cache, user_data, request_data):
         """Construct list uploaded files controller."""
         self.ctx = DeleteFileChunksCtrl.REQUEST_SERIALIZER.load(request_data)
-        super(DeleteFileChunksCtrl, self).__init__(cache, user_data, request_data)
+        super().__init__(cache, user_data, request_data)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/cache_files_upload.py
+++ b/renku/ui/service/controllers/cache_files_upload.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -51,7 +50,7 @@ class UploadFilesCtrl(ServiceCtrl, RenkuOperationMixin):
         args = {**flask_request.args, **flask_request.form}
         self.response_builder.update(UploadFilesCtrl.REQUEST_SERIALIZER.load(args))
 
-        super(UploadFilesCtrl, self).__init__(cache, user_data, {})
+        super().__init__(cache, user_data, {})
 
     @property
     def context(self):
@@ -149,7 +148,7 @@ class UploadFilesCtrl(ServiceCtrl, RenkuOperationMixin):
         """Postprocessing of uploaded file."""
         files = []
         if self.response_builder["unpack_archive"] and self.response_builder["is_archive"]:
-            unpack_dir = "{0}.unpacked".format(file_path.name)
+            unpack_dir = f"{file_path.name}.unpacked"
             temp_dir = file_path.parent / Path(unpack_dir)
             if temp_dir.exists():
                 shutil.rmtree(temp_dir)

--- a/renku/ui/service/controllers/cache_list_projects.py
+++ b/renku/ui/service/controllers/cache_list_projects.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -32,7 +31,7 @@ class ListProjectsCtrl(ServiceCtrl, RenkuOperationMixin):
     def __init__(self, cache, user_data):
         """Construct controller."""
         self.ctx = {}
-        super(ListProjectsCtrl, self).__init__(cache, user_data, {})
+        super().__init__(cache, user_data, {})
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/cache_list_uploaded.py
+++ b/renku/ui/service/controllers/cache_list_uploaded.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -30,7 +29,7 @@ class ListUploadedFilesCtrl(ServiceCtrl, RenkuOperationMixin):
     def __init__(self, cache, user_data):
         """Construct list uploaded files controller."""
         self.ctx = {}
-        super(ListUploadedFilesCtrl, self).__init__(cache, user_data, {})
+        super().__init__(cache, user_data, {})
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/cache_migrate_project.py
+++ b/renku/ui/service/controllers/cache_migrate_project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -81,7 +80,7 @@ class MigrateProjectCtrl(ServiceCtrl, RenkuOpSyncMixin):
         self.skip_migrations = self.ctx.get("skip_migrations", False)
         self.commit_message = f"{MESSAGE_PREFIX} migrate to latest version for renku {__version__}"
 
-        super(MigrateProjectCtrl, self).__init__(
+        super().__init__(
             cache,
             user_data,
             request_data,

--- a/renku/ui/service/controllers/cache_migrations_check.py
+++ b/renku/ui/service/controllers/cache_migrations_check.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -42,7 +41,7 @@ class MigrationsCheckCtrl(ServiceCtrl, RenkuOperationMixin):
         """Construct migration check controller."""
         self.ctx = MigrationsCheckCtrl.REQUEST_SERIALIZER.load(request_data)
         self.git_api_provider = git_api_provider
-        super(MigrationsCheckCtrl, self).__init__(cache, user_data, request_data)
+        super().__init__(cache, user_data, request_data)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/cache_project_clone.py
+++ b/renku/ui/service/controllers/cache_project_clone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -35,7 +34,7 @@ class ProjectCloneCtrl(ServiceCtrl, RenkuOperationMixin):
         """Construct controller."""
         self.request_data = ProjectCloneCtrl.REQUEST_SERIALIZER.load(request_data)
         self.ctx = ProjectCloneContext().load({**user_data, **self.request_data}, unknown=EXCLUDE)
-        super(ProjectCloneCtrl, self).__init__(cache, user_data, self.request_data)
+        super().__init__(cache, user_data, self.request_data)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/config_set.py
+++ b/renku/ui/service/controllers/config_set.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -37,7 +36,7 @@ class SetConfigCtrl(ServiceCtrl, RenkuOpSyncMixin):
         config_keys = ", ".join(request_data["config"].keys())
         self.ctx["commit_message"] = f"{MESSAGE_PREFIX} config set {config_keys}"
 
-        super(SetConfigCtrl, self).__init__(cache, user_data, request_data, migrate_project=migrate_project)
+        super().__init__(cache, user_data, request_data, migrate_project=migrate_project)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/config_show.py
+++ b/renku/ui/service/controllers/config_show.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -33,7 +32,7 @@ class ShowConfigCtrl(ServiceCtrl, RenkuOperationMixin):
     def __init__(self, cache, user_data, request_data):
         """Construct controller."""
         self.ctx = ShowConfigCtrl.REQUEST_SERIALIZER.load(request_data)
-        super(ShowConfigCtrl, self).__init__(cache, user_data, request_data)
+        super().__init__(cache, user_data, request_data)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/datasets_add_file.py
+++ b/renku/ui/service/controllers/datasets_add_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -44,7 +43,7 @@ class DatasetsAddFileCtrl(ServiceCtrl, RenkuOpSyncMixin):
         self.ctx = DatasetsAddFileCtrl.REQUEST_SERIALIZER.load(request_data)
         self.ctx["commit_message"] = f"{MESSAGE_PREFIX} dataset add {self.ctx['name']}"
 
-        super(DatasetsAddFileCtrl, self).__init__(cache, user_data, request_data, migrate_project=migrate_project)
+        super().__init__(cache, user_data, request_data, migrate_project=migrate_project)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/datasets_create.py
+++ b/renku/ui/service/controllers/datasets_create.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -39,7 +38,7 @@ class DatasetsCreateCtrl(ServiceCtrl, RenkuOpSyncMixin):
         self.ctx = DatasetsCreateCtrl.REQUEST_SERIALIZER.load(request_data)
         self.ctx["commit_message"] = f"{MESSAGE_PREFIX} dataset create {self.ctx['name']}"
 
-        super(DatasetsCreateCtrl, self).__init__(cache, user_data, request_data, migrate_project)
+        super().__init__(cache, user_data, request_data, migrate_project)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/datasets_edit.py
+++ b/renku/ui/service/controllers/datasets_edit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -43,7 +42,7 @@ class DatasetsEditCtrl(ServiceCtrl, RenkuOpSyncMixin):
         self.ctx = cast(Dict, DatasetsEditCtrl.REQUEST_SERIALIZER.load(request_data))
         self.ctx["commit_message"] = f"{MESSAGE_PREFIX} dataset edit {self.ctx['name']}"
 
-        super(DatasetsEditCtrl, self).__init__(cache, user_data, request_data, migrate_project=migrate_project)
+        super().__init__(cache, user_data, request_data, migrate_project=migrate_project)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/datasets_files_list.py
+++ b/renku/ui/service/controllers/datasets_files_list.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -34,7 +33,7 @@ class DatasetsFilesListCtrl(ServiceCtrl, RenkuOperationMixin):
         """Construct a datasets files list controller."""
         self.ctx = DatasetsFilesListCtrl.REQUEST_SERIALIZER.load(request_data)
 
-        super(DatasetsFilesListCtrl, self).__init__(cache, user_data, request_data)
+        super().__init__(cache, user_data, request_data)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/datasets_import.py
+++ b/renku/ui/service/controllers/datasets_import.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -39,7 +38,7 @@ class DatasetsImportCtrl(ServiceCtrl, RenkuOpSyncMixin):
         self.ctx = DatasetsImportCtrl.REQUEST_SERIALIZER.load(request_data)
         self.ctx["commit_message"] = f"{MESSAGE_PREFIX} dataset import of {self.ctx['dataset_uri']}"
 
-        super(DatasetsImportCtrl, self).__init__(cache, user_data, request_data, migrate_project=migrate_project)
+        super().__init__(cache, user_data, request_data, migrate_project=migrate_project)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/datasets_list.py
+++ b/renku/ui/service/controllers/datasets_list.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -33,7 +32,7 @@ class DatasetsListCtrl(ServiceCtrl, RenkuOperationMixin):
     def __init__(self, cache, user_data, request_data):
         """Construct a datasets list controller."""
         self.ctx = DatasetsListCtrl.REQUEST_SERIALIZER.load(request_data)
-        super(DatasetsListCtrl, self).__init__(cache, user_data, request_data)
+        super().__init__(cache, user_data, request_data)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/datasets_remove.py
+++ b/renku/ui/service/controllers/datasets_remove.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -36,7 +35,7 @@ class DatasetsRemoveCtrl(ServiceCtrl, RenkuOpSyncMixin):
         self.ctx = DatasetsRemoveCtrl.REQUEST_SERIALIZER.load(request_data)
         self.ctx["commit_message"] = f"{MESSAGE_PREFIX} dataset remove {self.ctx['name']}"
 
-        super(DatasetsRemoveCtrl, self).__init__(cache, user_data, request_data, migrate_project=migrate_project)
+        super().__init__(cache, user_data, request_data, migrate_project=migrate_project)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/datasets_unlink.py
+++ b/renku/ui/service/controllers/datasets_unlink.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -46,7 +45,7 @@ class DatasetsUnlinkCtrl(ServiceCtrl, RenkuOpSyncMixin):
             filters = f"-I {self.include}"
         self.ctx["commit_message"] = f"{MESSAGE_PREFIX} unlink dataset {self.ctx['name']} {filters}"
 
-        super(DatasetsUnlinkCtrl, self).__init__(cache, user_data, request_data, migrate_project=migrate_project)
+        super().__init__(cache, user_data, request_data, migrate_project=migrate_project)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/graph_export.py
+++ b/renku/ui/service/controllers/graph_export.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -45,7 +44,7 @@ class GraphExportCtrl(ServiceCtrl, RenkuOperationMixin):
     def __init__(self, cache, user_data, request_data):
         """Construct a datasets list controller."""
         self.ctx = GraphExportCtrl.REQUEST_SERIALIZER.load(request_data)
-        super(GraphExportCtrl, self).__init__(cache, user_data, request_data, clone_depth=PROJECT_CLONE_NO_DEPTH)
+        super().__init__(cache, user_data, request_data, clone_depth=PROJECT_CLONE_NO_DEPTH)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/project_edit.py
+++ b/renku/ui/service/controllers/project_edit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/project_lock_status.py
+++ b/renku/ui/service/controllers/project_lock_status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/project_show.py
+++ b/renku/ui/service/controllers/project_show.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/templates_create_project.py
+++ b/renku/ui/service/controllers/templates_create_project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -50,7 +49,7 @@ class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
             TemplatesCreateProjectCtrl.REQUEST_SERIALIZER.load({**user_data, **request_data}, unknown=EXCLUDE),
         )
         self.ctx["commit_message"] = f"{MESSAGE_PREFIX} init {self.ctx['project_name']}"
-        super(TemplatesCreateProjectCtrl, self).__init__(cache, user_data, request_data)
+        super().__init__(cache, user_data, request_data)
 
         self.template: Optional[Template] = None
 
@@ -126,7 +125,7 @@ class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
         self.template_version = repository.head.commit.hexsha
 
         # Verify missing parameters
-        template_parameters = set(p.name for p in self.template.parameters)
+        template_parameters = {p.name for p in self.template.parameters}
         provided_parameters = {p["key"]: p["value"] for p in self.ctx["parameters"]}
         missing_keys = list(template_parameters - provided_parameters.keys())
         if len(missing_keys) > 0:

--- a/renku/ui/service/controllers/templates_read_manifest.py
+++ b/renku/ui/service/controllers/templates_read_manifest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -40,7 +39,7 @@ class TemplatesReadManifestCtrl(ServiceCtrl, RenkuOperationMixin):
     def __init__(self, cache, user_data, request_data):
         """Construct a templates read manifest controller."""
         self.ctx = TemplatesReadManifestCtrl.REQUEST_SERIALIZER.load({**user_data, **request_data}, unknown=EXCLUDE)
-        super(TemplatesReadManifestCtrl, self).__init__(cache, user_data, request_data)
+        super().__init__(cache, user_data, request_data)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/utils/__init__.py
+++ b/renku/ui/service/controllers/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/utils/datasets.py
+++ b/renku/ui/service/controllers/utils/datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/utils/project_clone.py
+++ b/renku/ui/service/controllers/utils/project_clone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/utils/remote_project.py
+++ b/renku/ui/service/controllers/utils/remote_project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/version.py
+++ b/renku/ui/service/controllers/version.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/controllers/workflow_plans_export.py
+++ b/renku/ui/service/controllers/workflow_plans_export.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -33,7 +32,7 @@ class WorkflowPlansExportCtrl(ServiceCtrl, RenkuOperationMixin):
     def __init__(self, cache, user_data, request_data):
         """Construct a workflow plan show controller."""
         self.ctx = WorkflowPlansExportCtrl.REQUEST_SERIALIZER.load(request_data)
-        super(WorkflowPlansExportCtrl, self).__init__(cache, user_data, request_data)
+        super().__init__(cache, user_data, request_data)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/workflow_plans_list.py
+++ b/renku/ui/service/controllers/workflow_plans_list.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -34,7 +33,7 @@ class WorkflowPlansListCtrl(ServiceCtrl, RenkuOperationMixin):
     def __init__(self, cache, user_data, request_data):
         """Construct a plans list controller."""
         self.ctx = WorkflowPlansListCtrl.REQUEST_SERIALIZER.load(request_data)
-        super(WorkflowPlansListCtrl, self).__init__(cache, user_data, request_data)
+        super().__init__(cache, user_data, request_data)
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/workflow_plans_show.py
+++ b/renku/ui/service/controllers/workflow_plans_show.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -33,7 +32,7 @@ class WorkflowPlansShowCtrl(ServiceCtrl, RenkuOperationMixin):
     def __init__(self, cache, user_data, request_data):
         """Construct a workflow plan show controller."""
         self.ctx = WorkflowPlansShowCtrl.REQUEST_SERIALIZER.load(request_data)
-        super(WorkflowPlansShowCtrl, self).__init__(cache, user_data, request_data)
+        super().__init__(cache, user_data, request_data)
 
     @property
     def context(self):

--- a/renku/ui/service/entrypoint.py
+++ b/renku/ui/service/entrypoint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -89,7 +88,7 @@ def create_app(custom_exceptions=True):
         """Service health check."""
         import renku
 
-        return "renku repository service version {}\n".format(renku.__version__)
+        return f"renku repository service version {renku.__version__}\n"
 
     if custom_exceptions:
         register_exceptions(app)
@@ -163,11 +162,7 @@ app = create_app()
 @app.after_request
 def after_request(response):
     """After request handler."""
-    service_log.info(
-        "{0} {1} {2} {3} {4}".format(
-            request.remote_addr, request.method, request.scheme, request.full_path, response.status
-        )
-    )
+    service_log.info(f"{request.remote_addr} {request.method} {request.scheme} {request.full_path} {response.status}")
 
     return response
 

--- a/renku/ui/service/errors.py
+++ b/renku/ui/service/errors.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/service/errors.py
+++ b/renku/ui/service/errors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/gateways/__init__.py
+++ b/renku/ui/service/gateways/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/gateways/gitlab_api_provider.py
+++ b/renku/ui/service/gateways/gitlab_api_provider.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/interfaces/__init__.py
+++ b/renku/ui/service/interfaces/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/interfaces/git_api_provider.py
+++ b/renku/ui/service/interfaces/git_api_provider.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/jobs/__init__.py
+++ b/renku/ui/service/jobs/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/service/jobs/__init__.py
+++ b/renku/ui/service/jobs/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/jobs/cleanup.py
+++ b/renku/ui/service/jobs/cleanup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/jobs/constants.py
+++ b/renku/ui/service/jobs/constants.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/jobs/contexts.py
+++ b/renku/ui/service/jobs/contexts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -31,7 +30,7 @@ def enqueue_retry(queue, retry=3):
     while count < retry:
         try:
             yield WorkerQueues.get(queue)
-        except (OSError, IOError, BusyLoadingError):
+        except (OSError, BusyLoadingError):
             time.sleep(2**count)
             count += 1
         break

--- a/renku/ui/service/jobs/datasets.py
+++ b/renku/ui/service/jobs/datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/jobs/delayed_ctrl.py
+++ b/renku/ui/service/jobs/delayed_ctrl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/jobs/queues.py
+++ b/renku/ui/service/jobs/queues.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/logger.py
+++ b/renku/ui/service/logger.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/scheduler.py
+++ b/renku/ui/service/scheduler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/__init__.py
+++ b/renku/ui/service/serializers/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/cache.py
+++ b/renku/ui/service/serializers/cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -50,7 +49,7 @@ def extract_file(request):
 
     file = files["file"]
     if file and not file.filename:
-        raise ValidationError("wrong filename: {0}".format(file.filename))
+        raise ValidationError(f"wrong filename: {file.filename}")
 
     if file:
         file.filename = secure_filename(file.filename)
@@ -182,7 +181,7 @@ class ProjectCloneContext(RepositoryCloneRequest):
         """Format url with auth."""
         git_url = urlparse(data["git_url"])
 
-        url = "oauth2:{0}@{1}".format(data["token"], git_url.netloc)
+        url = "oauth2:{}@{}".format(data["token"], git_url.netloc)
         return git_url._replace(netloc=url).geturl()
 
     @post_load

--- a/renku/ui/service/serializers/common.py
+++ b/renku/ui/service/serializers/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/config.py
+++ b/renku/ui/service/serializers/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/datasets.py
+++ b/renku/ui/service/serializers/datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -117,7 +116,7 @@ class DatasetAddRequest(
         """Check serialized file list."""
         for _file in data["files"]:
             if "file_id" in _file and "file_path" in _file:
-                raise ValidationError(("invalid reference found:" "use either `file_id` or `file_path`"))
+                raise ValidationError("invalid reference found: use either `file_id` or `file_path`")
 
         return data
 

--- a/renku/ui/service/serializers/graph.py
+++ b/renku/ui/service/serializers/graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/headers.py
+++ b/renku/ui/service/serializers/headers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/jobs.py
+++ b/renku/ui/service/serializers/jobs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/project.py
+++ b/renku/ui/service/serializers/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/rpc.py
+++ b/renku/ui/service/serializers/rpc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/templates.py
+++ b/renku/ui/service/serializers/templates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -90,7 +89,7 @@ class ProjectTemplateRequest(ProjectCloneContext, ManifestTemplatesRequest):
         data["project_slug"] = project_slug
 
         new_project_url_parsed = urlparse(new_project_url)
-        url = "oauth2:{0}@{1}".format(data["token"], new_project_url_parsed.netloc)
+        url = "oauth2:{}@{}".format(data["token"], new_project_url_parsed.netloc)
         data["new_project_url_with_auth"] = new_project_url_parsed._replace(netloc=url).geturl()
 
         return data

--- a/renku/ui/service/serializers/v1/__init__.py
+++ b/renku/ui/service/serializers/v1/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/v1/cache.py
+++ b/renku/ui/service/serializers/v1/cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/v1/templates.py
+++ b/renku/ui/service/serializers/v1/templates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/serializers/workflows.py
+++ b/renku/ui/service/serializers/workflows.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/utils/__init__.py
+++ b/renku/ui/service/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/utils/callback.py
+++ b/renku/ui/service/utils/callback.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/ui/service/utils/callback.py
+++ b/renku/ui/service/utils/callback.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/utils/json_encoder.py
+++ b/renku/ui/service/utils/json_encoder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/utils/squash.py
+++ b/renku/ui/service/utils/squash.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/utils/timeout.py
+++ b/renku/ui/service/utils/timeout.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/__init__.py
+++ b/renku/ui/service/views/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/api_versions.py
+++ b/renku/ui/service/views/api_versions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/apispec.py
+++ b/renku/ui/service/views/apispec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/cache.py
+++ b/renku/ui/service/views/cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/config.py
+++ b/renku/ui/service/views/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/datasets.py
+++ b/renku/ui/service/views/datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/decorators.py
+++ b/renku/ui/service/views/decorators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -29,7 +28,7 @@ from renku.ui.service.views.error_handlers import handle_redis_except
 
 def requires_identity(f):
     """Wrapper which indicates that route requires user identification."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kws):
         """Represents decorated function."""
@@ -58,7 +57,7 @@ def optional_identity(f):
 @handle_redis_except
 def requires_cache(f):
     """Wrapper which injects cache object into view."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -69,7 +68,7 @@ def requires_cache(f):
 
 def accepts_json(f):
     """Wrapper which ensures only JSON payload can be in request."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""

--- a/renku/ui/service/views/error_handlers.py
+++ b/renku/ui/service/views/error_handlers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -86,7 +85,7 @@ from renku.ui.service.views import error_response
 
 def handle_redis_except(f):
     """Wrapper which handles Redis exceptions."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -101,7 +100,7 @@ def handle_redis_except(f):
 def handle_validation_except(f):
     """Wrapper which handles marshmallow `ValidationError`."""
 
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -128,7 +127,7 @@ def handle_validation_except(f):
 
 def handle_jwt_except(f):
     """Wrapper which handles invalid JWT."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -142,7 +141,7 @@ def handle_jwt_except(f):
 
 def handle_renku_except(f):
     """Wrapper which handles `RenkuException`."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -162,7 +161,7 @@ def handle_renku_except(f):
 
 def handle_git_except(f):
     """Wrapper which handles `RenkuException`."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -186,7 +185,7 @@ def handle_git_except(f):
 
 def handle_base_except(f):
     """Wrapper which handles base exceptions."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -199,7 +198,7 @@ def handle_base_except(f):
         # NOTE: GitError here may not be necessary anymore
         except GitError as e:
             return error_response(ProgramGitError(e, cast(str, e.message) if hasattr(e, "message") else ""))
-        except (Exception, BaseException, OSError, IOError) as e:
+        except (Exception, BaseException, OSError) as e:
             if hasattr(e, "stderr") and e.stderr:
                 error_message = " ".join(e.stderr.strip().split("\n"))
             else:
@@ -212,7 +211,7 @@ def handle_base_except(f):
 
 def handle_common_except(f):
     """Handle common exceptions."""
-    # noqa
+
     @wraps(f)
     def dec(*args, **kwargs):
         """Decorated function."""
@@ -232,7 +231,7 @@ def handle_common_except(f):
 
 def handle_templates_read_errors(f):
     """Wrapper which handles reading templates errors."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -256,7 +255,7 @@ def handle_templates_read_errors(f):
 @handle_templates_read_errors
 def handle_templates_create_errors(f):
     """Wrapper which handles template creating projects errors."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -288,7 +287,7 @@ def handle_templates_create_errors(f):
 
 def handle_project_write_errors(f):
     """Wrapper which handles writing project metadata errors."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -304,7 +303,7 @@ def handle_project_write_errors(f):
 
 def handle_config_read_errors(f):
     """Wrapper which handles reading config errors."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -321,7 +320,7 @@ def handle_config_read_errors(f):
 @handle_config_read_errors
 def handle_config_write_errors(f):
     """Wrapper which handles setting config errors."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -341,7 +340,7 @@ def handle_config_write_errors(f):
 
 def handle_datasets_write_errors(f):
     """Wrapper which handles datasets write errors."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -372,7 +371,7 @@ def handle_datasets_write_errors(f):
 
 def handle_workflow_errors(f):
     """Wrapper which handles workflow errors."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -388,7 +387,7 @@ def handle_workflow_errors(f):
 
 def handle_datasets_unlink_errors(f):
     """Wrapper which handles datasets unlink errors."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -408,7 +407,7 @@ def handle_datasets_unlink_errors(f):
 
 def handle_migration_read_errors(f):
     """Wrapper which handles migrations read exceptions."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -427,7 +426,7 @@ def handle_migration_read_errors(f):
 @handle_migration_read_errors
 def handle_migration_write_errors(f):
     """Wrapper which handles migrations write exceptions."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""
@@ -441,7 +440,7 @@ def handle_migration_write_errors(f):
 
 def handle_graph_errors(f):
     """Wrapper which handles graph exceptions."""
-    # noqa
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         """Represents decorated function."""

--- a/renku/ui/service/views/error_handlers.py
+++ b/renku/ui/service/views/error_handlers.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 - Swiss Data Science Center (SDSC)
+# Copyright 2022-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #
@@ -99,7 +99,6 @@ def handle_redis_except(f):
 
 def handle_validation_except(f):
     """Wrapper which handles marshmallow `ValidationError`."""
-
 
     @wraps(f)
     def decorated_function(*args, **kwargs):

--- a/renku/ui/service/views/graph.py
+++ b/renku/ui/service/views/graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/jobs.py
+++ b/renku/ui/service/views/jobs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/project.py
+++ b/renku/ui/service/views/project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/templates.py
+++ b/renku/ui/service/views/templates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/v1/__init__.py
+++ b/renku/ui/service/views/v1/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/v1/cache.py
+++ b/renku/ui/service/views/v1/cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/v1/templates.py
+++ b/renku/ui/service/views/v1/templates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/views/workflow_plans.py
+++ b/renku/ui/service/views/workflow_plans.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/renku/ui/service/worker.py
+++ b/renku/ui/service/worker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -58,7 +57,7 @@ def check_queues(queue_list):
     """Check if listening on specified queues is possible."""
     for queue in queue_list:
         if queue and queue not in QUEUES:
-            err_msg = "Invalid queue name: {0}\n\n" "Valid queue names: \n{1}".format(queue, "\n".join(QUEUES))
+            err_msg = "Invalid queue name: {}\n\nValid queue names: \n{}".format(queue, "\n".join(QUEUES))
             raise UsageError(err_msg)
 
 

--- a/renku/version.py
+++ b/renku/version.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/renku/version.py
+++ b/renku/version.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/api/test_activity.py
+++ b/tests/api/test_activity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/api/test_activity.py
+++ b/tests/api/test_activity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/api/test_dataset.py
+++ b/tests/api/test_dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -62,4 +61,4 @@ def test_list_dataset_files(project_with_datasets, dataset, files_paths):
         dataset = next(d for d in Dataset.list() if d.name == dataset)
 
         assert set(files_paths) == {f.path for f in dataset.files}
-        assert set(project.path / p for p in files_paths) == {d.full_path for d in dataset.files}
+        assert {project.path / p for p in files_paths} == {d.full_path for d in dataset.files}

--- a/tests/api/test_dataset.py
+++ b/tests/api/test_dataset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/api/test_parameter.py
+++ b/tests/api/test_parameter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/api/test_parameter.py
+++ b/tests/api/test_parameter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/api/test_plan.py
+++ b/tests/api/test_plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/api/test_plan.py
+++ b/tests/api/test_plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/api/test_rdfgraph.py
+++ b/tests/api/test_rdfgraph.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/api/test_rdfgraph.py
+++ b/tests/api/test_rdfgraph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/fixtures/__init__.py
+++ b/tests/cli/fixtures/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/fixtures/cli_gateway.py
+++ b/tests/cli/fixtures/cli_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/fixtures/cli_integration_datasets.py
+++ b/tests/cli/fixtures/cli_integration_datasets.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Swiss Data Science Center (SDSC)
+# Copyright 2022-2023 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/fixtures/cli_integration_datasets.py
+++ b/tests/cli/fixtures/cli_integration_datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2022 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/fixtures/cli_kg.py
+++ b/tests/cli/fixtures/cli_kg.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/fixtures/cli_old_projects.py
+++ b/tests/cli/fixtures/cli_old_projects.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/fixtures/cli_projects.py
+++ b/tests/cli/fixtures/cli_projects.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/fixtures/cli_providers.py
+++ b/tests/cli/fixtures/cli_providers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -147,9 +146,7 @@ def doi_responses():
                 ),
             )
 
-        response.add_callback(
-            method="GET", url=re.compile("{base_url}/.*".format(base_url=DOI_BASE_URL)), callback=doi_callback
-        )
+        response.add_callback(method="GET", url=re.compile(f"{DOI_BASE_URL}/.*"), callback=doi_callback)
 
         def version_callback(_):
             return (
@@ -162,7 +159,7 @@ def doi_responses():
 
         url_parts = list(urllib.parse.urlparse(base_url))
         url_parts[2] = posixpath.join(DATAVERSE_API_PATH, DATAVERSE_VERSION_API)
-        pattern = "{url}.*".format(url=urllib.parse.urlunparse(url_parts))
+        pattern = f"{urllib.parse.urlunparse(url_parts)}.*"
 
         response.add_callback(method="GET", url=re.compile(pattern), callback=version_callback)
         yield response

--- a/tests/cli/fixtures/cli_runner.py
+++ b/tests/cli/fixtures/cli_runner.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
 
 class Result(NamedTuple):
+    """CLI execution result."""
+
     exit_code: int
     activities: Union[None, "Activity", List["Activity"]]
 

--- a/tests/cli/fixtures/cli_runner.py
+++ b/tests/cli/fixtures/cli_runner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -24,7 +23,10 @@ import pytest
 if TYPE_CHECKING:
     from renku.domain_model.provenance.activity import Activity
 
-Result = NamedTuple("Result", [("exit_code", int), ("activities", Union[None, "Activity", List["Activity"]])])
+
+class Result(NamedTuple):
+    exit_code: int
+    activities: Union[None, "Activity", List["Activity"]]
 
 
 @pytest.fixture

--- a/tests/cli/fixtures/cli_workflow.py
+++ b/tests/cli/fixtures/cli_workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -416,7 +415,7 @@ def test_dataset_creator_is_invalid(runner, project, creator, field):
 @pytest.mark.parametrize("output_format", DATASETS_FORMATS.keys())
 def test_datasets_list_empty(output_format, runner, project):
     """Test listing without datasets."""
-    format_option = "--format={0}".format(output_format)
+    format_option = f"--format={output_format}"
     result = runner.invoke(cli, ["dataset", "ls", format_option])
     assert 0 == result.exit_code, format_result_exception(result)
 
@@ -427,7 +426,7 @@ def test_datasets_list_empty(output_format, runner, project):
 )
 def test_datasets_list_non_empty(output_format, runner, project, datadir_option, datadir):
     """Test listing with datasets."""
-    format_option = "--format={0}".format(output_format)
+    format_option = f"--format={output_format}"
     result = runner.invoke(cli, ["dataset", "create", "my-dataset"] + datadir_option)
     assert 0 == result.exit_code, format_result_exception(result)
     assert "OK" in result.output
@@ -593,7 +592,7 @@ def test_add_unicode_file(tmpdir, runner, project):
 
     filename = "fi1é-àèû爱ಠ_ಠ.txt"
     new_file = tmpdir.join(filename)
-    new_file.write(str("test"))
+    new_file.write("test")
 
     # add data
     result = runner.invoke(cli, ["dataset", "add", "--copy", "my-dataset", str(new_file)])
@@ -616,7 +615,7 @@ def test_multiple_file_to_dataset(tmpdir, runner, project):
 
     paths = []
     for i in range(3):
-        new_file = tmpdir.join("file_{0}".format(i))
+        new_file = tmpdir.join(f"file_{i}")
         new_file.write(str(i))
         paths.append(str(new_file))
 
@@ -809,7 +808,7 @@ def test_dataset_add_with_copy(tmpdir, runner, project):
     paths = []
     original_inodes = []
     for i in range(3):
-        new_file = tmpdir.join("file_{0}".format(i))
+        new_file = tmpdir.join(f"file_{i}")
         new_file.write(str(i))
         original_inodes.append(os.lstat(str(new_file))[stat.ST_INO])
         paths.append(str(new_file))
@@ -842,7 +841,7 @@ def test_dataset_add_many(tmpdir, runner, project):
 
     paths = []
     for i in range(1000):
-        new_file = tmpdir.join("file_{0}".format(i))
+        new_file = tmpdir.join(f"file_{i}")
         new_file.write(str(i))
         paths.append(str(new_file))
 
@@ -898,7 +897,7 @@ def test_datasets_ls_files_tabular_empty(runner, project):
 @pytest.mark.parametrize("output_format", DATASET_FILES_FORMATS.keys())
 def test_datasets_ls_files_check_exit_code(output_format, runner, project):
     """Test file listing exit codes for different formats."""
-    format_option = "--format={0}".format(output_format)
+    format_option = f"--format={output_format}"
     result = runner.invoke(cli, ["dataset", "ls-files", format_option])
     assert 0 == result.exit_code, format_result_exception(result)
 
@@ -964,8 +963,8 @@ def test_datasets_ls_files_json(runner, project, tmpdir, large_file):
     result = json.loads(result.output)
 
     assert len(result) == 2
-    file1 = next((f for f in result if f["path"].endswith("file_1")))
-    file2 = next((f for f in result if f["path"].endswith(large_file.name)))
+    file1 = next(f for f in result if f["path"].endswith("file_1"))
+    file2 = next(f for f in result if f["path"].endswith(large_file.name))
 
     assert not file1["is_lfs"]
     assert file2["is_lfs"]
@@ -1058,7 +1057,7 @@ def test_datasets_ls_files_tabular_creators(runner, project, directory_tree):
     assert creator is not None
 
     # check creators filters
-    result = runner.invoke(cli, ["dataset", "ls-files", "--creators={0}".format(creator)])
+    result = runner.invoke(cli, ["dataset", "ls-files", f"--creators={creator}"])
     assert 0 == result.exit_code, format_result_exception(result)
 
     # check output
@@ -1481,7 +1480,7 @@ def test_dataset_tag(tmpdir, runner, project, subdirectory):
 
     # create some data
     new_file = tmpdir.join("file")
-    new_file.write(str("test"))
+    new_file.write("test")
 
     # add data to dataset
     result = runner.invoke(cli, ["dataset", "add", "--copy", "my-dataset", str(new_file)], catch_exceptions=False)
@@ -1517,7 +1516,7 @@ def test_dataset_ls_tags(tmpdir, runner, project, form):
 
     # create some data
     new_file = tmpdir.join("file")
-    new_file.write(str("test"))
+    new_file.write("test")
 
     # add data to dataset
     result = runner.invoke(cli, ["dataset", "add", "--copy", "my-dataset", str(new_file)], catch_exceptions=False)
@@ -1534,9 +1533,7 @@ def test_dataset_ls_tags(tmpdir, runner, project, form):
     result = runner.invoke(cli, ["dataset", "tag", "my-dataset", "aBc9.34-11_55.t"], catch_exceptions=False)
     assert 0 == result.exit_code, format_result_exception(result)
 
-    result = runner.invoke(
-        cli, ["dataset", "ls-tags", "my-dataset", "--format={}".format(form)], catch_exceptions=False
-    )
+    result = runner.invoke(cli, ["dataset", "ls-tags", "my-dataset", f"--format={form}"], catch_exceptions=False)
     assert 0 == result.exit_code, format_result_exception(result)
     assert "1.0" in result.output
     assert "aBc9.34-11_55.t" in result.output
@@ -1553,7 +1550,7 @@ def test_dataset_rm_tag(tmpdir, runner, project, subdirectory):
 
     # create some data
     new_file = tmpdir.join("file")
-    new_file.write(str("test"))
+    new_file.write("test")
 
     # add data to dataset
     result = runner.invoke(cli, ["dataset", "add", "--copy", "my-dataset", str(new_file)], catch_exceptions=False)
@@ -1594,7 +1591,7 @@ def test_dataset_rm_tags_multiple(tmpdir, runner, project):
 
     # create some data
     new_file = tmpdir.join("file")
-    new_file.write(str("test"))
+    new_file.write("test")
 
     # add data to dataset
     result = runner.invoke(cli, ["dataset", "add", "--copy", "my-dataset", str(new_file)], catch_exceptions=False)
@@ -1623,7 +1620,7 @@ def test_dataset_rm_tags_failure(tmpdir, runner, project):
 
     # create some data
     new_file = tmpdir.join("file")
-    new_file.write(str("test"))
+    new_file.write("test")
 
     # add data to dataset
     result = runner.invoke(cli, ["dataset", "add", "--copy", "my-dataset", str(new_file)], catch_exceptions=False)
@@ -1697,7 +1694,7 @@ def test_add_protected_file(runner, project, filename, subdirectory):
 def test_add_non_protected_file(runner, project, tmpdir, filename, subdirectory):
     """Check adding an 'almost' protected file."""
     new_file = tmpdir.join(filename)
-    new_file.write(str("test"))
+    new_file.write("test")
 
     result = runner.invoke(cli, ["dataset", "add", "--copy", "-c", "my-dataset1", str(new_file)])
 

--- a/tests/cli/test_errors.py
+++ b/tests/cli/test_errors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2019- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_gc.py
+++ b/tests/cli/test_gc.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_gc.py
+++ b/tests/cli/test_gc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_gitignore.py
+++ b/tests/cli/test_gitignore.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_gitignore.py
+++ b/tests/cli/test_gitignore.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_graph.py
+++ b/tests/cli/test_graph.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_graph.py
+++ b/tests/cli/test_graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_indirect.py
+++ b/tests/cli/test_indirect.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_indirect.py
+++ b/tests/cli/test_indirect.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -65,7 +65,7 @@ def test_template_selection_helpers(isolated_runner):
 
     stripped_output = " ".join(result.output.split())
 
-    assert "Please choose a template by typing its index:" in stripped_output
+    assert "Please choose a template by typing its number:" in stripped_output
 
     assert "1 python-minimal" in stripped_output
     assert "2 R-minimal" in stripped_output

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_integration_cli.py
+++ b/tests/cli/test_integration_cli.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_integration_cli.py
+++ b/tests/cli/test_integration_cli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -393,8 +392,8 @@ def test_dataset_import_renkulab_dataset_with_image(runner, project, with_inject
     with with_injection():
         dataset = [d for d in DatasetGateway().get_all_active_datasets()][0]
     assert 2 == len(dataset.images)
-    img1 = next((i for i in dataset.images if i.position == 1))
-    img2 = next((i for i in dataset.images if i.position == 2))
+    img1 = next(i for i in dataset.images if i.position == 1)
+    img2 = next(i for i in dataset.images if i.position == 2)
 
     assert img1.content_url == "https://example.com/image1.jpg"
     assert img2.content_url.endswith("/2.png")
@@ -747,7 +746,7 @@ def test_dataset_export_upload_multiple(
     # create data file
     paths = []
     for i in range(3):
-        new_file = tmpdir.join("file_{0}".format(i))
+        new_file = tmpdir.join(f"file_{i}")
         new_file.write(str(i))
         paths.append(str(new_file))
 
@@ -1633,7 +1632,7 @@ def test_files_are_tracked_in_lfs(runner, project, no_lfs_size_limit):
         ],
     )
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
-    path = "data/dataset/{}".format(filename)
+    path = f"data/dataset/{filename}"
     assert path in subprocess.check_output(["git", "lfs", "ls-files"]).decode()
 
 
@@ -1701,7 +1700,10 @@ def test_check_disk_space(runner, project, monkeypatch, url):
 
     def disk_usage(_):
         """Mocked response."""
-        Usage = NamedTuple("Usage", [("free", int)])
+
+        class Usage(NamedTuple):
+            free: int
+
         return Usage(free=0)
 
     monkeypatch.setattr(shutil, "disk_usage", disk_usage)

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_isolation.py
+++ b/tests/cli/test_isolation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_isolation.py
+++ b/tests/cli/test_isolation.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_merge.py
+++ b/tests/cli/test_merge.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_merge.py
+++ b/tests/cli/test_merge.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_migrate.py
+++ b/tests/cli/test_migrate.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_migrate.py
+++ b/tests/cli/test_migrate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_move.py
+++ b/tests/cli/test_move.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_move.py
+++ b/tests/cli/test_move.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_output_option.py
+++ b/tests/cli/test_output_option.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_output_option.py
+++ b/tests/cli/test_output_option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_range_queries.py
+++ b/tests/cli/test_range_queries.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_range_queries.py
+++ b/tests/cli/test_range_queries.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_rerun.py
+++ b/tests/cli/test_rerun.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_rerun.py
+++ b/tests/cli/test_rerun.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_rollback.py
+++ b/tests/cli/test_rollback.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_rollback.py
+++ b/tests/cli/test_rollback.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -47,7 +46,7 @@ def test_run_many_args(project, run):
     os.mkdir("files")
     output = "output.txt"
     for i in range(103):
-        os.system("touch files/{}.txt".format(i))
+        os.system(f"touch files/{i}.txt")
     project.repository.add("files/")
     project.repository.commit("add many files")
 

--- a/tests/cli/test_save.py
+++ b/tests/cli/test_save.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_save.py
+++ b/tests/cli/test_save.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_service.py
+++ b/tests/cli/test_service.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_session.py
+++ b/tests/cli/test_session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_template.py
+++ b/tests/cli/test_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_template.py
+++ b/tests/cli/test_template.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_workflow.py
+++ b/tests/cli/test_workflow.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_workflow.py
+++ b/tests/cli/test_workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/cli/test_workflow_file.py
+++ b/tests/cli/test_workflow_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/cli/test_workflow_file.py
+++ b/tests/cli/test_workflow_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/__init__.py
+++ b/tests/core/commands/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/__init__.py
+++ b/tests/core/commands/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/providers/test_dataverse.py
+++ b/tests/core/commands/providers/test_dataverse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/providers/test_dataverse.py
+++ b/tests/core/commands/providers/test_dataverse.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_cli.py
+++ b/tests/core/commands/test_cli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -122,7 +121,7 @@ def test_streams(runner, project, capsys, no_lfs_warning):
                 finally:
                     sys.stdin, sys.stdout = old_stdin, old_stdout
 
-    with open("result.txt", "r") as f:
+    with open("result.txt") as f:
         assert f.read().strip() == "second"
 
     result = runner.invoke(cli, ["workflow", "export", workflow_name])
@@ -199,7 +198,7 @@ def test_streams_and_args_names(runner, project, capsys, no_lfs_warning):
             finally:
                 sys.stdout = old_stdout
 
-    with open("lalala", "r") as f:
+    with open("lalala") as f:
         assert f.read().strip() == "lalala"
 
     result = runner.invoke(cli, ["status"], catch_exceptions=False)
@@ -593,7 +592,7 @@ def test_input_directory(runner, project, run, no_lfs_warning):
 
     result = runner.invoke(cli, ["workflow", "inputs"])
     assert 0 == result.exit_code, format_result_exception(result)
-    assert set(str(p.relative_to(cwd)) for p in inputs.rglob("*") if p.name != ".gitkeep") == set(
+    assert {str(p.relative_to(cwd)) for p in inputs.rglob("*") if p.name != ".gitkeep"} == set(
         result.output.strip().split("\n")
     )
 

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_dataset.py
+++ b/tests/core/commands/test_dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/test_doctor.py
+++ b/tests/core/commands/test_doctor.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_doctor.py
+++ b/tests/core/commands/test_doctor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/test_graph.py
+++ b/tests/core/commands/test_graph.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_graph.py
+++ b/tests/core/commands/test_graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/test_indirect.py
+++ b/tests/core/commands/test_indirect.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/test_indirect.py
+++ b/tests/core/commands/test_indirect.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_log.py
+++ b/tests/core/commands/test_log.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_log.py
+++ b/tests/core/commands/test_log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -200,7 +199,7 @@ def test_log_dataset_create_complex(mocker):
     assert not entry.details.files_added
     assert not entry.details.files_removed
     assert not entry.details.creators_removed
-    assert set(["a", "b"]) == set(entry.details.keywords_added)
+    assert {"a", "b"} == set(entry.details.keywords_added)
     assert not entry.details.keywords_removed
     assert ["./img/img1.png"] == entry.details.images_changed_to
     assert not entry.details.source
@@ -255,7 +254,7 @@ def test_log_dataset_add_create(mocker):
     assert "new-title" == entry.details.title_changed
     assert "new-description" == entry.details.description_changed
     assert not entry.details.creators_added
-    assert set(["file_b", "file_a"]) == set(entry.details.files_added)
+    assert {"file_b", "file_a"} == set(entry.details.files_added)
     assert not entry.details.files_removed
     assert not entry.details.creators_removed
     assert not entry.details.keywords_added
@@ -312,7 +311,7 @@ def test_log_dataset_import(mocker):
     assert "new-title" == entry.details.title_changed
     assert "new-description" == entry.details.description_changed
     assert not entry.details.creators_added
-    assert set(["file_b", "file_a"]) == set(entry.details.files_added)
+    assert {"file_b", "file_a"} == set(entry.details.files_added)
     assert not entry.details.files_removed
     assert not entry.details.creators_removed
     assert not entry.details.keywords_added

--- a/tests/core/commands/test_merge.py
+++ b/tests/core/commands/test_merge.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_merge.py
+++ b/tests/core/commands/test_merge.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -299,7 +298,7 @@ def test_merge_project_both_changed():
 
     result = GitMerger().merge_projects(local_project, remote_project, base_project)
 
-    assert set(result.keywords) == set(["datascience", "awesome"])
+    assert set(result.keywords) == {"datascience", "awesome"}
     assert "9" == result.version
     assert result.agent_version
 

--- a/tests/core/commands/test_plan_factory.py
+++ b/tests/core/commands/test_plan_factory.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_plan_factory.py
+++ b/tests/core/commands/test_plan_factory.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/test_renku.py
+++ b/tests/core/commands/test_renku.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_renku.py
+++ b/tests/core/commands/test_renku.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/test_serialization.py
+++ b/tests/core/commands/test_serialization.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_serialization.py
+++ b/tests/core/commands/test_serialization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/test_status.py
+++ b/tests/core/commands/test_status.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_status.py
+++ b/tests/core/commands/test_status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/test_storage.py
+++ b/tests/core/commands/test_storage.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_storage.py
+++ b/tests/core/commands/test_storage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/commands/test_workflow.py
+++ b/tests/core/commands/test_workflow.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/commands/test_workflow.py
+++ b/tests/core/commands/test_workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/fixtures/__init__.py
+++ b/tests/core/fixtures/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/fixtures/core_database.py
+++ b/tests/core/fixtures/core_database.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/fixtures/core_datasets.py
+++ b/tests/core/fixtures/core_datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/fixtures/core_models.py
+++ b/tests/core/fixtures/core_models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/fixtures/core_plugins.py
+++ b/tests/core/fixtures/core_plugins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -30,7 +29,7 @@ def dummy_pre_run_plugin_hook():
     """A dummy hook to be used with the renku run plugin."""
     from renku.core.plugin import hookimpl
 
-    class _PreRun(object):
+    class _PreRun:
         """CmdlineTool Hook implementation namespace."""
 
         called = 0
@@ -48,7 +47,7 @@ def dummy_plan_plugin_hook():
     """A dummy hook to be used with the renku run plugin for plans."""
     from renku.core.plugin import hookimpl
 
-    class _PlanPlugin(object):
+    class _PlanPlugin:
         """CmdlineTool Hook implementation namespace."""
 
         called = 0
@@ -68,7 +67,7 @@ def dummy_activity_plugin_hook():
     """A dummy hook to be used with the renku run plugin."""
     from renku.core.plugin import hookimpl
 
-    class _ActivityAnnotations(object):
+    class _ActivityAnnotations:
         """CmdlineTool Hook implementation namespace."""
 
         @hookimpl

--- a/tests/core/fixtures/core_projects.py
+++ b/tests/core/fixtures/core_projects.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/fixtures/core_serialization.py
+++ b/tests/core/fixtures/core_serialization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/fixtures/core_workflow.py
+++ b/tests/core/fixtures/core_workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/incubation/__init__.py
+++ b/tests/core/incubation/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/incubation/__init__.py
+++ b/tests/core/incubation/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/incubation/test_communication.py
+++ b/tests/core/incubation/test_communication.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/incubation/test_communication.py
+++ b/tests/core/incubation/test_communication.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/management/test_repository.py
+++ b/tests/core/management/test_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/management/test_repository.py
+++ b/tests/core/management/test_repository.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/management/test_storage.py
+++ b/tests/core/management/test_storage.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/management/test_storage.py
+++ b/tests/core/management/test_storage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/metadata/__init__.py
+++ b/tests/core/metadata/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/metadata/__init__.py
+++ b/tests/core/metadata/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/metadata/test_activity_gateway.py
+++ b/tests/core/metadata/test_activity_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/metadata/test_activity_gateway.py
+++ b/tests/core/metadata/test_activity_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/metadata/test_database.py
+++ b/tests/core/metadata/test_database.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/metadata/test_database.py
+++ b/tests/core/metadata/test_database.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/metadata/test_immutable.py
+++ b/tests/core/metadata/test_immutable.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/metadata/test_immutable.py
+++ b/tests/core/metadata/test_immutable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/metadata/test_plan_gateway.py
+++ b/tests/core/metadata/test_plan_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/metadata/test_plan_gateway.py
+++ b/tests/core/metadata/test_plan_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/metadata/test_project_gateway.py
+++ b/tests/core/metadata/test_project_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/metadata/test_project_gateway.py
+++ b/tests/core/metadata/test_project_gateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/metadata/test_repository.py
+++ b/tests/core/metadata/test_repository.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/metadata/test_repository.py
+++ b/tests/core/metadata/test_repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/models/__init__.py
+++ b/tests/core/models/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/models/__init__.py
+++ b/tests/core/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/models/test_activity.py
+++ b/tests/core/models/test_activity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/models/test_activity.py
+++ b/tests/core/models/test_activity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/models/test_agents.py
+++ b/tests/core/models/test_agents.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2018-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/models/test_agents.py
+++ b/tests/core/models/test_agents.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/models/test_calamus.py
+++ b/tests/core/models/test_calamus.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/models/test_calamus.py
+++ b/tests/core/models/test_calamus.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/models/test_git.py
+++ b/tests/core/models/test_git.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2018-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/models/test_git.py
+++ b/tests/core/models/test_git.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2022- Swiss Data Science Center (SDSC)
+# Copyright 2018-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/models/test_shacl_schema.py
+++ b/tests/core/models/test_shacl_schema.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/models/test_shacl_schema.py
+++ b/tests/core/models/test_shacl_schema.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -42,7 +41,7 @@ def test_dataset_shacl(tmpdir, runner, project):
 
     paths = []
     for i in range(3):
-        new_file = tmpdir.join("file_{0}".format(i))
+        new_file = tmpdir.join(f"file_{i}")
         new_file.write(str(i))
         paths.append(str(new_file))
 

--- a/tests/core/models/test_template.py
+++ b/tests/core/models/test_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/models/test_template.py
+++ b/tests/core/models/test_template.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/plugins/__init__.py
+++ b/tests/core/plugins/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/plugins/__init__.py
+++ b/tests/core/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/plugins/test_run.py
+++ b/tests/core/plugins/test_run.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/plugins/test_run.py
+++ b/tests/core/plugins/test_run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/plugins/test_session.py
+++ b/tests/core/plugins/test_session.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/plugins/test_session.py
+++ b/tests/core/plugins/test_session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/plugins/test_workflow.py
+++ b/tests/core/plugins/test_workflow.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/plugins/test_workflow.py
+++ b/tests/core/plugins/test_workflow.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/test_activity.py
+++ b/tests/core/test_activity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/test_activity.py
+++ b/tests/core/test_activity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/test_plan.py
+++ b/tests/core/test_plan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/test_project_context.py
+++ b/tests/core/test_project_context.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/test_project_context.py
+++ b/tests/core/test_project_context.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/test_template.py
+++ b/tests/core/test_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/test_template.py
+++ b/tests/core/test_template.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/utils/__init__.py
+++ b/tests/core/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/utils/__init__.py
+++ b/tests/core/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/utils/test_git.py
+++ b/tests/core/utils/test_git.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/utils/test_git.py
+++ b/tests/core/utils/test_git.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/utils/test_os.py
+++ b/tests/core/utils/test_os.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/utils/test_os.py
+++ b/tests/core/utils/test_os.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/utils/test_utils.py
+++ b/tests/core/utils/test_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/utils/test_utils.py
+++ b/tests/core/utils/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/workflow/__init__.py
+++ b/tests/core/workflow/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/workflow/__init__.py
+++ b/tests/core/workflow/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/core/workflow/test_workflow_file.py
+++ b/tests/core/workflow/test_workflow_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2017-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/core/workflow/test_workflow_file.py
+++ b/tests/core/workflow/test_workflow_file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/fixtures/common.py
+++ b/tests/fixtures/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/fixtures/communication.py
+++ b/tests/fixtures/communication.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/fixtures/domain_models.py
+++ b/tests/fixtures/domain_models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/fixtures/repository.py
+++ b/tests/fixtures/repository.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/fixtures/runners.py
+++ b/tests/fixtures/runners.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/fixtures/session.py
+++ b/tests/fixtures/session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/fixtures/templates.py
+++ b/tests/fixtures/templates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/__init__.py
+++ b/tests/service/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/__init__.py
+++ b/tests/service/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/cache/test_cache.py
+++ b/tests/service/cache/test_cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -40,9 +39,9 @@ def test_service_cache_get_users(svc_client_cache):
     """Test getting multiple users."""
     client, _, cache = svc_client_cache
 
-    expected_users = set([cache.ensure_user({"user_id": uuid.uuid4().hex}).user_id for _ in range(10)])
+    expected_users = {cache.ensure_user({"user_id": uuid.uuid4().hex}).user_id for _ in range(10)}
 
-    received_users = set([user.user_id for user in cache.get_users()])
+    received_users = {user.user_id for user in cache.get_users()}
 
     assert expected_users.issubset(received_users)
 
@@ -169,26 +168,26 @@ def test_service_cache_set_files(svc_client_cache):
         for _ in range(10)
     ]
 
-    expected = set([file_["file_name"] for file_ in files])
+    expected = {file_["file_name"] for file_ in files}
 
     received_files = cache.set_files(user, files)
-    received_names = set([file_.file_name for file_ in received_files])
+    received_names = {file_.file_name for file_ in received_files}
 
-    files_age = set([file_.age for file_ in received_files])
+    files_age = {file_.age for file_ in received_files}
     assert {0} == files_age
 
-    files_ttl_exp = set([file_.ttl_expired() for file_ in received_files])
+    files_ttl_exp = {file_.ttl_expired() for file_ in received_files}
     assert {False} == files_ttl_exp
 
     time.sleep(2)
     os.environ["RENKU_SVC_CLEANUP_TTL_FILES"] = "1"
-    files_age = set([file_.age for file_ in received_files])
+    files_age = {file_.age for file_ in received_files}
     assert {2} == files_age
 
-    files_ttl_exp = set([file_.ttl_expired() for file_ in received_files])
+    files_ttl_exp = {file_.ttl_expired() for file_ in received_files}
     assert {True} == files_ttl_exp
 
-    received_users = set([file_.user_id for file_ in received_files])
+    received_users = {file_.user_id for file_ in received_files}
 
     assert expected.issubset(received_names)
     assert user.user_id in received_users

--- a/tests/service/cache/test_cache.py
+++ b/tests/service/cache/test_cache.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 -Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/controllers/test_templates_create_project.py
+++ b/tests/service/controllers/test_templates_create_project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/controllers/test_templates_create_project.py
+++ b/tests/service/controllers/test_templates_create_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 -Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/controllers/test_templates_read_manifest.py
+++ b/tests/service/controllers/test_templates_read_manifest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/controllers/test_templates_read_manifest.py
+++ b/tests/service/controllers/test_templates_read_manifest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 -Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/controllers/utils/test_project_clone.py
+++ b/tests/service/controllers/utils/test_project_clone.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/controllers/utils/test_project_clone.py
+++ b/tests/service/controllers/utils/test_project_clone.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 -Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/controllers/utils/test_remote_project.py
+++ b/tests/service/controllers/utils/test_remote_project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/controllers/utils/test_remote_project.py
+++ b/tests/service/controllers/utils/test_remote_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 -Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/fixtures/__init__.py
+++ b/tests/service/fixtures/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/fixtures/service_cache.py
+++ b/tests/service/fixtures/service_cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/fixtures/service_client.py
+++ b/tests/service/fixtures/service_client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -137,7 +136,7 @@ def identity_headers():
     headers = {
         "Content-Type": "application/json",
         "Renku-User": jwt.encode(jwt_data, JWT_TOKEN_SECRET, algorithm="HS256"),
-        "Authorization": "Bearer {0}".format(os.getenv("IT_OAUTH_GIT_TOKEN")),
+        "Authorization": "Bearer {}".format(os.getenv("IT_OAUTH_GIT_TOKEN")),
     }
 
     return headers
@@ -210,10 +209,10 @@ def svc_client_templates_creation(svc_client_with_templates):
     # cleanup by invoking the GitLab delete API
     # TODO: consider using the project delete endpoint once implemented
     def remove_project():
-        project_slug = "{0}/{1}".format(payload["project_namespace"], normalize_to_ascii(payload["project_name"]))
+        project_slug = "{}/{}".format(payload["project_namespace"], normalize_to_ascii(payload["project_name"]))
 
         project_slug_encoded = urllib.parse.quote(project_slug, safe="")
-        project_delete_url = "{0}/api/v4/projects/{1}".format(payload["project_repository"], project_slug_encoded)
+        project_delete_url = "{}/api/v4/projects/{}".format(payload["project_repository"], project_slug_encoded)
 
         requests.delete(url=project_delete_url, headers=authentication_headers)
 

--- a/tests/service/fixtures/service_controllers.py
+++ b/tests/service/fixtures/service_controllers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/fixtures/service_data.py
+++ b/tests/service/fixtures/service_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/fixtures/service_endpoints.py
+++ b/tests/service/fixtures/service_endpoints.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/fixtures/service_integration.py
+++ b/tests/service/fixtures/service_integration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -248,7 +247,7 @@ def local_remote_repository(svc_client, tmp_path, mock_redis, identity_headers, 
         finally:
             try:
                 shutil.rmtree(home)
-            except OSError:  # noqa: B014
+            except OSError:
                 pass
 
             payload = {"git_url": f"file://{remote_repo_path}", "depth": PROJECT_CLONE_NO_DEPTH}
@@ -268,12 +267,12 @@ def local_remote_repository(svc_client, tmp_path, mock_redis, identity_headers, 
 
         try:
             shutil.rmtree(remote_repo_path)
-        except OSError:  # noqa: B014
+        except OSError:
             pass
 
         try:
             shutil.rmtree(remote_repo_checkout_path)
-        except OSError:  # noqa: B014
+        except OSError:
             pass
 
 

--- a/tests/service/fixtures/service_jobs.py
+++ b/tests/service/fixtures/service_jobs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/fixtures/service_projects.py
+++ b/tests/service/fixtures/service_projects.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -79,7 +78,7 @@ def it_remote_repo_url_temp_branch(it_remote_repo_url):
         # NOTE: create temporary branch and push it
         git_url = urlparse(it_remote_repo_url)
 
-        url = "oauth2:{0}@{1}".format(os.getenv("IT_OAUTH_GIT_TOKEN"), git_url.netloc)
+        url = "oauth2:{}@{}".format(os.getenv("IT_OAUTH_GIT_TOKEN"), git_url.netloc)
         git_url = git_url._replace(netloc=url).geturl()
         repo = Repository.clone_from(url=git_url, path=tempdir)
         origin = repo.remotes["origin"]

--- a/tests/service/fixtures/service_scheduler.py
+++ b/tests/service/fixtures/service_scheduler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/jobs/test_config.py
+++ b/tests/service/jobs/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/jobs/test_datasets.py
+++ b/tests/service/jobs/test_datasets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/jobs/test_datasets.py
+++ b/tests/service/jobs/test_datasets.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/jobs/test_jobs.py
+++ b/tests/service/jobs/test_jobs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/jobs/test_jobs.py
+++ b/tests/service/jobs/test_jobs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/jobs/test_project.py
+++ b/tests/service/jobs/test_project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/jobs/test_project.py
+++ b/tests/service/jobs/test_project.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/scheduler/test_scheduler.py
+++ b/tests/service/scheduler/test_scheduler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2021 Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/serializers/test_headers.py
+++ b/tests/service/serializers/test_headers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/serializers/test_headers.py
+++ b/tests/service/serializers/test_headers.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/__init__.py
+++ b/tests/service/views/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2022- Swiss Data Science Center (SDSC)
+# Copyright 2017-2023- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/__init__.py
+++ b/tests/service/views/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017-2022- Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_api_versions_views.py
+++ b/tests/service/views/test_api_versions_views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2022 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_api_versions_views.py
+++ b/tests/service/views/test_api_versions_views.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 -Swiss Data Science Center (SDSC)
+# Copyright 2022-2023 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/test_cache_views.py
+++ b/tests/service/views/test_cache_views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_cache_views.py
+++ b/tests/service/views/test_cache_views.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/test_config_views.py
+++ b/tests/service/views/test_config_views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_dataset_views.py
+++ b/tests/service/views/test_dataset_views.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/test_dataset_views.py
+++ b/tests/service/views/test_dataset_views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -120,7 +119,7 @@ def test_remote_create_dataset_view(svc_client_cache, it_remote_repo_url):
 
     payload = {
         "git_url": it_remote_repo_url,
-        "name": "{0}".format(uuid.uuid4().hex),
+        "name": f"{uuid.uuid4().hex}",
     }
 
     response = svc_client.post("/datasets.create", data=json.dumps(payload), headers=headers)
@@ -137,7 +136,7 @@ def test_delay_create_dataset_view(svc_client_cache, it_remote_repo_url):
 
     payload = {
         "git_url": it_remote_repo_url,
-        "name": "{0}".format(uuid.uuid4().hex),
+        "name": f"{uuid.uuid4().hex}",
         "is_delayed": True,
     }
 

--- a/tests/service/views/test_exceptions.py
+++ b/tests/service/views/test_exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_exceptions.py
+++ b/tests/service/views/test_exceptions.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 -Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/test_graph.py
+++ b/tests/service/views/test_graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_graph_views.py
+++ b/tests/service/views/test_graph_views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2020 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_jobs_views.py
+++ b/tests/service/views/test_jobs_views.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/test_jobs_views.py
+++ b/tests/service/views/test_jobs_views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
@@ -212,9 +211,9 @@ def test_job_details_by_user(svc_client_with_user):
     }
 
     for job in jobs:
-        response = svc_client.get("/jobs/{0}".format(job["job_id"]), headers=headers)
+        response = svc_client.get("/jobs/{}".format(job["job_id"]), headers=headers)
         assert response
         assert job["job_id"] == response.json["result"]["job_id"]
 
-        response = svc_client.get("/jobs/{0}".format(job["job_id"]), headers=excluded_user_headers)
+        response = svc_client.get("/jobs/{}".format(job["job_id"]), headers=excluded_user_headers)
         assert response.json["result"] is None

--- a/tests/service/views/test_project_views.py
+++ b/tests/service/views/test_project_views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_project_views.py
+++ b/tests/service/views/test_project_views.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/test_templates_views.py
+++ b/tests/service/views/test_templates_views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_templates_views.py
+++ b/tests/service/views/test_templates_views.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/test_utils.py
+++ b/tests/service/views/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_utils.py
+++ b/tests/service/views/test_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/test_version_views.py
+++ b/tests/service/views/test_version_views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_version_views.py
+++ b/tests/service/views/test_version_views.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 -Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/test_workflow_plan_views.py
+++ b/tests/service/views/test_workflow_plan_views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/test_workflow_plan_views.py
+++ b/tests/service/views/test_workflow_plan_views.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/service/views/v1_0/test_cache_views_1_0.py
+++ b/tests/service/views/v1_0/test_cache_views_1_0.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2019-2022 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/service/views/v1_0/test_cache_views_1_0.py
+++ b/tests/service/views/v1_0/test_cache_views_1_0.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019-2022 - Swiss Data Science Center (SDSC)
+# Copyright 2019-2023 - Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020-2022 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2022 -Swiss Data Science Center (SDSC)
+# Copyright 2020-2023 -Swiss Data Science Center (SDSC)
 # A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #


### PR DESCRIPTION
closes #3247 

Also bumps copyright headers.

I split it into several commits to make it easier to review (manual changes, changes done by pyupgrade to renku/ and tests/ and copyright header updates)
