### PR TITLE
chore: fix install on python 3.11 due to version regex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,8 +234,7 @@ format-jinja = """
         {{ base }}{{"-%s"|format(stage) if stage else ""}}{{".%s"|format(revision) if revision else ""}}.dev{{distance}}+g{{commit}}{{"-dirty" if dirty else ""}}
     {%- endif -%}
 """
-pattern = """
-    (?x)                                                (?# ignore whitespace)
+pattern = """(?x)                                          (?# ignore whitespace)
     ^v(?P<base>\\d+(\\.\\d+)*)                             (?# v1.2.3)
     (-?((?P<stage>[a-zA-Z0-9]+)?\\.?(?P<revision>(pre|post)\\d+)?))?    (?# b0)
     (\\+(?P<tagged_metadata>.+))?$                       (?# e.g., +linux)


### PR DESCRIPTION
Python 3.11 requires global flags (like `(?x)`) to be at the beginning of a regex, having this after some white-space caused installation to fail on Python 3.11.1+

This fixes all tests on `develop`/`master` not running