### PR TITLE
chore: update git-lfs to 3.x in core service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-slim as base
 
 # hadolint ignore=DL3008,DL3009,DL3013
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git git-lfs=2.* python3-dev tini bash curl && \
+    apt-get install --no-install-recommends -y git git-lfs=3.* python3-dev tini bash curl && \
     pip install --no-cache-dir --upgrade pip
 
 FROM base as builder


### PR DESCRIPTION
/deploy #persist

It seems that git lfs 2.x is not available anymore.

Doing the following in Docker causes the same error I have been seeing when trying to build the core service in a CI pipeline.

```
➜ docker run -ti --rm --entrypoint bash python:3.9-slim
Unable to find image 'python:3.9-slim' locally
3.9-slim: Pulling from library/python
5b5fe70539cd: Already exists 
f4b0e4004dc0: Already exists 
ec1650096fae: Already exists 
2ee3c5a347ae: Already exists 
d854e82593a7: Already exists 
Digest: sha256:0074c6241f2ff175532c72fb0fb37264e8a1ac68f9790f9ee6da7e9fdfb67a0e
Status: Downloaded newer image for python:3.9-slim
root@a2d22e73ee16:/# apt-get update
Get:1 http://deb.debian.org/debian bookworm InRelease [147 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8904 kB]
Get:5 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [27.7 kB]
Fetched 9179 kB in 1s (6535 kB/s)                           
Reading package lists... Done
root@a2d22e73ee16:/# apt-get install --no-install-recommends -y git git-lfs=2.*
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package git-lfs is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Version '2.*' for 'git-lfs' was not found
```