### PR TITLE
test: remove redis action from macos

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -496,9 +496,7 @@ jobs:
           CLOUD_STORAGE_AZURE_KEY: ${{ secrets.CLOUD_STORAGE_AZURE_KEY }}
           CLOUD_STORAGE_S3_ACCESS_KEY_ID: ${{ secrets.CLOUD_STORAGE_S3_ACCESS_KEY_ID }}
           CLOUD_STORAGE_S3_SECRET_ACCESS_KEY: ${{ secrets.CLOUD_STORAGE_S3_SECRET_ACCESS_KEY }}
-        run: pytest -m "integration and not serial and not service" -v
-      - name: Start Redis
-        uses: supercharge/redis-github-action@1.5.0
+        run: pytest -m "integration and not serial and not service and not redis" -v
       - name: Test with pytest (serial)
         env:
           POETRY_VIRTUALENVS_CREATE: false


### PR DESCRIPTION
removes redis action from macos test since it only works on linux. This test doesn't use redis anyways so everything passed when I tested