### PR TITLE
fix(cli): ssh setup and key usage

### DIFF
--- a/renku/command/session.py
+++ b/renku/command/session.py
@@ -39,7 +39,7 @@ def search_session_providers_command():
 
 def session_list_command():
     """List all the running interactive sessions."""
-    return Command().command(session_list)
+    return Command().command(session_list).with_database(write=False)
 
 
 def session_start_command():

--- a/renku/core/session/renkulab.py
+++ b/renku/core/session/renkulab.py
@@ -310,7 +310,8 @@ class RenkulabSessionProvider(ISessionProvider):
                     commit=session.get("annotations", {}).get("renku.io/commit-sha"),
                     branch=session.get("annotations", {}).get("renku.io/branch"),
                     provider="renkulab",
-                    ssh_enabled=system_config.session_config_path(name, session["name"]).exists(),
+                    ssh_enabled=get_value("renku", "ssh_supported") == "true"
+                    or project_context.project.template_metadata.ssh_supported,
                 )
                 for session in sessions_res.json().get("servers", {}).values()
             ]

--- a/renku/core/session/renkulab.py
+++ b/renku/core/session/renkulab.py
@@ -299,8 +299,6 @@ class RenkulabSessionProvider(ISessionProvider):
             params=self._get_renku_project_name_parts(),
         )
         if sessions_res.status_code == 200:
-            system_config = SystemSSHConfig()
-            name = self._project_name_from_full_project_name(project_name)
             sessions = [
                 Session(
                     id=session["name"],

--- a/renku/core/session/session.py
+++ b/renku/core/session/session.py
@@ -353,3 +353,8 @@ def ssh_setup(existing_key: Optional[Path] = None, force: bool = False):
             """
         )
         f.write(content)
+
+    communication.warn(
+        "This command does not add any public SSH keys into your project. "
+        "Keys have to be added manually or by using the renku session start command with the --ssh flag."
+    )

--- a/renku/core/session/session.py
+++ b/renku/core/session/session.py
@@ -355,6 +355,6 @@ def ssh_setup(existing_key: Optional[Path] = None, force: bool = False):
         f.write(content)
 
     communication.warn(
-        "This command does not add any public SSH keys into your project. "
-        "Keys have to be added manually or by using the renku session start command with the --ssh flag."
+        "This command does not add any public SSH keys to your project. "
+        "Keys have to be added manually or by using the 'renku session start' command with the '--ssh' flag."
     )

--- a/renku/core/util/ssh.py
+++ b/renku/core/util/ssh.py
@@ -177,6 +177,12 @@ class SystemSSHConfig:
                 ServerAliveCountMax 3
                 ProxyJump  jumphost-{self.renku_host}
                 IdentityFile {self.keyfile}
+                IdentityFile ~/.ssh/id_rsa
+                IdentityFile ~/.ssh/id_ecdsa
+                IdentityFile ~/.ssh/id_ecdsa_sk
+                IdentityFile ~/.ssh/id_ed25519
+                IdentityFile ~/.ssh/id_ed25519_sk
+                IdentityFile ~/.ssh/id_dsa
                 User jovyan
                 StrictHostKeyChecking no
             """

--- a/renku/ui/cli/session.py
+++ b/renku/ui/cli/session.py
@@ -379,7 +379,10 @@ def open(session_name, provider, **kwargs):
 )
 @click.option("--force", is_flag=True, help="Overwrite existing keys/config.")
 def ssh_setup(existing_key, force):
-    """Setup keys for SSH connections into sessions."""
+    """Generate keys and configuration for SSH connections into sessions. Note that this
+    will not add any keys to a specific project, adding keys to a project has to be done
+    manually or through the renku session start command by using the --ssh flag.
+    """
     from renku.command.session import ssh_setup_command
 
     communicator = ClickCallback()

--- a/renku/ui/cli/session.py
+++ b/renku/ui/cli/session.py
@@ -379,9 +379,10 @@ def open(session_name, provider, **kwargs):
 )
 @click.option("--force", is_flag=True, help="Overwrite existing keys/config.")
 def ssh_setup(existing_key, force):
-    """Generate keys and configuration for SSH connections into sessions. Note that this
-    will not add any keys to a specific project, adding keys to a project has to be done
-    manually or through the renku session start command by using the --ssh flag.
+    """Generate keys and configuration for SSH connections into sessions.
+
+    Note that this will not add any keys to a specific project, adding keys to a project
+    has to be done manually or through the renku session start command by using the --ssh flag.
     """
     from renku.command.session import ssh_setup_command
 


### PR DESCRIPTION
closes #3585 
closes #3584 

I am not sure that getting into people's ssh configurations to such extent (as we currently do) is maintainable and feasible without a lot of edge cases or bugs. So I decided to simply give a warning when the `renku session ssh-setup` command is used. When I saw this command (including other users from discord) I expected that it would inject ssh keys into the current project. But it does not do this. It only generates/updates stuff in `~/.ssh/renku`. 

I think a more sustainable solution is to step back from doing all this ssh configuration manipulation for users. Because the biggest problem is that it is hard to make things work both with and without using the renku CLI. But we can discuss this further in a separate issue.