### PR TITLE
feat(core): do not update template if dockerfile is modified

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -287,6 +287,7 @@ versioned
 versioning
 Versioning
 vertices
+viewmodel
 vm
 wasDerivedFrom
 webhook

--- a/renku/command/migrate.py
+++ b/renku/command/migrate.py
@@ -131,9 +131,9 @@ def _dockerfile_migration_check():
         Dictionary of Dockerfile migration status.
     """
     from renku import __version__
-    from renku.core.migration.migrate import is_docker_update_possible
+    from renku.core.migration.migrate import update_dockerfile
 
-    automated_dockerfile_update, newer_renku_available, dockerfile_renku_version = is_docker_update_possible()
+    automated_dockerfile_update, newer_renku_available, dockerfile_renku_version = update_dockerfile()
 
     return {
         "automated_dockerfile_update": automated_dockerfile_update,
@@ -194,14 +194,13 @@ def _check_project():
             # NOTE: v10 migration not done
             return MIGRATION_REQUIRED
 
-    # NOTE: ``project.automated_update`` is deprecated and we always allow template update for a project
+    # NOTE: ``project.automated_update`` is deprecated. We always allow template update for a project
     status = AUTOMATED_TEMPLATE_UPDATE_SUPPORTED
 
     if check_for_template_update(project_context.project)[0]:
         status |= TEMPLATE_UPDATE_POSSIBLE
-    if is_docker_update_possible()[0]:
+    if is_docker_update_possible():
         status |= DOCKERFILE_UPDATE_POSSIBLE
-
     if is_migration_required():
         return status | MIGRATION_REQUIRED
 

--- a/renku/command/migrate.py
+++ b/renku/command/migrate.py
@@ -133,7 +133,7 @@ def _dockerfile_migration_check():
     from renku import __version__
     from renku.core.migration.migrate import update_dockerfile
 
-    automated_dockerfile_update, newer_renku_available, dockerfile_renku_version = update_dockerfile()
+    automated_dockerfile_update, newer_renku_available, dockerfile_renku_version = update_dockerfile(check_only=True)
 
     return {
         "automated_dockerfile_update": automated_dockerfile_update,

--- a/renku/command/view_model/template.py
+++ b/renku/command/view_model/template.py
@@ -156,6 +156,7 @@ class TemplateChangeViewModel:
             FileAction.KEEP: "Keep",
             FileAction.OVERWRITE: "Overwrite",
             FileAction.RECREATE: "Recreate deleted file",
+            FileAction.DOCKERFILE: "Update",
         }
 
         file_changes = [

--- a/renku/command/view_model/template.py
+++ b/renku/command/view_model/template.py
@@ -156,7 +156,7 @@ class TemplateChangeViewModel:
             FileAction.KEEP: "Keep",
             FileAction.OVERWRITE: "Overwrite",
             FileAction.RECREATE: "Recreate deleted file",
-            FileAction.DOCKERFILE: "Update",
+            FileAction.UPDATE_DOCKERFILE: "Update",
         }
 
         file_changes = [

--- a/renku/core/login.py
+++ b/renku/core/login.py
@@ -136,7 +136,7 @@ def login(endpoint: Optional[str], git_login: bool, yes: bool):
             raise errors.AuthenticationError(f"Invalid status code from server: {status_code} - {response.content}")
 
     access_token = response.json().get("access_token")
-    _store_token(parsed_endpoint.netloc, access_token)
+    store_token(parsed_endpoint.netloc, access_token)
 
     if git_login and repository:
         set_git_credential_helper(repository=cast("Repository", repository), hostname=parsed_endpoint.netloc)
@@ -170,8 +170,9 @@ def _get_url(parsed_endpoint, path, **query_args) -> str:
     return parsed_endpoint._replace(path=path, query=query).geturl()
 
 
-def _store_token(netloc, access_token):
-    set_value(section=CONFIG_SECTION, key=netloc, value=access_token, global_only=True)
+def store_token(hostname: str, access_token: str):
+    """Store access token for ``hostname``."""
+    set_value(section=CONFIG_SECTION, key=hostname, value=access_token, global_only=True)
     os.chmod(project_context.global_config_path, 0o600)
 
 
@@ -267,6 +268,11 @@ def _restore_git_remote(repository):
             repository.remotes.remove(backup_remote)
         except errors.GitCommandError:
             communication.error(f"Cannot delete backup remote '{backup_remote}'")
+
+
+def has_credentials_for_hostname(hostname: str) -> bool:
+    """Check if credentials are set for the given hostname."""
+    return bool(_read_renku_token_for_hostname(hostname))
 
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))

--- a/renku/core/migration/migrate.py
+++ b/renku/core/migration/migrate.py
@@ -85,7 +85,7 @@ def is_project_unsupported():
 
 def is_docker_update_possible() -> bool:
     """Check if the Dockerfile can be updated to a new version of renku-python."""
-    return update_dockerfile()[0]
+    return update_dockerfile(check_only=True)[0]
 
 
 @inject.autoparams("project_gateway")
@@ -145,7 +145,7 @@ def migrate_project(
 
     if not skip_docker_update:
         try:
-            docker_updated, _, _ = update_dockerfile(check_only=False)
+            docker_updated, _, _ = update_dockerfile()
         except DockerfileUpdateError:
             raise
         except Exception as e:
@@ -209,7 +209,7 @@ def _update_template() -> bool:
     return bool(update_template(interactive=False, force=False, dry_run=False))
 
 
-def update_dockerfile(check_only=True) -> Tuple[bool, Optional[bool], Optional[str]]:
+def update_dockerfile(*, check_only=False) -> Tuple[bool, Optional[bool], Optional[str]]:
     """Update the dockerfile to the newest version of renku."""
     from renku import __version__
 

--- a/renku/core/template/template.py
+++ b/renku/core/template/template.py
@@ -29,7 +29,6 @@ from packaging.version import Version
 from renku.core import errors
 from renku.core.util import communication
 from renku.core.util.git import clone_repository
-from renku.core.util.os import hash_file
 from renku.core.util.util import to_semantic_version, to_string
 from renku.domain_model.project_context import project_context
 from renku.domain_model.template import (
@@ -40,6 +39,8 @@ from renku.domain_model.template import (
     TemplateParameter,
     TemplatesManifest,
     TemplatesSource,
+    hash_template_file,
+    update_dockerfile_content,
 )
 from renku.infrastructure.repository import Repository
 
@@ -73,6 +74,7 @@ class FileAction(IntEnum):
     KEEP = 6
     OVERWRITE = 7
     RECREATE = 8
+    DOCKERFILE = 9
 
 
 def fetch_templates_source(source: Optional[str], reference: Optional[str]) -> TemplatesSource:
@@ -142,6 +144,7 @@ def copy_template_to_project(
         FileAction.KEEP: ("", "Keeping"),
         FileAction.OVERWRITE: ("copy", "Overwriting"),
         FileAction.RECREATE: ("copy", "Recreating deleted file"),
+        FileAction.DOCKERFILE: ("dockerfile", "Updating"),
     }
 
     for relative_path, action in get_sorted_actions(actions=actions).items():
@@ -161,6 +164,10 @@ def copy_template_to_project(
                 shutil.copy(source, destination, follow_symlinks=False)
             elif operation == "append":
                 destination.write_text(destination.read_text() + "\n" + source.read_text())
+            elif operation == "dockerfile":
+                update_dockerfile_content(source=source, destination=destination)
+            else:
+                raise errors.TemplateUpdateError(f"Unknown operation '{operation}'")
         except OSError as e:
             # TODO: Use a general cleanup strategy: https://github.com/SwissDataScienceCenter/renku-python/issues/736
             if cleanup:
@@ -211,7 +218,7 @@ def get_file_actions(
 
     def get_action_for_set(relative_path: str, destination: Path, new_checksum: Optional[str]) -> FileAction:
         """Decide what to do with a template file."""
-        current_checksum = hash_file(destination)
+        current_checksum = hash_template_file(relative_path=relative_path, absolute_path=destination)
 
         if not destination.exists():
             return FileAction.CREATE
@@ -220,8 +227,6 @@ def get_file_actions(
         elif interactive:
             overwrite = communication.confirm(f"Overwrite {relative_path}?", default=True)
             return FileAction.OVERWRITE if overwrite else FileAction.KEEP
-        elif relative_path == "Dockerfile" and not is_dockerfile_updated_by_user():
-            return FileAction.OVERWRITE
         elif should_keep(relative_path):
             return FileAction.KEEP
         else:
@@ -231,7 +236,7 @@ def get_file_actions(
         relative_path: str, destination: Path, old_checksum: Optional[str], new_checksum: Optional[str]
     ) -> FileAction:
         """Decide what to do with a template file."""
-        current_checksum = hash_file(destination)
+        current_checksum = hash_template_file(relative_path=relative_path, absolute_path=destination)
         local_changes = current_checksum != old_checksum
         remote_changes = new_checksum != old_checksum
         file_exists = destination.exists()
@@ -250,8 +255,11 @@ def get_file_actions(
                 return FileAction.OVERWRITE if overwrite else FileAction.KEEP
         elif not remote_changes:
             return FileAction.IGNORE_UNCHANGED_REMOTE
-        elif relative_path == "Dockerfile" and not is_dockerfile_updated_by_user():
-            return FileAction.OVERWRITE
+        elif relative_path == "Dockerfile":
+            if is_dockerfile_updated_by_user():
+                raise errors.TemplateUpdateError("Can't update template as Dockerfile was locally changed.")
+            else:
+                return FileAction.DOCKERFILE
         elif file_deleted or local_changes:
             if relative_path in immutable_files:
                 # NOTE: There are local changes in a file that should not be changed by users, and the file was

--- a/renku/core/template/template.py
+++ b/renku/core/template/template.py
@@ -74,7 +74,7 @@ class FileAction(IntEnum):
     KEEP = 6
     OVERWRITE = 7
     RECREATE = 8
-    DOCKERFILE = 9
+    UPDATE_DOCKERFILE = 9
 
 
 def fetch_templates_source(source: Optional[str], reference: Optional[str]) -> TemplatesSource:
@@ -144,7 +144,7 @@ def copy_template_to_project(
         FileAction.KEEP: ("", "Keeping"),
         FileAction.OVERWRITE: ("copy", "Overwriting"),
         FileAction.RECREATE: ("copy", "Recreating deleted file"),
-        FileAction.DOCKERFILE: ("dockerfile", "Updating"),
+        FileAction.UPDATE_DOCKERFILE: ("dockerfile", "Updating"),
     }
 
     for relative_path, action in get_sorted_actions(actions=actions).items():
@@ -259,7 +259,7 @@ def get_file_actions(
             if is_dockerfile_updated_by_user():
                 raise errors.TemplateUpdateError("Can't update template as Dockerfile was locally changed.")
             else:
-                return FileAction.DOCKERFILE
+                return FileAction.UPDATE_DOCKERFILE
         elif file_deleted or local_changes:
             if relative_path in immutable_files:
                 # NOTE: There are local changes in a file that should not be changed by users, and the file was

--- a/renku/core/template/usecase.py
+++ b/renku/core/template/usecase.py
@@ -41,11 +41,16 @@ from renku.core.template.template import (
 )
 from renku.core.util import communication
 from renku.core.util.metadata import is_renku_project, replace_renku_version_in_dockerfile
-from renku.core.util.os import hash_file, hash_string
 from renku.core.util.tabulate import tabulate
 from renku.domain_model.project import Project
 from renku.domain_model.project_context import project_context
-from renku.domain_model.template import RenderedTemplate, Template, TemplateMetadata, TemplatesSource
+from renku.domain_model.template import (
+    RenderedTemplate,
+    Template,
+    TemplateMetadata,
+    TemplatesSource,
+    calculate_dockerfile_checksum,
+)
 from renku.infrastructure.repository import DiffLineChangeType, Repository
 
 
@@ -89,7 +94,7 @@ def is_dockerfile_updated_by_user() -> bool:
         return False
 
     original_checksum = read_template_checksum().get("Dockerfile")
-    current_checksum = hash_file(dockerfile)
+    current_checksum = calculate_dockerfile_checksum(dockerfile=dockerfile)
 
     if original_checksum == current_checksum:  # Dockerfile was never updated
         return False
@@ -99,7 +104,7 @@ def is_dockerfile_updated_by_user() -> bool:
     original_renku_version = metadata.get("__renku_version__")
 
     original_dockerfile_content = replace_renku_version_in_dockerfile(dockerfile.read_text(), original_renku_version)
-    original_calculated_checksum = hash_string(original_dockerfile_content)
+    original_calculated_checksum = calculate_dockerfile_checksum(dockerfile_content=original_dockerfile_content)
 
     if original_checksum == original_calculated_checksum:
         return False
@@ -186,7 +191,7 @@ def set_template(
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
 def update_template(force: bool, interactive: bool, dry_run: bool) -> Optional[TemplateChangeViewModel]:
-    """Update project's template if possible. Return True if updated."""
+    """Update project's template if possible. Return corresponding viewmodel if updated."""
     template_metadata = TemplateMetadata.from_project(project=project_context.project)
 
     if not template_metadata.source:

