### PR TITLE
fix(service): add support for using default values in template parameters

### DIFF
--- a/renku/ui/service/controllers/templates_create_project.py
+++ b/renku/ui/service/controllers/templates_create_project.py
@@ -130,9 +130,10 @@ class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
         self.template_version = repository.head.commit.hexsha
 
         # Verify missing parameters
-        template_parameters = {p.name for p in self.template.parameters}
+        template_parameters = {p.name: p for p in self.template.parameters}
         provided_parameters = {p["key"]: p["value"] for p in self.ctx["parameters"]}
-        missing_keys = list(template_parameters - provided_parameters.keys())
+        missing_keys = list(template_parameters.keys() - provided_parameters.keys())
+        missing_keys = [k for k in missing_keys if not template_parameters[k].has_default]
         if len(missing_keys) > 0:
             raise UserProjectCreationError(error_message=f"the template requires a value for '${missing_keys[0]}'")
 


### PR DESCRIPTION
https://github.com/SwissDataScienceCenter/renku-project-template/commit/56aa0a25cc8d7c5133e2933e9fed10a87f95f5fd added a template parameter to our templates, breaking RP tests. This PR adds proper support for using default values for template parameters.