### PR TITLE
fix(core): update template checksum when updating Dockerfile

### DIFF
--- a/renku/command/clone.py
+++ b/renku/command/clone.py
@@ -62,8 +62,8 @@ def _project_clone(
         Tuple of cloned ``Repository`` and whether it's a Renku project or not.
     """
     from renku.command.mergetool import setup_mergetool
-    from renku.core.migration.migrate import is_renku_project
     from renku.core.util.git import clone_renku_repository
+    from renku.core.util.metadata import is_renku_project
 
     install_lfs = project_context.external_storage_requested
 

--- a/renku/command/migrate.py
+++ b/renku/command/migrate.py
@@ -177,13 +177,9 @@ def check_project():
 
 
 def _check_project():
-    from renku.core.migration.migrate import (
-        is_docker_update_possible,
-        is_migration_required,
-        is_project_unsupported,
-        is_renku_project,
-    )
+    from renku.core.migration.migrate import is_docker_update_possible, is_migration_required, is_project_unsupported
     from renku.core.template.usecase import check_for_template_update
+    from renku.core.util.metadata import is_renku_project
 
     if not is_renku_project():
         return NON_RENKU_REPOSITORY

--- a/renku/command/rollback.py
+++ b/renku/command/rollback.py
@@ -149,10 +149,10 @@ def _get_modifications_from_diff(diff):
             continue
 
         # normal file
-        if diff_index.change_type == "A":
+        if diff_index.added:
             modifications["files"]["removed"].append(entry)
 
-        elif diff_index.change_type == "D":
+        elif diff_index.deleted:
             modifications["files"]["restored"].append(entry)
         else:
             modifications["files"]["modified"].append(entry)

--- a/renku/command/schema/activity.py
+++ b/renku/command/schema/activity.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 """Activity JSON-LD schema."""
 
-from marshmallow import EXCLUDE
+from marshmallow import EXCLUDE, pre_dump
 
 from renku.command.schema.agent import PersonSchema, SoftwareAgentSchema
 from renku.command.schema.annotation import AnnotationSchema
@@ -123,6 +123,28 @@ class ActivitySchema(JsonLDSchema):
     project_id = fields.IRI(renku.hasActivity, reverse=True)
     started_at_time = fields.DateTime(prov.startedAtTime, add_value_types=True)
     usages = Nested(prov.qualifiedUsage, UsageSchema, many=True)
+
+    @pre_dump(pass_many=True)
+    def removes_ms(self, objs, many, **kwargs):
+        """Remove milliseconds from datetimes.
+
+        Note: since DateField uses `strftime` as format, which only supports timezone info without a colon
+        e.g. `+0100` instead of `+01:00`, we have to deal with milliseconds manually instead of using a format string.
+        """
+
+        def _replace_times(obj):
+            obj.unfreeze()
+            obj.started_at_time = obj.started_at_time.replace(microsecond=0)
+            obj.ended_at_time = obj.ended_at_time.replace(microsecond=0)
+            obj.freeze()
+
+        if many:
+            for obj in objs:
+                _replace_times(obj)
+            return objs
+
+        _replace_times(objs)
+        return objs
 
 
 class WorkflowFileActivityCollectionSchema(JsonLDSchema):

--- a/renku/command/schema/composite_plan.py
+++ b/renku/command/schema/composite_plan.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 """Represent a group of run templates."""
 
-from marshmallow import EXCLUDE
+from marshmallow import EXCLUDE, pre_dump
 
 from renku.command.schema.agent import PersonSchema
 from renku.command.schema.calamus import JsonLDSchema, Nested, fields, prov, renku, schema
@@ -49,3 +49,27 @@ class CompositePlanSchema(JsonLDSchema):
     project_id = fields.IRI(renku.hasPlan, reverse=True)
     plans = Nested(renku.hasSubprocess, [PlanSchema, "CompositePlanSchema"], many=True)
     links = Nested(renku.workflowLinks, [ParameterLinkSchema], many=True, load_default=None)
+
+    @pre_dump(pass_many=True)
+    def removes_ms(self, objs, many, **kwargs):
+        """Remove milliseconds from datetimes.
+
+        Note: since DateField uses `strftime` as format, which only supports timezone info without a colon
+        e.g. `+0100` instead of `+01:00`, we have to deal with milliseconds manually instead of using a format string.
+        """
+
+        def _replace_times(obj):
+            obj.unfreeze()
+            obj.date_created = obj.date_created.replace(microsecond=0)
+            obj.date_modified = obj.date_modified.replace(microsecond=0)
+            if obj.date_removed:
+                obj.date_removed = obj.date_removed.replace(microsecond=0)
+            obj.freeze()
+
+        if many:
+            for obj in objs:
+                _replace_times(obj)
+            return objs
+
+        _replace_times(objs)
+        return objs

--- a/renku/command/schema/dataset.py
+++ b/renku/command/schema/dataset.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 """Datasets JSON-LD schemes."""
 
-from marshmallow import EXCLUDE
+from marshmallow import EXCLUDE, pre_dump
 
 from renku.command.schema.agent import PersonSchema
 from renku.command.schema.annotation import AnnotationSchema
@@ -68,6 +68,27 @@ class DatasetTagSchema(JsonLDSchema):
     description = fields.String(schema.description, load_default=None)
     id = fields.Id()
     name = fields.String(schema.name)
+
+    @pre_dump(pass_many=True)
+    def removes_ms(self, objs, many, **kwargs):
+        """Remove milliseconds from datetimes.
+
+        Note: since DateField uses `strftime` as format, which only supports timezone info without a colon
+        e.g. `+0100` instead of `+01:00`, we have to deal with milliseconds manually instead of using a format string.
+        """
+
+        def _replace_times(obj):
+            obj.unfreeze()
+            obj.date_created = obj.date_created.replace(microsecond=0)
+            obj.freeze()
+
+        if many:
+            for obj in objs:
+                _replace_times(obj)
+            return objs
+
+        _replace_times(objs)
+        return objs
 
 
 class LanguageSchema(JsonLDSchema):
@@ -134,6 +155,27 @@ class DatasetFileSchema(JsonLDSchema):
     is_external = fields.Boolean(renku.external, load_default=False)
     source = fields.String(renku.source, load_default=None)
 
+    @pre_dump(pass_many=True)
+    def removes_ms(self, objs, many, **kwargs):
+        """Remove milliseconds from datetimes.
+
+        Note: since DateField uses `strftime` as format, which only supports timezone info without a colon
+        e.g. `+0100` instead of `+01:00`, we have to deal with milliseconds manually instead of using a format string.
+        """
+
+        def _replace_times(obj):
+            obj.date_added = obj.date_added.replace(microsecond=0)
+            if obj.date_removed:
+                obj.date_removed = obj.date_removed.replace(microsecond=0)
+
+        if many:
+            for obj in objs:
+                _replace_times(obj)
+            return objs
+
+        _replace_times(objs)
+        return objs
+
 
 class DatasetSchema(JsonLDSchema):
     """Dataset schema."""
@@ -168,3 +210,30 @@ class DatasetSchema(JsonLDSchema):
     same_as = Nested(schema.sameAs, UrlSchema, load_default=None)
     title = fields.String(schema.name)
     version = fields.String(schema.version, load_default=None)
+
+    @pre_dump(pass_many=True)
+    def removes_ms(self, objs, many, **kwargs):
+        """Remove milliseconds from datetimes.
+
+        Note: since DateField uses `strftime` as format, which only supports timezone info without a colon
+        e.g. `+0100` instead of `+01:00`, we have to deal with milliseconds manually instead of using a format string.
+        """
+
+        def _replace_times(obj):
+            obj.unfreeze()
+            if obj.date_created:
+                obj.date_created = obj.date_created.replace(microsecond=0)
+            if obj.date_removed:
+                obj.date_removed = obj.date_removed.replace(microsecond=0)
+            if obj.date_published:
+                obj.date_published = obj.date_published.replace(microsecond=0)
+            obj.date_modified = obj.date_modified.replace(microsecond=0)
+            obj.freeze()
+
+        if many:
+            for obj in objs:
+                _replace_times(obj)
+            return objs
+
+        _replace_times(objs)
+        return objs

--- a/renku/core/git.py
+++ b/renku/core/git.py
@@ -207,6 +207,6 @@ def ensure_clean(ignore_std_streams=False):
         if dirty_paths - set(mapped_streams.values()):
             _clean_streams(repository, mapped_streams)
             raise errors.DirtyRepository(repository)
-    elif repository.is_dirty():
+    elif repository.is_dirty(untracked_files=False):
         _clean_streams(repository, mapped_streams)
         raise errors.DirtyRepository(repository)

--- a/renku/core/migration/m_0005__2_cwl.py
+++ b/renku/core/migration/m_0005__2_cwl.py
@@ -107,7 +107,7 @@ def _migrate_old_workflows(migration_context, strict):
 
                 repository.add(cwl_file, path)
 
-                if repository.is_dirty():
+                if repository.is_dirty(untracked_files=False):
                     commit_msg = "renku migrate: committing migrated workflow"
                     committer = Actor(name=f"renku {__version__}", email=version_url)
                     repository.commit(commit_msg + project_context.transaction_id, committer=committer, no_verify=True)

--- a/renku/core/migration/m_0009__new_metadata_storage.py
+++ b/renku/core/migration/m_0009__new_metadata_storage.py
@@ -96,7 +96,7 @@ def migrate(migration_context: MigrationContext):
 
 def _commit_previous_changes():
     repository = project_context.repository
-    if repository.is_dirty():
+    if repository.is_dirty(untracked_files=False):
         project_path = project_context.metadata_path.joinpath(OLD_METADATA_PATH)
         project = old_schema.Project.from_yaml(project_path)
         project.version = "8"
@@ -349,7 +349,7 @@ def _process_workflows(
     migration_context: MigrationContext, activity_gateway: IActivityGateway, commit: "Commit", remove: bool
 ):
 
-    for file in commit.get_changes(paths=f"{project_context.metadata_path}/workflow/*.yaml"):
+    for file in commit.get_changes(f"{project_context.metadata_path}/workflow/*.yaml"):
         if file.deleted:
             continue
 
@@ -640,7 +640,7 @@ def _process_datasets(
     is_last_commit,
     preserve_identifiers,
 ):
-    changes = commit.get_changes(paths=".renku/datasets/*/*.yml")
+    changes = commit.get_changes(".renku/datasets/*/*.yml")
     changed_paths = [c.b_path for c in changes if not c.deleted]
     paths = [p for p in changed_paths if len(Path(p).parents) == 4]  # Exclude files that are not in the right place
     deleted_paths = [c.a_path for c in changes if c.deleted]

--- a/renku/core/migration/m_0010__metadata_fixes.py
+++ b/renku/core/migration/m_0010__metadata_fixes.py
@@ -254,7 +254,7 @@ def fix_plan_times(plan_gateway: IPlanGateway):
             if plan.date_removed.tzinfo is None:
                 # NOTE: There was a bug that caused date_removed to be set without timezone (as UTC time)
                 # so we patch in the timezone here
-                plan.date_removed = plan.date_removed.replace(microsecond=0).astimezone(timezone.utc)
+                plan.date_removed = plan.date_removed.astimezone(timezone.utc)
             if plan.date_removed < plan.date_created:
                 # NOTE: Fix invalidation times set before creation date on plans
                 plan.date_removed = plan.date_created

--- a/renku/core/migration/migrate.py
+++ b/renku/core/migration/migrate.py
@@ -47,8 +47,15 @@ from renku.core.errors import (
 )
 from renku.core.interface.project_gateway import IProjectGateway
 from renku.core.migration.models.migration import MigrationContext, MigrationType
-from renku.core.migration.utils import OLD_METADATA_PATH, is_using_temporary_datasets_path, read_project_version
+from renku.core.migration.utils import is_using_temporary_datasets_path, read_project_version
+from renku.core.template.usecase import update_dockerfile_checksum
 from renku.core.util import communication
+from renku.core.util.metadata import (
+    is_renku_project,
+    read_renku_version_from_dockerfile,
+    replace_renku_version_in_dockerfile,
+)
+from renku.core.util.os import hash_string
 from renku.domain_model.project import ProjectTemplateMetadata
 from renku.domain_model.project_context import project_context
 
@@ -209,37 +216,39 @@ def _update_dockerfile(check_only=False):
     """Update the dockerfile to the newest version of renku."""
     from renku import __version__
 
-    if not project_context.docker_path.exists():
+    if not project_context.dockerfile_path.exists():
         return False, None, None
 
     communication.echo("Updating dockerfile...")
 
-    with open(project_context.docker_path, "r") as f:
+    with open(project_context.dockerfile_path, "r") as f:
         dockerfile_content = f.read()
 
-    current_version = Version(__version__)
-    m = re.search(r"^ARG RENKU_VERSION=(\d+\.\d+\.\d+)$", dockerfile_content, flags=re.MULTILINE)
-    if not m:
+    docker_version = read_renku_version_from_dockerfile()
+    if not docker_version:
         if check_only:
             return False, None, None
         raise DockerfileUpdateError(
             "Couldn't update renku-python version in Dockerfile, as it doesn't contain an 'ARG RENKU_VERSION=...' line."
         )
 
-    docker_version = Version(m.group(1))
-
+    current_version = Version(__version__)
     if docker_version >= current_version:
         return True, False, str(docker_version)
 
     if check_only:
         return True, True, str(docker_version)
 
-    dockerfile_content = re.sub(
-        r"^ARG RENKU_VERSION=\d+\.\d+\.\d+$", f"ARG RENKU_VERSION={__version__}", dockerfile_content, flags=re.MULTILINE
-    )
+    new_content = replace_renku_version_in_dockerfile(dockerfile_content=dockerfile_content, version=__version__)
+    new_checksum = hash_string(new_content)
 
-    with open(project_context.docker_path, "w") as f:
-        f.write(dockerfile_content)
+    try:
+        update_dockerfile_checksum(new_checksum=new_checksum)
+    except DockerfileUpdateError:
+        pass
+
+    with open(project_context.dockerfile_path, "w") as f:
+        f.write(new_content)
 
     communication.echo("Updated dockerfile.")
 
@@ -252,14 +261,6 @@ def get_project_version():
         return int(read_project_version())
     except ValueError:
         return 1
-
-
-def is_renku_project() -> bool:
-    """Check if repository is a renku project."""
-    try:
-        return project_context.project is not None
-    except ValueError:  # NOTE: Error in loading due to an older schema
-        return project_context.metadata_path.joinpath(OLD_METADATA_PATH).exists()
 
 
 def get_migrations():

--- a/renku/core/session/renkulab.py
+++ b/renku/core/session/renkulab.py
@@ -147,7 +147,7 @@ class RenkulabSessionProvider(ISessionProvider):
 
         repository = project_context.repository
 
-        if repository.is_dirty(untracked_files=True):
+        if repository.is_dirty():
             communication.confirm(
                 "You have new uncommitted or untracked changes to your repository. "
                 "Renku can automatically commit these changes so that it builds "

--- a/renku/core/session/session.py
+++ b/renku/core/session/session.py
@@ -134,7 +134,7 @@ def session_start(
                 abort=True,
             )
             with communication.busy(msg=f"Building image {image_name}"):
-                provider_api.build_image(project_context.docker_path.parent, image_name, config)
+                provider_api.build_image(project_context.dockerfile_path.parent, image_name, config)
             communication.echo(f"Image {image_name} built successfully.")
     else:
         if not provider_api.find_image(image_name, config):

--- a/renku/core/template/template.py
+++ b/renku/core/template/template.py
@@ -184,6 +184,8 @@ def get_file_actions(
     rendered_template: RenderedTemplate, template_action: TemplateAction, interactive
 ) -> Dict[str, FileAction]:
     """Render a template regarding files in a project."""
+    from renku.core.template.usecase import is_dockerfile_updated_by_user
+
     if interactive and not communication.has_prompt():
         raise errors.ParameterError("Cannot use interactive mode with no prompt")
 
@@ -220,6 +222,8 @@ def get_file_actions(
         elif interactive:
             overwrite = communication.confirm(f"Overwrite {relative_path}?", default=True)
             return FileAction.OVERWRITE if overwrite else FileAction.KEEP
+        elif relative_path == "Dockerfile" and not is_dockerfile_updated_by_user():
+            return FileAction.OVERWRITE
         elif should_keep(relative_path):
             return FileAction.KEEP
         else:
@@ -248,6 +252,8 @@ def get_file_actions(
                 return FileAction.OVERWRITE if overwrite else FileAction.KEEP
         elif not remote_changes:
             return FileAction.IGNORE_UNCHANGED_REMOTE
+        elif relative_path == "Dockerfile" and not is_dockerfile_updated_by_user():
+            return FileAction.OVERWRITE
         elif file_deleted or local_changes:
             if relative_path in immutable_files:
                 # NOTE: There are local changes in a file that should not be changed by users, and the file was
@@ -417,6 +423,9 @@ class RepositoryTemplates(TemplatesSource):
 
     A template repository is checked out at a specific Git reference if one is provided. However, it's still possible to
     get available versions of templates.
+
+    For these templates, ``reference`` is set to whatever user passed as a reference (defaults to remote HEAD if not
+    passed) and ``version`` is set to the commit SHA of the reference commit.
     """
 
     def __init__(self, path, source, reference, version, repository: Repository, skip_validation: bool = False):

--- a/renku/core/template/usecase.py
+++ b/renku/core/template/usecase.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Template use cases."""
-
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -29,7 +29,6 @@ from renku.command.command_builder.command import inject
 from renku.command.view_model.template import TemplateChangeViewModel, TemplateViewModel
 from renku.core import errors
 from renku.core.interface.project_gateway import IProjectGateway
-from renku.core.migration.migrate import is_renku_project
 from renku.core.template.template import (
     FileAction,
     RepositoryTemplates,
@@ -38,14 +37,76 @@ from renku.core.template.template import (
     fetch_templates_source,
     get_file_actions,
     has_template_checksum,
+    read_template_checksum,
     set_template_parameters,
+    write_template_checksum,
 )
 from renku.core.util import communication
+from renku.core.util.metadata import is_renku_project, replace_renku_version_in_dockerfile
+from renku.core.util.os import hash_file, hash_string
 from renku.core.util.tabulate import tabulate
 from renku.domain_model.project import Project
 from renku.domain_model.project_context import project_context
 from renku.domain_model.template import RenderedTemplate, Template, TemplateMetadata, TemplatesSource
 from renku.infrastructure.repository import Repository
+
+
+def update_dockerfile_checksum(new_checksum: str):
+    """Update ``Dockerfile`` template checksum if possible."""
+    if not project_context.dockerfile_path.exists():
+        raise errors.DockerfileUpdateError("Project doesn't have a Dockerfile")
+    if is_dockerfile_updated_by_user():
+        raise errors.DockerfileUpdateError("Cannot update Dockerfile checksum because it was update by the user")
+
+    checksums = read_template_checksum()
+    checksums["Dockerfile"] = new_checksum
+    write_template_checksum(checksums)
+
+
+def does_dockerfile_contains_only_version_change() -> bool:
+    """Return True if Dockerfile only contains Renku version changes."""
+    commits = list(project_context.repository.iterate_commits(project_context.dockerfile_path))
+    # NOTE: Don't include the first commit that added the Dockerfile
+    for commit in commits[:-1]:
+        changes = commit.get_changes(project_context.dockerfile_path, patch=True)
+        if not changes:
+            continue
+        diff = changes[0].diff
+        # NOTE: Check the Dockerfile change only includes adding and removing a Renku version line
+        if (
+            len(diff) != 2
+            or {c.change_type for c in diff} != {"A", "D"}
+            or any("ARG RENKU_VERSION=" not in c.text for c in diff)
+        ):
+            return False
+
+    return True
+
+
+def is_dockerfile_updated_by_user() -> bool:
+    """Return if user modified the ``Dockerfile``."""
+    dockerfile = project_context.dockerfile_path
+
+    if not has_template_checksum() or not dockerfile.exists():
+        return False
+
+    original_checksum = read_template_checksum().get("Dockerfile")
+    current_checksum = hash_file(dockerfile)
+
+    if original_checksum == current_checksum:  # Dockerfile was never updated
+        return False
+
+    # NOTE: Check if original Dockerfile has the same checksum as the time when the template was set/updated
+    metadata = json.loads(project_context.project.template_metadata.metadata)
+    original_renku_version = metadata.get("__renku_version__")
+
+    original_dockerfile_content = replace_renku_version_in_dockerfile(dockerfile.read_text(), original_renku_version)
+    original_calculated_checksum = hash_string(original_dockerfile_content)
+
+    if original_checksum == original_calculated_checksum:
+        return False
+
+    return False if does_dockerfile_contains_only_version_change() else True
 
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))

--- a/renku/core/util/datetime8601.py
+++ b/renku/core/util/datetime8601.py
@@ -64,8 +64,6 @@ def fix_datetime(value) -> Optional[datetime]:
     if isinstance(value, datetime):
         if not value.tzinfo:
             value = _set_to_local_timezone(value)
-        if value.microsecond:
-            value = value.replace(microsecond=0)
 
     return value
 
@@ -75,7 +73,7 @@ def _set_to_local_timezone(value):
     return value.replace(tzinfo=local_tz)
 
 
-def local_now(remove_microseconds: bool = True) -> datetime:
+def local_now(remove_microseconds: bool = False) -> datetime:
     """Return current datetime in local timezone."""
     now = datetime.now(timezone.utc).astimezone()
     return now.replace(microsecond=0) if remove_microseconds else now

--- a/renku/core/util/git.py
+++ b/renku/core/util/git.py
@@ -32,12 +32,13 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union, cast
 from uuid import uuid4
 
 from renku.core import errors
+from renku.infrastructure.repository import DiffChangeType
 
 if TYPE_CHECKING:
     from renku.domain_model.entity import Collection, Entity
     from renku.domain_model.git import GitURL
     from renku.domain_model.provenance.agent import Person, SoftwareAgent
-    from renku.infrastructure.repository import Commit, DiffChangeType, Remote, Repository
+    from renku.infrastructure.repository import Commit, Remote, Repository
 
 COMMIT_DIFF_STRATEGY = "DIFF"
 STARTED_AT = int(time.time() * 1e3)

--- a/renku/core/util/git.py
+++ b/renku/core/util/git.py
@@ -37,8 +37,7 @@ if TYPE_CHECKING:
     from renku.domain_model.entity import Collection, Entity
     from renku.domain_model.git import GitURL
     from renku.domain_model.provenance.agent import Person, SoftwareAgent
-    from renku.infrastructure.repository import Commit, Remote, Repository
-
+    from renku.infrastructure.repository import Commit, DiffChangeType, Remote, Repository
 
 COMMIT_DIFF_STRATEGY = "DIFF"
 STARTED_AT = int(time.time() * 1e3)
@@ -1101,7 +1100,7 @@ def finalize_commit(
     if isinstance(commit_only, list):
         for path_ in commit_only:
             p = repository.path / path_
-            if p.exists() or change_types.get(str(path_)) == "D":
+            if p.exists() or change_types.get(str(path_)) == DiffChangeType.DELETED:
                 repository.add(path_)
 
     if not commit_only:

--- a/renku/core/util/metadata.py
+++ b/renku/core/util/metadata.py
@@ -29,6 +29,7 @@ from packaging.version import Version
 from renku.core import errors
 from renku.core.config import get_value, set_value
 from renku.core.constant import RENKU_HOME, RENKU_PROTECTED_PATHS, RENKU_TMP
+from renku.core.migration.utils import OLD_METADATA_PATH
 from renku.core.util import communication
 from renku.core.util.os import is_subpath
 
@@ -97,23 +98,32 @@ def is_external_file(path: Union[Path, str], project_path: Path):
     return str(os.path.join(RENKU_HOME, POINTERS)) in pointer
 
 
-def read_renku_version_from_dockerfile(path: Optional[Union[Path, str]] = None) -> Optional[str]:
+def read_renku_version_from_dockerfile(path: Optional[Union[Path, str]] = None) -> Optional[Version]:
     """Read RENKU_VERSION from the content of path if a valid version is available."""
     from renku.domain_model.project_context import project_context
 
-    path = Path(path) if path else project_context.docker_path
+    path = Path(path) if path else project_context.dockerfile_path
     if not path.exists():
         return None
 
-    docker_content = path.read_text()
-    m = re.search(r"^\s*ARG RENKU_VERSION=(.+)$", docker_content, flags=re.MULTILINE)
+    m = re.search(r"^\s*ARG RENKU_VERSION=(\d+\.\d+\.\d+\S*)$", path.read_text(), flags=re.MULTILINE)
     if not m:
         return None
 
     try:
-        return str(Version(m.group(1)))
+        return Version(m.group(1))
     except ValueError:
         return None
+
+
+def replace_renku_version_in_dockerfile(dockerfile_content: str, version: str) -> str:
+    """Replace Renku version in the Dockerfile."""
+    return re.sub(
+        r"^\s*ARG RENKU_VERSION=(\d+\.\d+\.\d+\S*)$",
+        f"ARG RENKU_VERSION={version}",
+        dockerfile_content,
+        flags=re.MULTILINE,
+    )
 
 
 def make_project_temp_dir(project_path: Path) -> Path:
@@ -180,3 +190,13 @@ def is_protected_path(path: Path) -> bool:
             return True
 
     return False
+
+
+def is_renku_project() -> bool:
+    """Check if repository is a renku project."""
+    from renku.domain_model.project_context import project_context
+
+    try:
+        return project_context.project is not None
+    except ValueError:  # NOTE: Error in loading due to an older schema
+        return project_context.metadata_path.joinpath(OLD_METADATA_PATH).exists()

--- a/renku/core/util/os.py
+++ b/renku/core/util/os.py
@@ -20,6 +20,7 @@
 import fnmatch
 import glob
 import hashlib
+import io
 import os
 import re
 import shutil
@@ -246,6 +247,14 @@ def hash_file(path: Union[Path, str], hash_type: str = "sha256") -> Optional[str
 
     with open(path, "rb") as f:
         return hash_file_descriptor(f, hash_type)
+
+
+def hash_string(content: str, hash_type: str = "sha256") -> str:
+    """Hash a string."""
+    content_bytes = content.encode("utf-8")
+    file = io.BytesIO(content_bytes)
+
+    return hash_file_descriptor(file, hash_type)
 
 
 def hash_file_descriptor(file: BinaryIO, hash_type: str = "sha256") -> str:

--- a/renku/domain_model/project_context.py
+++ b/renku/domain_model/project_context.py
@@ -95,7 +95,7 @@ class ProjectContext(threading.local):
         return self.path / RENKU_HOME / DATASET_IMAGES
 
     @property
-    def docker_path(self) -> Path:
+    def dockerfile_path(self) -> Path:
         """Path to the Dockerfile."""
         return self.path / DOCKERFILE
 

--- a/renku/domain_model/template.py
+++ b/renku/domain_model/template.py
@@ -534,7 +534,7 @@ class TemplateMetadata:
         # NOTE: Always set __renku_version__ to the value read from the Dockerfile (if available) since setting/updating
         # the template doesn't change project's metadata version and shouldn't update the Renku version either
         renku_version = metadata.get("__renku_version__")
-        metadata["__renku_version__"] = read_renku_version_from_dockerfile() or renku_version or __version__
+        metadata["__renku_version__"] = str(read_renku_version_from_dockerfile()) or renku_version or __version__
 
         return cls(metadata=metadata, immutable_files=immutable_files)
 

--- a/renku/domain_model/workflow/plan.py
+++ b/renku/domain_model/workflow/plan.py
@@ -153,12 +153,14 @@ class AbstractPlan(Persistent, ABC):
         """Return if an ``AbstractPlan`` has correct derived_from."""
         raise NotImplementedError()
 
-    def delete(self, when: datetime = local_now()):
+    def delete(self, when: Optional[datetime] = None):
         """Mark a plan as deleted.
 
         NOTE: Don't call this function for deleting plans since it doesn't delete the whole plan derivatives chain. Use
         renku.core.workflow.plan::remove_plan instead.
         """
+        when = when or local_now()
+
         self.unfreeze()
         self.date_removed = when
         self.freeze()

--- a/renku/infrastructure/gateway/database_gateway.py
+++ b/renku/infrastructure/gateway/database_gateway.py
@@ -148,7 +148,7 @@ class DatabaseGateway(IDatabaseGateway):
             commits = [repository.get_commit(revision_or_range)]
 
         for commit in commits:
-            for file in commit.get_changes(paths=f"{project_context.database_path}/**"):
+            for file in commit.get_changes(f"{project_context.database_path}/**"):
                 if file.deleted:
                     continue
 

--- a/renku/infrastructure/repository.py
+++ b/renku/infrastructure/repository.py
@@ -400,7 +400,7 @@ class BaseRepository:
         """
         self.run_git_command("worktree", "remove", path)
 
-    def is_dirty(self, untracked_files: bool = False) -> bool:
+    def is_dirty(self, untracked_files: bool = True) -> bool:
         """Return True if the repository has modified or untracked files ignoring submodules."""
         if self._repository is None:
             raise errors.ParameterError("Repository not set.")
@@ -1259,6 +1259,28 @@ class Actor(NamedTuple):
         return hash((self.name, self.email))
 
 
+class DiffLine(NamedTuple):
+    """A single line in a patch."""
+
+    text: str
+    """
+    Possible values:
+        A = Added
+        D = Deleted
+    """
+    change_type: str
+
+    @property
+    def deleted(self) -> bool:
+        """True if line was deleted."""
+        return self.change_type == "D"
+
+    @property
+    def added(self) -> bool:
+        """True if line was added."""
+        return self.change_type == "A"
+
+
 class Diff(NamedTuple):
     """A single diff object between two trees."""
 
@@ -1274,10 +1296,33 @@ class Diff(NamedTuple):
         T = Changed in the type
     """
     change_type: str
+    diff: List[DiffLine]
 
     @classmethod
     def from_diff(cls, diff: git.Diff):
         """Create an instance from a git object."""
+
+        def process_diff_lines():
+            patch = diff.diff.decode("utf-8") if isinstance(diff.diff, bytes) else diff.diff
+            patch = patch or ""
+            lines = patch.splitlines()
+            last_index = len(lines) - 1
+
+            diff_lines = []
+
+            for index, line in enumerate(lines):
+                # NOTE: Ignore ``No newline at end of file`` message
+                if line.startswith("-") and index < last_index and lines[index + 1] == "\\ No newline at end of file":
+                    continue
+                elif line.startswith("+") and index > 0 and lines[index - 1] == "\\ No newline at end of file":
+                    continue
+                elif line.startswith("+"):
+                    diff_lines.append(DiffLine(text=line[1:], change_type="A"))
+                elif line.startswith("-"):
+                    diff_lines.append(DiffLine(text=line[1:], change_type="D"))
+
+            return diff_lines
+
         a_path = git_unicode_unescape(diff.a_path)
         b_path = git_unicode_unescape(diff.b_path)
 
@@ -1285,7 +1330,7 @@ class Diff(NamedTuple):
         a_path = a_path or b_path
         b_path = b_path or a_path
 
-        return cls(a_path=a_path, b_path=b_path, change_type=cast(str, diff.change_type))
+        return cls(a_path=a_path, b_path=b_path, change_type=cast(str, diff.change_type), diff=process_diff_lines())
 
     @property
     def deleted(self) -> bool:
@@ -1371,25 +1416,50 @@ class Commit:
         """Return all objects in the commit's tree."""
         return {o.path: Object.from_object(o) for o in self._commit.tree.traverse()}
 
+    @property
+    def root(self) -> bool:
+        """Return True if this commit is the root commit."""
+        return len(self._commit.parents) == 0
+
     def get_changes(
         self,
-        paths: Union[Path, str, List[Union[Path, str]], None] = None,
+        *paths: Optional[Union[Path, str]],
         commit: Optional[Union[str, "Commit"]] = None,
+        patch: bool = False,
     ) -> List[Diff]:
         """Return list of changes in a commit.
 
         NOTE: This function can be implemented with ``git diff-tree``.
+        NOTE: When ``patch`` is False ``Diff.diff`` will be empty. We need to call ``Commit.diff`` twice when ``patch``
+        is True because GitPython won't set ``Diff.change_type`` in this case.
         """
+
+        def merge(diff, patch_diff):
+            for d, p_d in zip(sorted(diff), sorted(patch_diff)):
+                d.diff = p_d.diff
+
         if commit:
             if isinstance(commit, Commit):
                 commit = commit.hexsha
 
             diff = self._commit.diff(commit, paths=paths, ignore_submodules=True)
+            if patch:
+                patch_diff = self._commit.diff(commit, paths=paths, ignore_submodules=True, create_patch=True)
+                merge(diff, patch_diff)
+
         elif len(self._commit.parents) == 0:
             diff = self._commit.diff(git.NULL_TREE, paths=paths, ignore_submodules=True)
+            if patch:
+                patch_diff = self._commit.diff(git.NULL_TREE, paths=paths, ignore_submodules=True, create_patch=True)
+                merge(diff, patch_diff)
         elif len(self._commit.parents) == 1:
             # NOTE: Diff is reverse so we get the diff of the parent to the child
             diff = self._commit.parents[0].diff(self._commit, paths=paths, ignore_submodules=True)
+            if patch:
+                patch_diff = self._commit.parents[0].diff(
+                    self._commit, paths=paths, ignore_submodules=True, create_patch=True
+                )
+                merge(diff, patch_diff)
         else:
             # NOTE: A merge commit, so there is no clear diff
             return []

--- a/tests/cli/test_datasets.py
+++ b/tests/cli/test_datasets.py
@@ -60,7 +60,7 @@ def test_datasets_create_clean(runner, project):
     assert isinstance(dataset, Dataset)
     assert Path("data/dataset/") == dataset.get_datadir()
 
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
 
 def test_datasets_create_clean_with_datadir(runner, project):
@@ -76,7 +76,7 @@ def test_datasets_create_clean_with_datadir(runner, project):
     assert isinstance(dataset, Dataset)
     assert datadir == dataset.get_datadir()
 
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
 
 def test_datasets_create_with_datadir_with_files(runner, project):
@@ -97,7 +97,7 @@ def test_datasets_create_with_datadir_with_files(runner, project):
     assert datadir == dataset.get_datadir()
     assert dataset.find_file(file)
 
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
 
 def test_datasets_create_dirty(runner, project):
@@ -571,7 +571,7 @@ def test_add_to_dirty_repo(directory_tree, runner, project):
     )
     assert 0 == result.exit_code, format_result_exception(result)
 