--- a/renku/domain_model/template.py
+++ b/renku/domain_model/template.py
@@ -603,7 +603,7 @@ def find_renku_section(lines: List[str]) -> Tuple[int, int]:
     return start, end
 
 
-def get_renku_section_from_dockerfile(content: str) -> str:
+def get_renku_section_from_dockerfile(content: str) -> Optional[str]:
     """Return the Renku-specific section of the Dockerfile or the whole Dockerfile if it doesn't exist."""
     lines = [line.rstrip() for line in content.splitlines()]
     start, end = find_renku_section(lines)
@@ -613,7 +613,7 @@ def get_renku_section_from_dockerfile(content: str) -> str:
         lines = [line for line in lines if line]  # NOTE: Remove empty lines
         return "\n".join(lines)
     else:
-        return content
+        return None
 
 
 def calculate_dockerfile_checksum(
@@ -630,7 +630,7 @@ def calculate_dockerfile_checksum(
         raise errors.ParameterError("Cannot pass both Dockerfile and its content")
 
     content = dockerfile_content if dockerfile_content is not None else dockerfile.read_text()  # type: ignore
-    renku_section = get_renku_section_from_dockerfile(content)
+    renku_section = get_renku_section_from_dockerfile(content) or content
     return hash_string(renku_section)
 
 

--- a/renku/domain_model/template.py
+++ b/renku/domain_model/template.py
@@ -28,7 +28,7 @@ import yaml
 
 from renku.core import errors
 from renku.core.constant import RENKU_HOME
-from renku.core.util.os import get_safe_relative_path, hash_file
+from renku.core.util.os import get_safe_relative_path, hash_file, hash_string
 from renku.core.util.util import to_string
 
 if TYPE_CHECKING:
@@ -379,7 +379,9 @@ class RenderedTemplate:
         self.path: Path = path
         self.template: Template = template
         self.metadata: Dict[str, Any] = metadata
-        self.checksums: Dict[str, Optional[str]] = {f: hash_file(self.path / f) for f in self.get_files()}
+        self.checksums: Dict[str, Optional[str]] = {
+            f: hash_template_file(relative_path=f, absolute_path=self.path / f) for f in self.get_files()
+        }
 
     def get_files(self) -> Generator[str, None, None]:
         """Return all files in a rendered renku template."""
@@ -586,3 +588,73 @@ class TemplateMetadata:
         self.metadata["__template_id__"] = template.id
         self.metadata["__automated_update__"] = template.allow_update
         self.immutable_files = template.immutable_files
+
+
+def find_renku_section(lines: List[str]) -> Tuple[int, int]:
+    """Return start and end line numbers of the Renku-specific section."""
+    start = end = -1
+    for index, line in enumerate(lines):
+        if line.startswith("#        Renku-specific section - DO NOT MODIFY        #"):
+            start = index
+        elif line.endswith("#              End Renku-specific section              #"):
+            end = index
+            break
+
+    return start, end
+
+
+def get_renku_section_from_dockerfile(content: str) -> str:
+    """Return the Renku-specific section of the Dockerfile or the whole Dockerfile if it doesn't exist."""
+    lines = [line.rstrip() for line in content.splitlines()]
+    start, end = find_renku_section(lines)
+
+    if 0 <= start < end:
+        lines = lines[start:end]
+        lines = [line for line in lines if line]  # NOTE: Remove empty lines
+        return "\n".join(lines)
+    else:
+        return content
+
+
+def calculate_dockerfile_checksum(
+    *, dockerfile: Optional[Path] = None, dockerfile_content: Optional[str] = None
+) -> str:
+    """Calculate checksum for the given file or content.
+
+    NOTE: We ignore empty lines and whitespace characters at the end of the lines when calculating Dockerfile checksum
+    if it has Renku-specific section markers.
+    """
+    if not dockerfile and not dockerfile_content:
+        raise errors.ParameterError("Either Dockerfile or its content must be passed")
+    elif dockerfile and dockerfile_content:
+        raise errors.ParameterError("Cannot pass both Dockerfile and its content")
+
+    content = dockerfile_content if dockerfile_content is not None else dockerfile.read_text()  # type: ignore
+    renku_section = get_renku_section_from_dockerfile(content)
+    return hash_string(renku_section)
+
+
+def update_dockerfile_content(source: Path, destination: Path) -> None:
+    """Update the Renku-specific section of the destination Dockerfile with the one from the source Dockerfile."""
+    source_lines = [line.rstrip() for line in source.read_text().splitlines()]
+    source_start, source_end = find_renku_section(source_lines)
+
+    destination_lines = [line.rstrip() for line in destination.read_text().splitlines()]
+    destination_start, destination_end = find_renku_section(destination_lines)
+
+    # NOTE: If source or destination Dockerfiles doesn't have Renku-specific section, we overwrite the whole file
+    if 0 <= source_start < source_end and 0 <= destination_start < destination_end:
+        destination_lines[destination_start:destination_end] = source_lines[source_start:source_end]
+        content = "\n".join(destination_lines)
+        destination.write_text(content)
+    else:
+        destination.write_text(source.read_text())
+
+
+def hash_template_file(*, relative_path: Union[Path, str], absolute_path: Union[Path, str]) -> Optional[str]:
+    """Use proper hash on a template file."""
+    return (
+        calculate_dockerfile_checksum(dockerfile=Path(absolute_path))
+        if str(relative_path) == "Dockerfile"
+        else hash_file(absolute_path)
+    )

--- a/tests/core/test_template.py
+++ b/tests/core/test_template.py
@@ -185,7 +185,7 @@ def test_get_file_actions_for_update(project_with_template, rendered_template_wi
     remotely_modified = ".gitignore"
     assert FileAction.OVERWRITE == actions[remotely_modified]
     dockerfile = "Dockerfile"
-    assert FileAction.DOCKERFILE == actions[dockerfile]
+    assert FileAction.UPDATE_DOCKERFILE == actions[dockerfile]
 
 
 def test_template_set_with_locally_modified_dockerfile(
@@ -248,7 +248,7 @@ def test_update_with_safe_modified_dockerfile(project_with_template, rendered_te
             rendered_template=rendered_template_with_update, template_action=TemplateAction.UPDATE, interactive=False
         )
 
-    assert FileAction.DOCKERFILE == actions["Dockerfile"]
+    assert FileAction.UPDATE_DOCKERFILE == actions["Dockerfile"]
 
 
 @pytest.mark.parametrize("delete", [False, True])

--- a/tests/core/test_template.py
+++ b/tests/core/test_template.py
@@ -182,20 +182,36 @@ def test_get_file_actions_for_update(project_with_template, rendered_template_wi
 
     identical_file = ".dummy"
     assert FileAction.IGNORE_IDENTICAL == actions[identical_file]
-    remotely_modified = "Dockerfile"
+    remotely_modified = ".gitignore"
     assert FileAction.OVERWRITE == actions[remotely_modified]
+    dockerfile = "Dockerfile"
+    assert FileAction.DOCKERFILE == actions[dockerfile]
+
+
+def test_template_set_with_locally_modified_dockerfile(
+    project_with_template, rendered_template_with_update, with_injection
+):
+    """Test setting template with a locally modified Dockerfile will overwrite the Dockerfile."""
+    (project_context.path / "Dockerfile").write_text("Local modification")
+
+    with with_injection():
+        actions = get_file_actions(
+            rendered_template=rendered_template_with_update, template_action=TemplateAction.SET, interactive=False
+        )
+
+    assert FileAction.OVERWRITE == actions["Dockerfile"]
 
 
 def test_update_with_locally_modified_file(project_with_template, rendered_template_with_update, with_injection):
     """Test a locally modified file that is remotely updated won't change."""
-    (project_context.path / "Dockerfile").write_text("Local modification")
+    (project_context.path / "requirements.txt").write_text("Local modification")
 
     with with_injection():
         actions = get_file_actions(
             rendered_template=rendered_template_with_update, template_action=TemplateAction.UPDATE, interactive=False
         )
 
-    assert FileAction.KEEP == actions["Dockerfile"]
+    assert FileAction.KEEP == actions["requirements.txt"]
 
 
 def test_update_with_locally_deleted_file(project_with_template, rendered_template_with_update, with_injection):
@@ -208,6 +224,31 @@ def test_update_with_locally_deleted_file(project_with_template, rendered_templa
         )
 
     assert FileAction.DELETED == actions["requirements.txt"]
+
+
+def test_update_with_unsafe_modified_dockerfile(project_with_template, rendered_template_with_update, with_injection):
+    """Test a locally modified Dockerfile that touches the Renku-specific section will raise an exception."""
+    (project_context.path / "Dockerfile").write_text("Local modification")
+
+    with pytest.raises(
+        errors.TemplateUpdateError, match="Can't update template as Dockerfile was locally changed."
+    ), with_injection():
+        get_file_actions(
+            rendered_template=rendered_template_with_update, template_action=TemplateAction.UPDATE, interactive=False
+        )
+
+
+def test_update_with_safe_modified_dockerfile(project_with_template, rendered_template_with_update, with_injection):
+    """Test a locally modified Dockerfile that doesn't touch the Renku-specific section updates the file."""
+    dockerfile = project_context.path / "Dockerfile"
+    dockerfile.write_text(f"{dockerfile.read_text()}\nLocal modification")
+
+    with with_injection():
+        actions = get_file_actions(
+            rendered_template=rendered_template_with_update, template_action=TemplateAction.UPDATE, interactive=False
+        )
+
+    assert FileAction.DOCKERFILE == actions["Dockerfile"]
 
 
 @pytest.mark.parametrize("delete", [False, True])


### PR DESCRIPTION
# Description
A Renku-specific section can be added to a Dockerfile.  Any lines of the Dockerfile that are between begin and end end markers must not be modified by users. This section is used to calculate Dockerfile checksum (empty lines and whitespaces at the end of lines are ignored). If it's missing then we use the whole Dockerfile.

When updating a template, Renku only update this section if it exists in both project and template Dockerfile; otherwise, the whole Dockerfile is overridden.

```
########################################################
#        Renku-specific section - DO NOT MODIFY        #
########################################################


########################################################
#              End Renku-specific section              #
########################################################
```

Fixes #3354 
