### PR TITLE
fix(service): normalize git url to avoid duplicate cache entries

### DIFF
--- a/renku/core/util/contexts.py
+++ b/renku/core/util/contexts.py
@@ -26,6 +26,7 @@ from renku.command.command_builder import inject
 from renku.core import errors
 from renku.core.interface.database_gateway import IDatabaseGateway
 from renku.core.interface.project_gateway import IProjectGateway
+from renku.ui.service.utils import normalize_git_url
 
 
 @contextlib.contextmanager
@@ -113,6 +114,8 @@ def renku_project_context(path, check_git_path=True):
 
     if check_git_path:
         path = get_git_path(path)
+
+    path = normalize_git_url(str(path))
 
     with project_context.with_path(path=path):
         project_context.external_storage_requested = True

--- a/renku/domain_model/git.py
+++ b/renku/domain_model/git.py
@@ -25,6 +25,7 @@ import attr
 
 from renku.core import errors
 from renku.core.util.os import is_ascii, normalize_to_ascii
+from renku.ui.service.utils import normalize_git_url
 
 _RE_SCHEME = r"(?P<scheme>(git\+)?(https?|git|ssh|rsync))\://"
 
@@ -70,13 +71,6 @@ _REPOSITORY_URLS = [
 ]
 
 
-def filter_repo_name(repo_name: str) -> str:
-    """Remove the .git extension from the repo name."""
-    if repo_name is not None and repo_name.endswith(".git"):
-        return repo_name[: -len(".git")]
-    return repo_name
-
-
 @attr.s()
 class GitURL:
     """Parser for common Git URLs."""
@@ -90,14 +84,14 @@ class GitURL:
     password = attr.ib(default=None)
     port = attr.ib(default=None)
     owner = attr.ib(default=None)
-    name: Optional[str] = attr.ib(default=None, converter=filter_repo_name)
+    name: Optional[str] = attr.ib(default=None, converter=normalize_git_url)
     slug = attr.ib(default=None)
     _regex = attr.ib(default=None, eq=False, order=False)
 
     def __attrs_post_init__(self):
         """Derive basic information."""
         if not self.name and self.path:
-            self.name = filter_repo_name(Path(self.path).name)
+            self.name = normalize_git_url(Path(self.path).name)
 
         self.slug = normalize_to_ascii(self.name)
 

--- a/renku/ui/service/cache/models/project.py
+++ b/renku/ui/service/cache/models/project.py
@@ -1,6 +1,5 @@
-#
-# Copyright 2020 - Swiss Data Science Center (SDSC)
-# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Copyright Swiss Data Science Center (SDSC). A partnership between
+# École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Renku service cache project related models."""
+
 import os
 import shutil
 from datetime import datetime
@@ -26,6 +26,7 @@ from walrus import BooleanField, DateTimeField, IntegerField, Model, TextField
 
 from renku.ui.service.cache.base import BaseCache
 from renku.ui.service.config import CACHE_PROJECTS_PATH
+from renku.ui.service.utils import normalize_git_url
 
 MAX_CONCURRENT_PROJECT_REQUESTS = 10
 LOCK_TIMEOUT = 15
@@ -61,7 +62,7 @@ class Project(Model):
         branch = self.branch
         if not self.branch:
             branch = NO_BRANCH_FOLDER
-        return CACHE_PROJECTS_PATH / self.user_id / self.owner / self.slug / branch
+        return CACHE_PROJECTS_PATH / self.user_id / self.owner / normalize_git_url(self.slug) / branch
 
     def read_lock(self, timeout: Optional[float] = None):
         """Shared read lock on the project."""

--- a/renku/ui/service/cache/projects.py
+++ b/renku/ui/service/cache/projects.py
@@ -31,7 +31,7 @@ class ProjectManagementCache(BaseCache):
 
     project_schema = ProjectSchema()
 
-    def make_project(self, user, project_data, persist=True):
+    def make_project(self, user, project_data, persist=True) -> Project:
         """Store user project metadata."""
         project_data.update({"user_id": user.user_id})
 

--- a/renku/ui/service/cache/serializers/project.py
+++ b/renku/ui/service/cache/serializers/project.py
@@ -1,6 +1,5 @@
-#
-# Copyright 2020 - Swiss Data Science Center (SDSC)
-# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Copyright Swiss Data Science Center (SDSC). A partnership between
+# École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +21,7 @@ from marshmallow import fields, post_load
 
 from renku.ui.service.cache.models.project import Project
 from renku.ui.service.serializers.common import AccessSchema, CreationSchema, MandatoryUserSchema
+from renku.ui.service.utils import normalize_git_url
 
 
 class ProjectSchema(CreationSchema, AccessSchema, MandatoryUserSchema):
@@ -43,4 +43,7 @@ class ProjectSchema(CreationSchema, AccessSchema, MandatoryUserSchema):
     @post_load
     def make_project(self, data, **options):
         """Construct project object."""
+        data["git_url"] = normalize_git_url(data["git_url"])
+        data["name"] = normalize_git_url(data["name"])
+        data["slug"] = normalize_git_url(data["slug"])
         return Project(**data)

--- a/renku/ui/service/controllers/project_lock_status.py
+++ b/renku/ui/service/controllers/project_lock_status.py
@@ -1,6 +1,5 @@
-#
-# Copyright 2021 - Swiss Data Science Center (SDSC)
-# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Copyright Swiss Data Science Center (SDSC). A partnership between
+# École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +23,7 @@ from renku.ui.service.controllers.api.abstract import ServiceCtrl
 from renku.ui.service.controllers.api.mixins import RenkuOperationMixin
 from renku.ui.service.errors import IntermittentProjectIdError
 from renku.ui.service.serializers.project import ProjectLockStatusRequest, ProjectLockStatusResponseRPC