-    assert project.repository.is_dirty(untracked_files=True)
+    assert project.repository.is_dirty()
     assert ["untracked"] == project.repository.untracked_files
 
     # Add without making a change
@@ -580,7 +580,7 @@ def test_add_to_dirty_repo(directory_tree, runner, project):
     )
     assert 1 == result.exit_code
 
-    assert project.repository.is_dirty(untracked_files=True)
+    assert project.repository.is_dirty()
     assert ["untracked"] == project.repository.untracked_files
 
 
@@ -755,7 +755,7 @@ def test_add_untracked_file(runner, project):
 
     assert 0 == result.exit_code, format_result_exception(result)
 
-    assert project.repository.is_dirty(untracked_files=True)
+    assert project.repository.is_dirty()
     assert project.repository.contains(project.path / "data" / "my-dataset" / "untracked")
     assert get_dataset_with_injection("my-dataset").find_file("data/my-dataset/untracked")
 
@@ -773,7 +773,7 @@ def test_add_untracked_file_as_external(runner, project):
 
     path = project.path / DATA_DIR / "my-dataset" / "untracked" / "some-file"
 
-    assert project.repository.is_dirty(untracked_files=True)
+    assert project.repository.is_dirty()
     assert not project.repository.contains(untracked)
     assert get_dataset_with_injection("my-dataset").find_file(path.relative_to(project.path))
     assert path.is_symlink()
