### PR TITLE
fix(core): fix error in metadata loading and v10 migration

### DIFF
--- a/renku/infrastructure/database.py
+++ b/renku/infrastructure/database.py
@@ -1086,12 +1086,17 @@ class ObjectReader:
 
                 # NOTE: we deserialize in the same order as we serialized, so the two stacks here match
                 self._deserialization_cache.append(new_object)
+                cache_index = len(self._deserialization_cache) - 1
 
                 data = self._deserialize_helper(data)
                 assert isinstance(data, dict)
 
                 if "id" in data and data["id"] in self._normal_object_cache:
-                    return self._normal_object_cache[data["id"]]
+                    existing_object = self._normal_object_cache[data["id"]]
+
+                    # NOTE: replace uninitialized object in cache with actual object
+                    self._deserialization_cache[cache_index] = existing_object
+                    return existing_object
 
                 if hasattr(new_object, "__setstate__"):
                     new_object.__setstate__(data)

--- a/renku/infrastructure/gateway/activity_gateway.py
+++ b/renku/infrastructure/gateway/activity_gateway.py
@@ -212,9 +212,13 @@ def reindex_catalog(database):
     """Clear and re-create database's activity-catalog and its relations."""
     activity_catalog = database["activity-catalog"]
     relations = database["_downstream_relations"]
+    by_usage = database["activities-by-usage"]
+    by_generation = database["activities-by-generation"]
 
     activity_catalog.clear()
     relations.clear()
+    by_usage.clear()
+    by_generation.clear()
 
     for activity in database["activities"].values():
         _index_activity(activity=activity, database=database)


### PR DESCRIPTION
fixes the issue reported in https://renku.discourse.group/t/pipeline-takes-ages-and-or-fails/785/8

The database returned uninitialized objects when loading objects from the deserialization cache and the by usage/by generation indices weren't updated in the migration and sometimes pointed at old (deleted) activities.