### PR TITLE
fix(cli): don't fail on workflows without inputs/outputs and print approriate warnings

### DIFF
--- a/renku/core/workflow/model/concrete_execution_graph.py
+++ b/renku/core/workflow/model/concrete_execution_graph.py
@@ -23,6 +23,7 @@ import networkx as nx
 from networkx.algorithms.cycles import simple_cycles
 
 from renku.core.errors import ParameterError
+from renku.core.util import communication
 from renku.core.util.os import are_paths_related
 from renku.domain_model.workflow import composite_plan, parameter, plan
 
@@ -65,6 +66,9 @@ class ExecutionGraph:
             else:
                 if not virtual_links:
                     continue
+                if not workflow.inputs and not workflow.outputs:
+                    communication.warn(f"Workflow {workflow.name} has no inputs and outputs.")
+                    self.graph.add_node(workflow)
 
                 for input in workflow.inputs:
                     inputs[input.actual_value].append(input)

--- a/renku/domain_model/workflow/plan.py
+++ b/renku/domain_model/workflow/plan.py
@@ -27,6 +27,7 @@ import marshmallow
 from werkzeug.utils import secure_filename
 
 from renku.core import errors
+from renku.core.util import communication
 from renku.core.util.datetime8601 import local_now
 from renku.domain_model.provenance.agent import Person
 from renku.domain_model.provenance.annotation import Annotation
@@ -195,6 +196,11 @@ class Plan(AbstractPlan):
     ):
         self.annotations: List[Annotation] = annotations or []
         self.command: str = command
+        cmd = self.command.split(" ", 1)[0]
+        if cmd == "renku" or cmd.endswith("/renku"):
+            communication.error(
+                f"Calling the 'renku' executable in workflows is not supported. Occurred in workflow {name}."
+            )
         self.hidden_inputs: List[HiddenInput] = hidden_inputs or []
         self.inputs: List[CommandInput] = inputs or []
         self.outputs: List[CommandOutput] = outputs or []


### PR DESCRIPTION
closes #3654 