### PR TITLE
fix(service): allow setting keywords on project creation

### DIFF
--- a/renku/ui/service/controllers/templates_create_project.py
+++ b/renku/ui/service/controllers/templates_create_project.py
@@ -182,6 +182,7 @@ class TemplatesCreateProjectCtrl(ServiceCtrl, RenkuOperationMixin):
                 data_dir=self.ctx.get("data_directory"),
                 ssh_supported=self.template.ssh_supported,
                 image_request=image,
+                keywords=self.ctx.get("project_keywords", []),
             )
 
         self.new_project_push(new_project_path)

--- a/tests/service/views/test_templates_views.py
+++ b/tests/service/views/test_templates_views.py
@@ -134,6 +134,7 @@ def test_create_project_from_template(svc_client_templates_creation, with_inject
         "content_url": "https://en.wikipedia.org/static/images/icons/wikipedia.png",
         "mirror_locally": True,
     }
+    payload["project_keywords"] = ["test", "ci"]
 
     response = svc_client.post("/templates.create_project", data=json.dumps(payload), headers=headers)
 
@@ -157,6 +158,7 @@ def test_create_project_from_template(svc_client_templates_creation, with_inject
         with with_injection():
             project = project_context.project
         assert project_context.datadir == "my-folder/"
+        assert project.keywords == ["test", "ci"]
 
     expected_id = f"/projects/{payload['project_namespace']}/{stripped_name}"
     assert expected_id == project.id


### PR DESCRIPTION
closes #3618 