### PR TITLE
fix: make doctor fix for workflow ids also update oid and derived_from

### DIFF
--- a/renku/command/checks/workflow.py
+++ b/renku/command/checks/workflow.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Checks needed to determine integrity of workflows."""
+
 from datetime import timedelta
 from typing import List, Optional, Tuple, cast
 
@@ -163,6 +164,7 @@ def check_plan_id(fix, plan_gateway: IPlanGateway, **_) -> Tuple[bool, bool, Opt
     for plan in to_be_processed:
         plan.unfreeze()
         plan.id = plan.id.replace("//plans/", "/")
+        plan.reassign_oid()
         plan.freeze()
     project_context.database.commit()
     communication.info("Workflow IDs were fixed")

--- a/renku/command/checks/workflow.py
+++ b/renku/command/checks/workflow.py
@@ -165,6 +165,7 @@ def check_plan_id(fix, plan_gateway: IPlanGateway, **_) -> Tuple[bool, bool, Opt
         plan.unfreeze()
         plan.id = plan.id.replace("//plans/", "/")
         plan.reassign_oid()
+        plan._p_changed = True
         plan.freeze()
     project_context.database.commit()
     communication.info("Workflow IDs were fixed")


### PR DESCRIPTION
this PR also introduces a `RENKU_LOCK_PATH` env var that a user can set to put the renku lockfile somewhere else, intended to solve issues users see when their home dir is mounted on NFS.