### PR TITLE
fix(cli): export removed datasets in graph export --full

### DIFF
--- a/renku/command/graph.py
+++ b/renku/command/graph.py
@@ -179,7 +179,7 @@ def get_graph_for_all_objects(
 
     objects.append(project)
 
-    datasets = dataset_gateway.get_all_active_datasets()
+    datasets = dataset_gateway.get_provenance_tails()
     objects.extend(datasets)
 
     for dataset in datasets:

--- a/tests/cli/test_graph.py
+++ b/tests/cli/test_graph.py
@@ -112,10 +112,10 @@ def test_graph_export_strict_dataset(tmpdir, runner, project, subdirectory):
     assert 2 == result.output.count("http://schema.org/Dataset")
 
     # remove and readd dataset
-    result = runner.invoke(cli, ["dataset", "rm", "my-dataset"] + paths)
+    result = runner.invoke(cli, ["dataset", "rm", "my-dataset"])
     assert 0 == result.exit_code, format_result_exception(result)
 
-    result = runner.invoke(cli, ["dataset", "add", "--copy", "my-dataset"] + paths)
+    result = runner.invoke(cli, ["dataset", "create", "my-dataset"])
     assert 0 == result.exit_code, format_result_exception(result)
 
     result = runner.invoke(cli, ["graph", "export", "--strict", "--format=json-ld"])

--- a/tests/cli/test_graph.py
+++ b/tests/cli/test_graph.py
@@ -111,6 +111,21 @@ def test_graph_export_strict_dataset(tmpdir, runner, project, subdirectory):
     # check that all datasets are exported
     assert 2 == result.output.count("http://schema.org/Dataset")
 
+    # remove and readd dataset
+    result = runner.invoke(cli, ["dataset", "rm", "my-dataset"] + paths)
+    assert 0 == result.exit_code, format_result_exception(result)
+
+    result = runner.invoke(cli, ["dataset", "add", "--copy", "my-dataset"] + paths)
+    assert 0 == result.exit_code, format_result_exception(result)
+
+    result = runner.invoke(cli, ["graph", "export", "--strict", "--format=json-ld"])
+    assert 0 == result.exit_code, format_result_exception(result)
+    assert all(p in result.output for p in test_paths), result.output
+
+    # check that all datasets are exported
+    assert 4 == result.output.count("http://schema.org/Dataset")
+    assert 1 == result.output.count("invalidatedAtTime")
+
 
 def test_graph_export_dataset_mutability(runner, project_with_datasets, with_injection):
     """Test export validation fails for datasets that have both same_as and derived_from."""

--- a/tests/core/commands/test_graph.py
+++ b/tests/core/commands/test_graph.py
@@ -256,7 +256,7 @@ def test_graph_export_full():
     """Test getting full graph."""
 
     dataset_gateway = MagicMock(spec=IDatasetGateway)
-    dataset_gateway.get_all_active_datasets.return_value = [
+    dataset_gateway.get_provenance_tails.return_value = [
         MagicMock(
             spec=Dataset,
             id="/datasets/abcdefg12345",


### PR DESCRIPTION
We need to export provenance tails so we also get deleted datasets into the graph. As it currently is, deleted datasets never show up in triples and will still show up in search.