### PR TITLE
chore: fix dependabot not checking poetry dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       prefix: "build(deps): "
       include: "scope"
     target-branch: "develop"
-    open-pull-requests-limit: 0
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
I think `open-pull-requests-limit: 0` used to mean "unlimited" but now it means "don't check"