### PR TITLE
fix(service): fix cache not getting refreshed

### DIFF
--- a/renku/ui/service/gateways/repository_cache.py
+++ b/renku/ui/service/gateways/repository_cache.py
@@ -56,11 +56,17 @@ class LocalRepositoryCache(IRepositoryCache):
         """Get a project from cache (clone if necessary)."""
         if git_url is None:
             raise ValidationError("Invalid `git_url`, URL is empty", "git_url")
+        # Note: walrus turns None into empty strings
+        branch = branch or ""
+        commit_sha = commit_sha or ""
 
         git_url = normalize_git_url(git_url)
         try:
             project = Project.get(
-                (Project.user_id == user.user_id) & (Project.git_url == git_url) & (Project.branch == branch)
+                (Project.user_id == user.user_id)
+                & (Project.git_url == git_url)
+                & (Project.branch == branch)
+                & (Project.commit_sha == commit_sha)
             )
         except ValueError:
             # project not found in DB
@@ -225,7 +231,7 @@ class LocalRepositoryCache(IRepositoryCache):
         if project.fetch_age < PROJECT_FETCH_TIME:
             return
 
-        if project.commit_sha is not None:
+        if project.commit_sha is not None and project.commit_sha != "":
             # NOTE: A project in a detached head state at a specific commit SHA cannot be updated
             return
 


### PR DESCRIPTION
the walrus library does not store None, but turns it into empty string, which would always fail the check.