+from renku.ui.service.utils import normalize_git_url
 from renku.ui.service.views import result_response
 
 
@@ -38,6 +38,9 @@ class ProjectLockStatusCtrl(ServiceCtrl, RenkuOperationMixin):
         self.ctx = self.REQUEST_SERIALIZER.load(request_data)
 
         super().__init__(cache, user_data, request_data)
+
+        if "git_url" in self.ctx:
+            self.ctx["git_url"] = normalize_git_url(self.ctx["git_url"])
 
     @property
     def context(self):

--- a/renku/ui/service/controllers/utils/remote_project.py
+++ b/renku/ui/service/controllers/utils/remote_project.py
@@ -1,6 +1,5 @@
-#
-# Copyright 2020 - Swiss Data Science Center (SDSC)
-# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Copyright Swiss Data Science Center (SDSC). A partnership between
+# École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +25,7 @@ from renku.core import errors
 from renku.core.util.contexts import renku_project_context
 from renku.infrastructure.repository import Repository
 from renku.ui.service.serializers.cache import ProjectCloneContext
+from renku.ui.service.utils import normalize_git_url
 
 ANONYMOUS_SESSION = "anonymous"
 
@@ -44,7 +44,7 @@ class RemoteProject:
 
         self.ctx = ProjectCloneContext().load({**user_data, **request_data}, unknown=EXCLUDE)
 
-        self.git_url = self.ctx["url_with_auth"]
+        self.git_url = normalize_git_url(self.ctx["url_with_auth"])
         self.branch = self.ctx["branch"]
 
     @property

--- a/renku/ui/service/gateways/gitlab_api_provider.py
+++ b/renku/ui/service/gateways/gitlab_api_provider.py
@@ -37,7 +37,7 @@ class GitlabAPIProvider(IGitAPIProvider):
         target_folder: Folder to use to download the files.
         remote: Remote repository URL.
         token: User bearer token.
-        ref: optional reference to checkout,
+        ref: optional reference to check out,
     Raises:
         errors.ProjectNotFound: If the remote URL is not accessible.
         errors.AuthenticationError: If the bearer token is invalid in any way.

--- a/renku/ui/service/serializers/templates.py
+++ b/renku/ui/service/serializers/templates.py
@@ -26,6 +26,7 @@ from renku.core.util.os import normalize_to_ascii
 from renku.ui.service.config import TEMPLATE_CLONE_DEPTH_DEFAULT
 from renku.ui.service.serializers.cache import ProjectCloneContext, RepositoryCloneRequest
 from renku.ui.service.serializers.rpc import JsonRPCResponse
+from renku.ui.service.utils import normalize_git_url
 
 
 class ManifestTemplatesRequest(RepositoryCloneRequest):
@@ -74,6 +75,7 @@ class ProjectTemplateRequest(ProjectCloneContext, ManifestTemplatesRequest):
     def add_required_fields(self, data, **kwargs):
         """Add necessary fields."""
         project_name_stripped = normalize_to_ascii(data["project_name"])
+        project_name_stripped = normalize_git_url(project_name_stripped)
         if len(project_name_stripped) == 0:
             raise ValidationError("Project name contains only unsupported characters")
         new_project_url = f"{data['project_repository']}/{data['project_namespace']}/{project_name_stripped}"

--- a/renku/ui/service/utils/__init__.py
+++ b/renku/ui/service/utils/__init__.py
@@ -1,6 +1,5 @@
-#
-# Copyright 2020 - Swiss Data Science Center (SDSC)
-# A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+# Copyright Swiss Data Science Center (SDSC). A partnership between
+# École Polytechnique Fédérale de Lausanne (EPFL) and
 # Eidgenössische Technische Hochschule Zürich (ETHZ).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,14 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Renku service utility functions."""
+from typing import Optional, overload
 
-from renku.core.util.git import push_changes
-from renku.ui.service.cache.models.project import NO_BRANCH_FOLDER
 from renku.ui.service.config import CACHE_PROJECTS_PATH, CACHE_UPLOADS_PATH
 
 
 def make_project_path(user, project):
     """Construct full path for cached project."""
+    from renku.ui.service.cache.models.project import NO_BRANCH_FOLDER
+
     valid_user = user and "user_id" in user
     valid_project = project and "owner" in project and "name" in project and "project_id" in project
 
@@ -56,9 +56,33 @@ def valid_file(user, cached_file):
 
 def new_repo_push(repo_path, source_url, source_name="origin", source_branch="master"):
     """Push a new repo to origin."""
+    from renku.core.util.git import push_changes
     from renku.infrastructure.repository import Repository
 
     repository = Repository(repo_path)
     repository.remotes.add(source_name, source_url)
     branch = push_changes(repository, remote=source_name)
     return branch == source_branch
+
+
+@overload
+def normalize_git_url(git_url: None) -> None:
+    ...
+
+
+@overload
+def normalize_git_url(git_url: str) -> str:
+    ...
+
+
+def normalize_git_url(git_url: Optional[str]) -> Optional[str]:
+    """Remove ``.git`` postfix from a repository's url."""
+    if git_url is None:
+        return None
+
+    git_url = git_url.rstrip("/")
+
+    while git_url.lower().endswith(".git"):
+        git_url = git_url[: -len(".git")]
+
+    return git_url


### PR DESCRIPTION
Normalizes git url in service by removing `.git` postfix.

Fixes #3575 