@@ -1188,7 +1188,7 @@ def test_dataset_unlink_file(tmpdir, runner, project, subdirectory):
     # add data to dataset
     result = runner.invoke(cli, ["dataset", "add", "--copy", "my-dataset", str(new_file)])
     assert 0 == result.exit_code, format_result_exception(result)
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
     dataset = get_dataset_with_injection("my-dataset")
     created_dataset_files = [Path(f.entity.path) for f in dataset.files]
@@ -1198,7 +1198,7 @@ def test_dataset_unlink_file(tmpdir, runner, project, subdirectory):
 
     result = runner.invoke(cli, ["dataset", "unlink", "my-dataset", "--include", new_file.basename, "-y"])
     assert 0 == result.exit_code, format_result_exception(result)
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
     commit_sha_after = project.repository.head.commit.hexsha
     assert commit_sha_before != commit_sha_after
@@ -1446,7 +1446,7 @@ def test_dataset_edit_no_change(runner, project, dirty):
 
     commit_sha_after = project.repository.head.commit.hexsha
     assert commit_sha_after == commit_sha_before
-    assert dirty is project.repository.is_dirty(untracked_files=True)
+    assert dirty is project.repository.is_dirty()
 
 
 @pytest.mark.parametrize(
@@ -2234,7 +2234,7 @@ def test_datasets_provenance_after_create(runner, project):
     assert dataset.same_as is None
     assert [] == dataset.dataset_files
 
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
 
 def test_datasets_provenance_after_create_when_adding(runner, project):
@@ -2249,7 +2249,7 @@ def test_datasets_provenance_after_create_when_adding(runner, project):
     assert dataset.same_as is None
     assert {"README.md"} == {Path(f.entity.path).name for f in dataset.dataset_files}
 
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
 
 def test_datasets_provenance_after_edit(runner, project):
@@ -2414,7 +2414,7 @@ def test_datasets_provenance_after_adding_tag(runner, project):
     assert current_version.identifier == current_version.initial_identifier
     assert current_version.derived_from is None
     assert current_version.identifier == old_dataset.identifier
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
 
 def test_datasets_provenance_after_removing_tag(runner, project):
@@ -2434,7 +2434,7 @@ def test_datasets_provenance_after_removing_tag(runner, project):
     assert current_version.identifier == current_version.initial_identifier
     assert current_version.derived_from is None
     assert current_version.identifier == old_dataset.identifier
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
 
 def test_datasets_provenance_multiple(runner, project, directory_tree):
@@ -2584,7 +2584,7 @@ def test_update_local_file(runner, project, directory_tree, datadir_option, data
     assert str(file1) in result.output
     assert str(file2) in result.output
     assert commit_sha_before_update == project.repository.head.commit.hexsha
-    assert project.repository.is_dirty(untracked_files=True)
+    assert project.repository.is_dirty()
 
     result = runner.invoke(cli, ["dataset", "update", "my-data", "--no-local"])
     assert 0 == result.exit_code, format_result_exception(result)
@@ -2593,7 +2593,7 @@ def test_update_local_file(runner, project, directory_tree, datadir_option, data
     result = runner.invoke(cli, ["dataset", "update", "my-data"])
 
     assert 0 == result.exit_code, format_result_exception(result)
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
     dataset = get_dataset_with_injection("my-data")
     assert new_checksum_file1 == dataset.find_file(file1).entity.checksum
     assert new_checksum_file2 == dataset.find_file(file2).entity.checksum
@@ -2630,7 +2630,7 @@ def test_update_local_file_in_datadir(runner, project, directory_tree, datadir_o
     assert str(file1) in result.output
     assert str(file2) in result.output
 
-    assert project.repository.is_dirty(untracked_files=True)
+    assert project.repository.is_dirty()
 
     result = runner.invoke(
         cli, ["dataset", "update", "my-data", "--check-data-directory", "--no-remote", "--no-external"]
@@ -2638,7 +2638,7 @@ def test_update_local_file_in_datadir(runner, project, directory_tree, datadir_o
 
     assert 0 == result.exit_code, format_result_exception(result)
 
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
     dataset = get_dataset_with_injection("my-data")
     assert dataset.find_file(file1)
     assert dataset.find_file(file2)
@@ -2663,7 +2663,7 @@ def test_update_local_deleted_file(runner, project, directory_tree):
     assert "The following files will be deleted" in result.output
     assert str(file1) in result.output
     assert commit_sha_after_file1_delete == project.repository.head.commit.hexsha
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
     # NOTE: Update without `--delete`
     result = runner.invoke(cli, ["dataset", "update", "my-data"])

--- a/tests/cli/test_graph.py
+++ b/tests/cli/test_graph.py
@@ -53,7 +53,7 @@ def test_graph_export_validation(runner, project, directory_tree, run, revision)
         assert "https://renkulab.io" in result.output
 
     # Make sure that nothing has changed during export which is a read-only operation
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
 
 @pytest.mark.serial

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -417,7 +417,7 @@ def test_init_with_data_dir(isolated_runner, data_dir, directory_tree, project_i
 
     assert (new_project / data_dir).exists()
     assert (new_project / data_dir / ".gitkeep").exists()
-    assert not Repository(new_project).is_dirty(untracked_files=True)
+    assert not Repository(new_project).is_dirty()
 
     os.chdir(new_project.resolve())
     result = isolated_runner.invoke(cli, ["dataset", "add", "--copy", "-c", "my-data", str(directory_tree)])

--- a/tests/cli/test_integration_datasets.py
+++ b/tests/cli/test_integration_datasets.py
@@ -707,7 +707,7 @@ def test_dataset_export_to_local(runner, tmp_path):
     assert 0 == result.exit_code, format_result_exception(result)
     assert f"Dataset metadata was copied to {repository.path}/data/parts-v1/METADATA.yml" in result.output
     assert f"Exported to: {repository.path}/data/parts-v1" in result.output
-    assert repository.is_dirty(untracked_files=True)
+    assert repository.is_dirty()
     assert (repository.path / "data" / "parts-v1" / "part_relationships.csv").exists()
     assert (repository.path / "data" / "parts-v1" / "parts.csv").read_text() == (
         repository.path / "data" / "parts-v1" / "parts.csv"
@@ -1198,7 +1198,7 @@ def test_dataset_update_zenodo(project, runner, doi):
     assert "The following imported datasets will be updated" in result.output
     assert "imported_dataset" in result.output
     assert commit_sha_after_file1_delete == project.repository.head.commit.hexsha
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
     result = runner.invoke(cli, ["dataset", "update", "imported_dataset"], catch_exceptions=False)
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
@@ -1278,7 +1278,7 @@ def test_dataset_update_renku(project, runner, with_injection):
     assert "The following imported datasets will be updated" in result.output
     assert "remote-dataset" in result.output
     assert commit_sha_after_file1_delete == project.repository.head.commit.hexsha
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
     result = runner.invoke(cli, ["dataset", "update", "--all"])
     assert 0 == result.exit_code, format_result_exception(result) + str(result.stderr_bytes)
@@ -1557,7 +1557,7 @@ def test_update_specific_refs(ref, runner, project):
     assert "The following files will be updated" in result.output
     assert str(file) in result.output
     assert commit_sha_after_file1_delete == project.repository.head.commit.hexsha
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
     # update data to a later version
     result = runner.invoke(cli, ["dataset", "update", "--ref", ref, "--all"])

--- a/tests/cli/test_migrate.py
+++ b/tests/cli/test_migrate.py
@@ -194,7 +194,7 @@ def test_comprehensive_dataset_migration(isolated_runner, old_dataset_project):
     assert "Cornell University" == dataset.creators[0].affiliation
     assert "Rooth, Mats" == dataset.creators[0].name
     assert dataset.date_published is None
-    assert "2020-08-10T21:35:05+00:00" == dataset.date_created.isoformat("T")
+    assert "2020-08-10T21:35:05+00:00" == dataset.date_created.replace(microsecond=0).isoformat("T")
     assert "Replication material for a paper to be presented" in dataset.description
     assert "https://doi.org/10.7910/DVN/EV6KLF" == dataset.same_as.url
     assert "1" == tags[0].name
@@ -204,7 +204,7 @@ def test_comprehensive_dataset_migration(isolated_runner, old_dataset_project):
 
     file_ = dataset.find_file("data/dataverse/copy.sh")
     assert "https://dataverse.harvard.edu/api/access/datafile/3050656" == file_.source
-    assert "2020-08-10T21:35:10+00:00" == file_.date_added.isoformat("T")
+    assert "2020-08-10T21:35:10+00:00" == file_.date_added.replace(microsecond=0).isoformat("T")
     assert file_.based_on is None
     assert not hasattr(file_, "creators")
 
@@ -406,8 +406,8 @@ def test_migrate_preserves_date_when_preserving_ids(isolated_runner, old_dataset
 
     dataset = get_dataset_with_injection("mixed")
 
-    assert "2020-08-10 21:35:20+00:00" == dataset.date_created.isoformat(" ")
-    assert "2020-08-10 21:35:20+00:00" == dataset.date_modified.isoformat(" ")
+    assert "2020-08-10 21:35:20+00:00" == dataset.date_created.replace(microsecond=0).isoformat(" ")
+    assert "2020-08-10 21:35:20+00:00" == dataset.date_modified.replace(microsecond=0).isoformat(" ")
 
 
 @pytest.mark.migration
@@ -418,8 +418,8 @@ def test_migrate_preserves_date_for_mutated_datasets(isolated_runner, old_datase
 
     dataset = get_dataset_with_injection("local")
 
-    assert "2021-07-23 14:34:24+00:00" == dataset.date_created.isoformat(" ")
-    assert "2021-07-23 14:34:58+00:00" == dataset.date_modified.isoformat(" ")
+    assert "2021-07-23 14:34:24+00:00" == dataset.date_created.replace(microsecond=0).isoformat(" ")
+    assert "2021-07-23 14:34:58+00:00" == dataset.date_modified.replace(microsecond=0).isoformat(" ")
 
 
 @pytest.mark.migration
@@ -429,5 +429,5 @@ def test_migrate_sets_correct_date_for_non_mutated_datasets(isolated_runner, old
 
     dataset = get_dataset_with_injection("mixed")
 
-    assert "2020-08-10 21:35:20+00:00" == dataset.date_created.isoformat(" ")
-    assert "2020-08-10 23:35:56+02:00" == dataset.date_modified.isoformat(" ")
+    assert "2020-08-10 21:35:20+00:00" == dataset.date_created.replace(microsecond=0).isoformat(" ")
+    assert "2020-08-10 23:35:56+02:00" == dataset.date_modified.replace(microsecond=0).isoformat(" ")

--- a/tests/cli/test_migrate.py
+++ b/tests/cli/test_migrate.py
@@ -40,7 +40,7 @@ def test_migrate_datasets_with_old_repository(isolated_runner, old_project):
     """Test migrate on old repository."""
     result = isolated_runner.invoke(cli, ["migrate", "--strict"])
     assert 0 == result.exit_code, format_result_exception(result)
-    assert not old_project.repository.is_dirty(untracked_files=True)
+    assert not old_project.repository.is_dirty()
 
 
 @pytest.mark.migration
@@ -48,7 +48,7 @@ def test_migrate_project(isolated_runner, old_project, with_injection):
     """Test migrate on old repository."""
     result = isolated_runner.invoke(cli, ["migrate", "--strict"])
     assert 0 == result.exit_code, format_result_exception(result)
-    assert not old_project.repository.is_dirty(untracked_files=True)
+    assert not old_project.repository.is_dirty()
 
     with project_context.with_path(old_project.path), with_injection():
         assert project_context.project

--- a/tests/cli/test_move.py
+++ b/tests/cli/test_move.py
@@ -181,7 +181,7 @@ def test_move_in_the_same_dataset(runner, project_with_datasets, args):
 
     result = runner.invoke(cli, ["doctor"], catch_exceptions=False)
     assert 0 == result.exit_code, format_result_exception(result)
-    assert not project_with_datasets.repository.is_dirty(untracked_files=True)
+    assert not project_with_datasets.repository.is_dirty()
 
 
 def test_move_to_existing_destination_in_a_dataset(runner, project_with_datasets):
@@ -216,7 +216,7 @@ def test_move_to_existing_destination_in_a_dataset(runner, project_with_datasets
 
     result = runner.invoke(cli, ["doctor"], catch_exceptions=False)
     assert 0 == result.exit_code, format_result_exception(result)
-    assert not project_with_datasets.repository.is_dirty(untracked_files=True)
+    assert not project_with_datasets.repository.is_dirty()
 
 
 @pytest.mark.parametrize(
@@ -250,7 +250,7 @@ def test_move_external_files(data_repository, runner, project, destination, dire
     result = runner.invoke(cli, ["doctor"], catch_exceptions=False)
 
     assert 0 == result.exit_code, result.output
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
 
 def test_move_between_datasets(runner, project, directory_tree, large_file, directory_tree_files):
@@ -300,4 +300,4 @@ def test_move_between_datasets(runner, project, directory_tree, large_file, dire
     assert {"data/dataset-3/large-file"} == {f.entity.path for f in get_dataset_with_injection("dataset-3").files}
 
     assert 0 == runner.invoke(cli, ["doctor"], catch_exceptions=False).exit_code
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -76,7 +76,7 @@ def test_project_edit(runner, project, subdirectory, with_injection):
     assert "Successfully updated: creator, description, keywords, custom_metadata." in result.output
     assert "Warning: No email or wrong format for: Forename Surname" in result.output
 
-    assert project.repository.is_dirty(untracked_files=True)
+    assert project.repository.is_dirty()
     commit_sha_after = project.repository.head.commit.hexsha
     assert commit_sha_before != commit_sha_after
 
@@ -117,7 +117,7 @@ def test_project_edit_no_change(runner, project):
 
     commit_sha_after = project.repository.head.commit.hexsha
     assert commit_sha_after == commit_sha_before
-    assert project.repository.is_dirty(untracked_files=True)
+    assert project.repository.is_dirty()
 
 
 def test_project_edit_unset(runner, project, subdirectory, with_injection):
@@ -166,7 +166,7 @@ def test_project_edit_unset(runner, project, subdirectory, with_injection):
     assert 0 == result.exit_code, format_result_exception(result)
     assert "Successfully updated: keywords, custom_metadata." in result.output
 
-    assert project.repository.is_dirty(untracked_files=True)
+    assert project.repository.is_dirty()
     commit_sha_after = project.repository.head.commit.hexsha
     assert commit_sha_before != commit_sha_after
 

--- a/tests/cli/test_save.py
+++ b/tests/cli/test_save.py
@@ -113,4 +113,4 @@ def test_save_with_staged(runner, project_with_remote):
     assert {"tracked", "untracked", "deleted"} == {
         f.a_path for f in project_with_remote.repository.head.commit.get_changes()
     }
-    assert not project_with_remote.repository.is_dirty(untracked_files=True)
+    assert not project_with_remote.repository.is_dirty()

--- a/tests/core/commands/test_doctor.py
+++ b/tests/core/commands/test_doctor.py
@@ -138,7 +138,7 @@ def test_fix_invalid_imported_dataset(runner, project_with_datasets, with_inject
     assert "Fixing dataset 'dataset-1'" in result.output
 
     assert before_commit_sha != project_with_datasets.repository.head.commit.hexsha
-    assert not project_with_datasets.repository.is_dirty(untracked_files=True)
+    assert not project_with_datasets.repository.is_dirty()
 
     with with_injection():
         with with_dataset(name="dataset-1") as dataset:
@@ -204,7 +204,7 @@ def test_doctor_fix_activity_catalog(runner, project, with_injection):
     assert 0 == result.exit_code, format_result_exception(result)
     assert "Workflow metadata was rebuilt" in result.output
     assert before_commit_sha != project_context.repository.head.commit.hexsha
-    assert not project_context.repository.is_dirty(untracked_files=True)
+    assert not project_context.repository.is_dirty()
 
     result = runner.invoke(cli, ["doctor", "--fix", "--force"])
 

--- a/tests/core/commands/test_graph.py
+++ b/tests/core/commands/test_graph.py
@@ -273,6 +273,8 @@ def test_graph_export_full():
             initial_identifier="abcdefg",
             date_created=datetime.fromisoformat("2022-07-12T16:29:14+02:00"),
             date_modified=datetime.fromisoformat("2022-07-12T16:29:14+02:00"),
+            date_removed=None,
+            date_published=None,
         )
     ]
     dataset_gateway.get_by_id.return_value = Dataset(
@@ -280,6 +282,8 @@ def test_graph_export_full():
         name="my-dataset",
         date_created=datetime.fromisoformat("2022-07-12T16:29:14+02:00"),
         date_modified=datetime.fromisoformat("2022-07-12T16:29:14+02:00"),
+        date_removed=None,
+        date_published=None,
         identifier="abcdefg",
         initial_identifier="abcdefg",
     )
@@ -313,6 +317,8 @@ def test_graph_export_full():
                 agent=Person(email="test@example.com", name="John Doe"),
                 plan=plan,
             ),
+            started_at_time=datetime.fromisoformat("2022-07-12T16:29:14+02:00"),
+            ended_at_time=datetime.fromisoformat("2022-07-12T16:29:15+02:00"),
         )
     ]
 
@@ -330,7 +336,9 @@ def test_graph_export_full():
     ]
 
     project_gateway = MagicMock(spec=IProjectGateway)
-    project_gateway.get_project.return_value = MagicMock(spec=Project, id="/projects/my-project")
+    project_gateway.get_project.return_value = MagicMock(
+        spec=Project, id="/projects/my-project", date_created=datetime.fromisoformat("2022-07-12T16:29:14+02:00")
+    )
 
     result = get_graph_for_all_objects(
         project_gateway=project_gateway,
@@ -344,6 +352,12 @@ def test_graph_export_full():
             "@id": "/activities/abcdefg123456",
             "@type": ["http://www.w3.org/ns/prov#Activity"],
             "http://www.w3.org/ns/prov#qualifiedAssociation": [{"@id": "/activities/abcdefg123456/association"}],
+            "http://www.w3.org/ns/prov#endedAtTime": [
+                {"@type": "http://www.w3.org/2001/XMLSchema#dateTime", "@value": "2022-07-12T16:29:15+02:00"}
+            ],
+            "http://www.w3.org/ns/prov#startedAtTime": [
+                {"@type": "http://www.w3.org/2001/XMLSchema#dateTime", "@value": "2022-07-12T16:29:14+02:00"}
+            ],
         },
         {
             "@id": "/activities/abcdefg123456/association",
@@ -413,6 +427,7 @@ def test_graph_export_full():
             "@id": "/projects/my-project",
             "@type": ["http://schema.org/Project", "http://www.w3.org/ns/prov#Location"],
             "http://schema.org/keywords": [],
+            "http://schema.org/dateCreated": [{"@value": "2022-07-12T16:29:14+02:00"}],
         },
         {
             "@id": "/dataset-files/abcdefg123456789",

--- a/tests/core/metadata/test_repository.py
+++ b/tests/core/metadata/test_repository.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import pytest
 
 from renku.core import errors
-from renku.infrastructure.repository import Repository
+from renku.infrastructure.repository import DiffChangeType, Repository
 
 FIRST_COMMIT_SHA = "d44be0700e7ad1d062544763fd55c6ccb6f456e1"
 LAST_COMMIT_SHA = "8853e0c1112e512c36db9cc76faff560b655e5d5"  # HEAD
@@ -74,7 +74,7 @@ def test_repository_get_changes_in_a_commit(git_repository):
 
     changes = {c.a_path: c for c in commit.get_changes()}
 
-    assert "M" == changes["A"].change_type
+    assert DiffChangeType.MODIFIED == changes["A"].change_type
     assert "A" == changes["A"].b_path
     assert not changes["A"].added
     assert not changes["A"].deleted
@@ -82,7 +82,7 @@ def test_repository_get_changes_in_a_commit(git_repository):
     assert changes["B"].deleted
     assert "B" == changes["B"].b_path
 
-    assert "R" == changes["C"].change_type
+    assert DiffChangeType.RENAMED == changes["C"].change_type
     assert "data/X" == changes["C"].b_path
     assert not changes["C"].added
     assert not changes["C"].deleted
@@ -95,12 +95,12 @@ def test_repository_get_changes_in_the_first_commit(git_repository):
 
     changes = {c.a_path: c for c in commit.get_changes()}
 
-    assert "A" == changes["A"].change_type
+    assert DiffChangeType.ADDED == changes["A"].change_type
     assert changes["A"].added
     assert not changes["A"].deleted
     assert "A" == changes["A"].b_path
 
-    assert "A" == changes["B"].change_type
+    assert DiffChangeType.ADDED == changes["B"].change_type
     assert changes["B"].added
     assert not changes["B"].deleted
     assert "B" == changes["B"].b_path

--- a/tests/core/models/test_activity.py
+++ b/tests/core/models/test_activity.py
@@ -77,8 +77,8 @@ def test_activity_parameter_values(project_with_injection, mocker):
         plan,
         repository=project_with_injection.repository,
         project_gateway=project_gateway,
-        started_at_time=local_now(remove_microseconds=False),
-        ended_at_time=local_now(remove_microseconds=False),
+        started_at_time=local_now(),
+        ended_at_time=local_now(),
         annotations=[],
     )
 

--- a/tests/core/models/test_template.py
+++ b/tests/core/models/test_template.py
@@ -38,6 +38,7 @@ def test_template_get_files(source_template):
         "Dockerfile",
         "README.md",
         "{{ __name__ }}.dummy",
+        "requirements.txt",
         "immutable.file",
     } == files
 
@@ -47,7 +48,7 @@ def test_template_render(source_template):
     rendered_template = source_template.render(metadata=TemplateMetadata.from_dict(TEMPLATE_METADATA))
 
     assert "A Renku project: My Project\n" == (rendered_template.path / "README.md").read_text()
-    assert "42.0.0" == read_renku_version_from_dockerfile(rendered_template.path / "Dockerfile")
+    assert "42.0.0" == str(read_renku_version_from_dockerfile(rendered_template.path / "Dockerfile"))
 
 
 @pytest.mark.parametrize("name", ["", "a-renku-project"])
@@ -62,9 +63,15 @@ def test_template_get_rendered_files(source_template):
     """Test get files of a rendered template."""
     rendered_template = source_template.render(metadata=TemplateMetadata.from_dict(TEMPLATE_METADATA))
 
-    assert {".gitignore", ".renku/renku.ini", "Dockerfile", "README.md", "my-project.dummy", "immutable.file"} == set(
-        rendered_template.get_files()
-    )
+    assert {
+        ".gitignore",
+        ".renku/renku.ini",
+        "Dockerfile",
+        "README.md",
+        "my-project.dummy",
+        "requirements.txt",
+        "immutable.file",
+    } == set(rendered_template.get_files())
 
 
 def test_templates_manifest():

--- a/tests/core/plugins/test_workflow.py
+++ b/tests/core/plugins/test_workflow.py
@@ -91,7 +91,7 @@ def test_cwl_workflow_export(
         stdout, stderr = ps.communicate()
         assert ps.returncode == 0, f"{stdout} + {stderr} + {command}"
 
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()
 
     ps = run_shell(
         f"renku workflow export --format cwl {workflow_name} > test.cwl", work_dir=project.path, return_ps=True
@@ -109,4 +109,4 @@ def test_cwl_workflow_export(
     assert ps.returncode == 0
 
     os.remove(project.path / "test.cwl")
-    assert not project.repository.is_dirty(untracked_files=True)
+    assert not project.repository.is_dirty()

--- a/tests/core/test_template.py
+++ b/tests/core/test_template.py
@@ -31,7 +31,7 @@ from renku.core.template.template import (
 )
 from renku.core.template.usecase import (
     check_for_template_update,
-    does_dockerfile_contains_only_version_change,
+    does_dockerfile_contain_only_version_change,
     is_dockerfile_updated_by_user,
     update_template,
 )
@@ -239,12 +239,12 @@ def test_detect_dockerfile_version_update(project, with_injection):
     write_and_commit_file(project.repository, dockerfile, new_content)
 
     with with_injection():
-        assert does_dockerfile_contains_only_version_change()
+        assert does_dockerfile_contain_only_version_change()
         assert not is_dockerfile_updated_by_user()
 
     new_content = dockerfile.read_text() + "\nRUN echo 'user modifications'"
     write_and_commit_file(project.repository, dockerfile, new_content)
 
     with with_injection():
-        assert not does_dockerfile_contains_only_version_change()
+        assert not does_dockerfile_contain_only_version_change()
         assert is_dockerfile_updated_by_user()

--- a/tests/core/test_template.py
+++ b/tests/core/test_template.py
@@ -29,9 +29,16 @@ from renku.core.template.template import (
     fetch_templates_source,
     get_file_actions,
 )
-from renku.core.template.usecase import check_for_template_update, update_template
+from renku.core.template.usecase import (
+    check_for_template_update,
+    does_dockerfile_contains_only_version_change,
+    is_dockerfile_updated_by_user,
+    update_template,
+)
+from renku.core.util.metadata import replace_renku_version_in_dockerfile
 from renku.domain_model.project_context import project_context
 from renku.domain_model.template import TEMPLATE_MANIFEST
+from tests.utils import write_and_commit_file
 
 TEMPLATES_URL = "https://github.com/SwissDataScienceCenter/renku-project-template"
 
@@ -194,14 +201,14 @@ def test_update_with_locally_modified_file(project_with_template, rendered_templ
 
 def test_update_with_locally_deleted_file(project_with_template, rendered_template_with_update, with_injection):
     """Test a locally deleted file that is remotely updated won't be re-created."""
-    (project_context.path / "Dockerfile").unlink()
+    (project_context.path / "requirements.txt").unlink()
 
     with with_injection():
         actions = get_file_actions(
             rendered_template=rendered_template_with_update, template_action=TemplateAction.UPDATE, interactive=False
         )
 
-    assert FileAction.DELETED == actions["Dockerfile"]
+    assert FileAction.DELETED == actions["requirements.txt"]
 
 
 @pytest.mark.parametrize("delete", [False, True])
@@ -220,3 +227,24 @@ def test_update_with_locally_changed_immutable_file(
         get_file_actions(
             rendered_template=rendered_template_with_update, template_action=TemplateAction.UPDATE, interactive=False
         )
+
+
+def test_detect_dockerfile_version_update(project, with_injection):
+    """Test detecting a Dockerfile was only updated for changing Renku version."""
+    dockerfile = project_context.path / "Dockerfile"
+    new_content = replace_renku_version_in_dockerfile(dockerfile.read_text(), version="1.42.42")
+    write_and_commit_file(project.repository, dockerfile, new_content)
+
+    new_content = replace_renku_version_in_dockerfile(dockerfile.read_text(), version="2.42.42")
+    write_and_commit_file(project.repository, dockerfile, new_content)
+
+    with with_injection():
+        assert does_dockerfile_contains_only_version_change()
+        assert not is_dockerfile_updated_by_user()
+
+    new_content = dockerfile.read_text() + "\nRUN echo 'user modifications'"
+    write_and_commit_file(project.repository, dockerfile, new_content)
+
+    with with_injection():
+        assert not does_dockerfile_contains_only_version_change()
+        assert is_dockerfile_updated_by_user()

--- a/tests/fixtures/templates.py
+++ b/tests/fixtures/templates.py
@@ -19,12 +19,15 @@
 
 import shutil
 import textwrap
-from typing import Generator, List, Optional, Tuple
+from pathlib import Path
+from typing import Generator, List, Optional
 
 import pytest
-from packaging.version import Version
 
+from renku.core.template.template import EmbeddedTemplates, FileAction, RepositoryTemplates, copy_template_to_project
 from renku.domain_model.project_context import project_context
+from renku.domain_model.template import RenderedTemplate, Template, TemplateMetadata, TemplateParameter
+from renku.infrastructure.repository import Repository
 from renku.version import __version__ as renku_version
 from tests.fixtures.repository import RenkuProject
 
@@ -98,11 +101,14 @@ def project_init(template):
 
 
 @pytest.fixture
-def source_template(tmp_path):
-    """A dummy Template."""
-    from renku.domain_model.template import Template
+def templates_source_root(tmp_path) -> Path:
+    """Root of Dummy TemplatesSource."""
+    return tmp_path / "templates_source"
 
-    templates_source_root = tmp_path / "templates_source"
+
+@pytest.fixture
+def source_template(templates_source_root) -> Template:
+    """A dummy Template."""
     dummy_template_root = templates_source_root / "dummy"
 
     (dummy_template_root / ".renku").mkdir(parents=True, exist_ok=True)
@@ -112,6 +118,7 @@ def source_template(tmp_path):
     (dummy_template_root / "immutable.file").write_text("immutable content")
     (dummy_template_root / ".gitignore").write_text(".swp")
     (dummy_template_root / ".renku" / "renku.ini").touch()
+    (dummy_template_root / "requirements.txt").touch()
     (dummy_template_root / "Dockerfile").write_text(
         textwrap.dedent(
             """
@@ -124,7 +131,7 @@ def source_template(tmp_path):
         )
     )
 
-    yield Template(
+    return Template(
         id="dummy",
         name="Dummy Template",
         description="A dummy template",
@@ -141,14 +148,9 @@ def source_template(tmp_path):
     )
 
 
-@pytest.fixture
-def templates_source(tmp_path, monkeypatch):
+@pytest.fixture(params=["renku", "repository"])
+def templates_source(request, monkeypatch, templates_source_root, source_template):
     """A dummy TemplatesSource."""
-    from renku.core import errors
-    from renku.domain_model.template import Template, TemplateParameter, TemplatesSource
-
-    templates_source_root = tmp_path / "templates_source"
-
     (templates_source_root / "manifest.yaml").write_text(
         textwrap.dedent(
             """
@@ -161,72 +163,66 @@ def templates_source(tmp_path, monkeypatch):
         )
     )
 
-    class DummyTemplatesSource(TemplatesSource):
+    def update_dummy_template_files(templates_source, id, content, parameters):
+        template = templates_source.get_template(id=id, reference=None)
+
+        if template is None or template.path is None:
+            return
+
+        for relative_path in template.get_files():
+            path = template.path / relative_path
+            path.write_text(f"{path.read_text()}\n{content}")
+
+        template.parameters = parameters or []
+
+    class DummyRenkuTemplatesSource(EmbeddedTemplates):
         """Base class for Renku template sources."""
 
-        def __init__(self, path, source, reference, version):
-            super().__init__(path=path, source=source, reference=reference, version=version)
-            self._versions = [Version(version)]
-
         @classmethod
-        def fetch(cls, source: Optional[str], reference: Optional[str]) -> "TemplatesSource":
-            raise NotImplementedError
-
-        def is_update_available(self, id: str, reference: Optional[str], version: Optional[str]) -> Tuple[bool, str]:
-            """Return True if an update is available along with the latest version of a template."""
-            _, latest_version = self.get_latest_reference_and_version(
-                id=id, reference=reference, version=version  # type: ignore
-            )
-
-            return latest_version != version, latest_version
-
-        def get_all_references(self, id) -> List[str]:
-            """Return all available references for a template id."""
-            return [str(v) for v in self._versions]
-
-        def get_latest_reference_and_version(
-            self, id: str, reference: Optional[str], version: Optional[str]
-        ) -> Tuple[Optional[str], str]:
-            """Return latest reference and version number of a template."""
-            _ = self.get_template(id=id, reference=reference)
-            version = str(max(self._versions))
-            return version, version
-
-        def get_template(self, id, reference: Optional[str]) -> Template:
-            """Return a template at a specific reference."""
-            if not reference:
-                reference = self.reference
-            elif Version(reference) not in self._versions:
-                raise errors.InvalidTemplateError(f"Cannot find reference '{reference}'")
-
-            try:
-                template = next(t for t in self.templates if t.id == id)
-            except StopIteration:
-                raise errors.TemplateNotFoundError(f"The template with id '{id}' is not available.")
-            else:
-                template.version = reference
-                template.reference = reference
-
-                return template
+        def fetch(cls, source: Optional[str], reference: Optional[str]) -> "DummyRenkuTemplatesSource":
+            return cls(path=templates_source_root, source="renku", reference=reference, version=reference)
 
         def update(self, id, version, content="# modification", parameters: Optional[List[TemplateParameter]] = None):
             """Update all files of a template."""
-            template = self.get_template(id=id, reference=None)
+            update_dummy_template_files(self, id, content, parameters)
 
-            if template is None or template.path is None:
-                return
+            self.version = self.reference = version
 
-            for relative_path in template.get_files():
-                path = template.path / relative_path
-                path.write_text(f"{path.read_text()}\n{content}")
+    class DummyRepositoryTemplatesSource(RepositoryTemplates):
+        """Base class for Renku template sources."""
 
-            template.parameters = parameters or []
+        @classmethod
+        def fetch(cls, source: Optional[str], reference: Optional[str]) -> "DummyRepositoryTemplatesSource":
+            repository = Repository.initialize(templates_source_root)
+            repository.add(all=True)
+            repository.commit("dummy template", no_verify=True)
+            repository.tags.add(reference)
 
-            self._versions.append(Version(version))
+            return cls(
+                path=templates_source_root,
+                source=f"file://{templates_source_root}",
+                reference=reference,
+                version=repository.head.commit.hexsha,
+                repository=repository,
+            )
 
-    dummy_templates_source = DummyTemplatesSource(
-        path=templates_source_root, source="dummy", reference="1.0.0", version="1.0.0"
-    )
+        def update(self, id, version, content="# modification", parameters: Optional[List[TemplateParameter]] = None):
+            """Update all files of a template."""
+            update_dummy_template_files(self, id, content, parameters)
+
+            self.repository.add(all=True)
+            self.repository.commit("updated dummy template", no_verify=True)
+            self.repository.tags.add(version)
+
+            self.version = self.repository.head.commit.hexsha
+            self.reference = version
+
+    if not request.param or request.param == "renku":
+        dummy_templates_source = DummyRenkuTemplatesSource.fetch("renku", reference="1.0.0")
+    elif request.param == "repository":
+        dummy_templates_source = DummyRepositoryTemplatesSource.fetch("renku", reference="1.0.0")
+    else:
+        raise ValueError(f"Invalid TemplatesSource value: {request.param}")
 
     with monkeypatch.context() as monkey:
         import renku.core.template.usecase
@@ -242,8 +238,6 @@ def templates_source(tmp_path, monkeypatch):
 @pytest.fixture
 def rendered_template(source_template, template_metadata):
     """A dummy RenderedTemplate."""
-    from renku.domain_model.template import TemplateMetadata
-
     rendered_template = source_template.render(metadata=TemplateMetadata.from_dict(template_metadata))
 
     yield rendered_template
@@ -252,8 +246,6 @@ def rendered_template(source_template, template_metadata):
 @pytest.fixture
 def project_with_template(project, rendered_template, with_injection) -> Generator[RenkuProject, None, None]:
     """A project with a dummy template."""
-    from renku.core.template.template import FileAction, copy_template_to_project
-
     with with_injection():
         actions = {f: FileAction.OVERWRITE for f in rendered_template.get_files()}
         project_object = project_context.project
@@ -263,25 +255,21 @@ def project_with_template(project, rendered_template, with_injection) -> Generat
         project_object.template_files = [str(project_context.path / f) for f in rendered_template.get_files()]
 
     project.repository.add(all=True)
-    project.repository.commit("Set a dummy template")
+    project.repository.commit("Set a dummy template", no_verify=True)
 
     yield project
 
 
 @pytest.fixture
 def rendered_template_with_update(tmp_path, rendered_template):
-    """An updated RenderedTemplate.
-
-    This fixture modifies these files: ``immutable.file``, ``.gitignore``, ``Dockerfile``, ``README.md``.
-    """
-    from renku.domain_model.template import RenderedTemplate
-
+    """An updated RenderedTemplate that modifies some template files."""
     updated_template_root = tmp_path / "rendered_template_with_update"
 
     shutil.copytree(str(rendered_template.path), str(updated_template_root))
 
     (updated_template_root / "immutable.file").write_text("updated immutable content")
     (updated_template_root / ".gitignore").write_text(".swp\n.idea")
+    (updated_template_root / "requirements.txt").write_text("changed\n")
     dockerfile = updated_template_root / "Dockerfile"
     dockerfile.write_text(f"{dockerfile.read_text()}\n# Updated Dockerfile")
     (updated_template_root / "README.md").write_text("""Updated README: {{ __project_description__ }}\n""")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -259,7 +259,7 @@ def write_and_commit_file(repository: "Repository", path: Union[Path, str], cont
 
     repository.add(path)
     if commit:
-        repository.commit(f"Updated '{path.relative_to(repository.path)}'")
+        repository.commit(f"Updated '{path.relative_to(repository.path)}'", no_verify=True)
 
 
 def delete_and_commit_file(repository: "Repository", path: Union[Path, str]):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -309,7 +309,7 @@ def create_dummy_activity(
         assert isinstance(plan, str)
         plan = Plan(id=Plan.generate_id(), name=plan, command=plan)
 
-    ended_at_time = ended_at_time or local_now(remove_microseconds=False)
+    ended_at_time = ended_at_time or (local_now() + timedelta(seconds=1))
     empty_checksum = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"  # Git hash of an empty string/file
     activity_id = id or Activity.generate_id(uuid=None if index is None else str(index))
 


### PR DESCRIPTION
# Description

We check Dockerfile changes in each commit and if they are only Renku version updates, we mark the Dockerfile as not being modified by users. Before doing this, we first check its checksum and checksum at time that the template was set to see if they match with the stored checksum; if so, we skip the git history traversal.

This PR also refactors `templates_source` fixture to use actual business models instead of a dummy template source.

Fixes #3346 
