### PR TITLE
fix(service): set job timeouts correctly

### DIFF
--- a/renku/ui/service/controllers/datasets_add_file.py
+++ b/renku/ui/service/controllers/datasets_add_file.py
@@ -80,6 +80,8 @@ class DatasetsAddFileCtrl(ServiceCtrl, RenkuOpSyncMixin):
                         _file["file_url"],
                         job_timeout=int(os.getenv("WORKER_DATASET_JOBS_TIMEOUT", 1800)),
                         result_ttl=int(os.getenv("WORKER_DATASET_JOBS_RESULT_TTL", 500)),
+                        ttl=int(os.getenv("WORKER_DATASET_JOBS_TIMEOUT", 1800)),
+                        failure_ttl=int(os.getenv("WORKER_DATASET_JOBS_RESULT_TTL", 500)),
                     )
                     enqueued_paths.append(_file["file_url"])
 

--- a/renku/ui/service/controllers/datasets_import.py
+++ b/renku/ui/service/controllers/datasets_import.py
@@ -65,6 +65,8 @@ class DatasetsImportCtrl(ServiceCtrl, RenkuOpSyncMixin):
                 tag=self.ctx.get("tag", None),
                 job_timeout=int(os.getenv("WORKER_DATASET_JOBS_TIMEOUT", 1800)),
                 result_ttl=int(os.getenv("WORKER_DATASET_JOBS_RESULT_TTL", 500)),
+                ttl=int(os.getenv("WORKER_DATASET_JOBS_TIMEOUT", 1800)),
+                failure_ttl=int(os.getenv("WORKER_DATASET_JOBS_RESULT_TTL", 500)),
                 commit_message=self.ctx["commit_message"],
                 data_directory=self.ctx.get("data_directory"),
             )


### PR DESCRIPTION
adds timeouts to rq jobs to cleanup metrics dashboard.
ttl=how long a job stays enqueued before failing
failure_ttl=how long a failed job is kept around