### PR TITLE
fix: fix poetry-core version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,5 +342,5 @@ exclude = ["docs"]
 
 
 [build-system]
-requires = ["poetry-core>=1.3.0<1.7.0", "poetry-dynamic-versioning==0.21.5", "gitpython==3.1.24"]
+requires = ["poetry-core>=1.3.0,<1.7.0", "poetry-dynamic-versioning==0.21.5", "gitpython==3.1.24"]
 build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
1.7.0 breaks poetry-dynamic-versioning. but it wasn't pinned correctly...
